### PR TITLE
Scrape all `"variablelist"` tags in "Properties" section

### DIFF
--- a/gen/scraper.py
+++ b/gen/scraper.py
@@ -38,21 +38,25 @@ def main(url):
 
 
 def get_variables(soup):
-    variable_list_tag = soup.find("div", attrs={"class": "variablelist"})
-    var_name_tags = variable_list_tag.find_all("dt")
     variables = []
-    for name_tag in var_name_tags:
-        var_name = name_tag.find("code").text
-        contents_tag = name_tag.find_next_sibling("dd")
-        docs = variable_docs(contents_tag)
-        var_required = variable_property(contents_tag, "Required")
-        var_type = variable_property(contents_tag, "Type")
-        variables.append(OrderedDict([
-            ("Name", var_name),
-            ("Type", _type_alternatives.get(var_type, var_type)),
-            ("Documentation", "\n".join(docs)),
-            ("Required", var_required.startswith("Yes")),
-        ]))
+    title_page_tag = soup.find("div", string="Properties",
+        attrs={"class":"titlepage"})
+    variable_list_tags = title_page_tag.find_next_siblings("div",
+        attrs={"class": "variablelist"})
+    for variable_list_tag in variable_list_tags:
+        var_name_tags = variable_list_tag.find_all("dt")
+        for name_tag in var_name_tags:
+            var_name = name_tag.find("code").text
+            contents_tag = name_tag.find_next_sibling("dd")
+            docs = variable_docs(contents_tag)
+            var_required = variable_property(contents_tag, "Required")
+            var_type = variable_property(contents_tag, "Type")
+            variables.append(OrderedDict([
+                ("Name", var_name),
+                ("Type", _type_alternatives.get(var_type, var_type)),
+                ("Documentation", "\n".join(docs)),
+                ("Required", var_required.startswith("Yes")),
+            ]))
     return variables
 
 


### PR DESCRIPTION
Fixes #23.

Originally the scraper only found the first two properties when
scraping [this CloudFormation doc][example doc]:

```json
  "Parameters": [
    {
      "Name": "Body",
      "Type": "JSON object",
      "Documentation": "A Swagger specification that defines a set of RESTful APIs in the JSON format.",
      "Required": false
    },
    {
      "Name": "BodyS3Location",
      "Type": "Amazon API Gateway RestApi S3Location",
      "Documentation": "The Amazon Simple Storage Service (Amazon S3) location that points to a Swagger file, which defines a set of RESTful APIs in JSON or YAML format.",
      "Required": false
    }
  ]
```

because the "Properties" section contains multiple `class="variablelist"` tags.

After this change, all of the properties are successfully scraped:

```json
  "Parameters": [
    {
      "Name": "Body",
      "Type": "JSON object",
      "Documentation": "A Swagger specification that defines a set of RESTful APIs in the JSON format.",
      "Required": false
    },
    {
      "Name": "BodyS3Location",
      "Type": "Amazon API Gateway RestApi S3Location",
      "Documentation": "The Amazon Simple Storage Service (Amazon S3) location that points to a Swagger file, which defines a set of RESTful APIs in JSON or YAML format.",
      "Required": false
    },
    {
      "Name": "CloneFrom",
      "Type": "Text",
      "Documentation": "The ID of the API Gateway RestApi resource that you want to clone.",
      "Required": false
    },
    {
      "Name": "Description",
      "Type": "Text",
      "Documentation": "A description of the purpose of this API Gateway RestApi resource.",
      "Required": false
    },
    {
      "Name": "FailOnWarnings",
      "Type": "Bool'",
      "Documentation": "If a warning occurs while API Gateway is creating the RestApi resource, indicates whether to roll back the resource.",
      "Required": false
    },
    {
      "Name": "Name",
      "Type": "Text",
      "Documentation": "A name for the API Gateway RestApi resource.",
      "Required": false
    },
    {
      "Name": "Parameters",
      "Type": "[Text]",
      "Documentation": "Custom header parameters for the request.",
      "Required": false
    }
  ]
```

Only `"variablelist"` tags in the "Properties" section are targeted. The
`"variablelist"` tag in the "Return Values" section is ignored.

[example doc]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html