### PR TITLE
Ignore extra content when scraping "Required"

### DIFF
--- a/gen/scraper.py
+++ b/gen/scraper.py
@@ -51,7 +51,7 @@ def get_variables(soup):
             ("Name", var_name),
             ("Type", _type_alternatives.get(var_type, var_type)),
             ("Documentation", "\n".join(docs)),
-            ("Required", var_required == "Yes"),
+            ("Required", var_required.startswith("Yes")),
         ]))
     return variables
 


### PR DESCRIPTION
Fixes #24.

Scraping [this CloudFormation doc][example doc] originally produced

```json
    {
      "Name": "AuthorizationType",
      "Type": "Text",
      "Documentation": "The method's authorization type.",
      "Required": false
    },
```

because of the extra content after "Yes" in

> Required: Yes. If you specify the AuthorizerId property, specify CUSTOM for this property.

After this change, the scraped result is

```json
    {
      "Name": "AuthorizationType",
      "Type": "Text",
      "Documentation": "The method's authorization type.",
      "Required": true
    },
```

[example doc]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html