### PR TITLE
Added ValList type so we can actually Ref parameters that are already lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 
-## 0.5.1
+## 0.6.0
+
+* **BREAKING CHANGE**: Added `ValList` type. This new type allows you to
+  reference parameters that are already list types. Previously you had to use
+  some kludgy workarounds. For example, you can now `Ref` a parameter of type
+  `List<AWS::EC2::AvailabilityZone::Name>`.
+
+  Every type that used to be `[Val a]` is now `ValList a`. If you use the
+  `OverloadedLists` pragma, you might not have to change any of your code.
+  Otherwise, you must wrap existing lists in the `ValList` constructor.
 
 ## 0.5.0
 

--- a/examples/auto-scaling-group.hs
+++ b/examples/auto-scaling-group.hs
@@ -22,6 +22,9 @@ myTemplate =
     & resUpdatePolicy ?~ asgUpdatePolicy
   , launchConfigResource
   ]
+  & parameters ?~
+  [ parameter "AvailabilityZones" "List<AWS::EC2::AvailabilityZone::Name>"
+  ]
   & description ?~ "Auto scaling group example"
   & formatVersion ?~ "2010-09-09"
 
@@ -34,6 +37,11 @@ asgResource =
   "4"
   & asasgDesiredCapacity ?~ "3"
   & asasgLaunchConfigurationName ?~ Ref "LaunchConfig"
+  & asasgAvailabilityZones ?~ RefList "AvailabilityZones"
+  & asasgTerminationPolicies ?~
+    [ "OldestLaunchConfiguration"
+    , "ClosestToNextInstanceHour"
+    ]
 
 asgCreationPolicy :: CreationPolicy
 asgCreationPolicy =

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayMethodIntegration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayMethodIntegration.hs
@@ -19,7 +19,7 @@ import Stratosphere.ResourceProperties.ApiGatewayMethodIntegrationResponse
 -- 'apiGatewayMethodIntegration' for a more convenient constructor.
 data ApiGatewayMethodIntegration =
   ApiGatewayMethodIntegration
-  { _apiGatewayMethodIntegrationCacheKeyParameters :: Maybe [Val Text]
+  { _apiGatewayMethodIntegrationCacheKeyParameters :: Maybe (ValList Text)
   , _apiGatewayMethodIntegrationCacheNamespace :: Maybe (Val Text)
   , _apiGatewayMethodIntegrationCredentials :: Maybe (Val Text)
   , _apiGatewayMethodIntegrationIntegrationHttpMethod :: Maybe (Val HttpMethod)
@@ -81,7 +81,7 @@ apiGatewayMethodIntegration  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration.html#cfn-apigateway-method-integration-cachekeyparameters
-agmiCacheKeyParameters :: Lens' ApiGatewayMethodIntegration (Maybe [Val Text])
+agmiCacheKeyParameters :: Lens' ApiGatewayMethodIntegration (Maybe (ValList Text))
 agmiCacheKeyParameters = lens _apiGatewayMethodIntegrationCacheKeyParameters (\s a -> s { _apiGatewayMethodIntegrationCacheKeyParameters = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration.html#cfn-apigateway-method-integration-cachenamespace

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupMetricsCollection.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupMetricsCollection.hs
@@ -21,7 +21,7 @@ import Stratosphere.Values
 data AutoScalingAutoScalingGroupMetricsCollection =
   AutoScalingAutoScalingGroupMetricsCollection
   { _autoScalingAutoScalingGroupMetricsCollectionGranularity :: Val Text
-  , _autoScalingAutoScalingGroupMetricsCollectionMetrics :: Maybe [Val Text]
+  , _autoScalingAutoScalingGroupMetricsCollectionMetrics :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON AutoScalingAutoScalingGroupMetricsCollection where
@@ -55,5 +55,5 @@ asasgmcGranularity :: Lens' AutoScalingAutoScalingGroupMetricsCollection (Val Te
 asasgmcGranularity = lens _autoScalingAutoScalingGroupMetricsCollectionGranularity (\s a -> s { _autoScalingAutoScalingGroupMetricsCollectionGranularity = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-metricscollection.html#cfn-as-metricscollection-metrics
-asasgmcMetrics :: Lens' AutoScalingAutoScalingGroupMetricsCollection (Maybe [Val Text])
+asasgmcMetrics :: Lens' AutoScalingAutoScalingGroupMetricsCollection (Maybe (ValList Text))
 asasgmcMetrics = lens _autoScalingAutoScalingGroupMetricsCollectionMetrics (\s a -> s { _autoScalingAutoScalingGroupMetricsCollectionMetrics = a })

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupNotificationConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupNotificationConfiguration.hs
@@ -20,7 +20,7 @@ import Stratosphere.Values
 -- convenient constructor.
 data AutoScalingAutoScalingGroupNotificationConfiguration =
   AutoScalingAutoScalingGroupNotificationConfiguration
-  { _autoScalingAutoScalingGroupNotificationConfigurationNotificationTypes :: Maybe [Val Text]
+  { _autoScalingAutoScalingGroupNotificationConfigurationNotificationTypes :: Maybe (ValList Text)
   , _autoScalingAutoScalingGroupNotificationConfigurationTopicARN :: Val Text
   } deriving (Show, Eq)
 
@@ -51,7 +51,7 @@ autoScalingAutoScalingGroupNotificationConfiguration topicARNarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-notificationconfigurations.html#cfn-as-group-notificationconfigurations-notificationtypes
-asasgncNotificationTypes :: Lens' AutoScalingAutoScalingGroupNotificationConfiguration (Maybe [Val Text])
+asasgncNotificationTypes :: Lens' AutoScalingAutoScalingGroupNotificationConfiguration (Maybe (ValList Text))
 asasgncNotificationTypes = lens _autoScalingAutoScalingGroupNotificationConfigurationNotificationTypes (\s a -> s { _autoScalingAutoScalingGroupNotificationConfigurationNotificationTypes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-notificationconfigurations.html#cfn-autoscaling-autoscalinggroup-notificationconfigurations-topicarn

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCacheBehavior.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCacheBehavior.hs
@@ -18,8 +18,8 @@ import Stratosphere.ResourceProperties.CloudFrontDistributionForwardedValues
 -- 'cloudFrontDistributionCacheBehavior' for a more convenient constructor.
 data CloudFrontDistributionCacheBehavior =
   CloudFrontDistributionCacheBehavior
-  { _cloudFrontDistributionCacheBehaviorAllowedMethods :: Maybe [Val Text]
-  , _cloudFrontDistributionCacheBehaviorCachedMethods :: Maybe [Val Text]
+  { _cloudFrontDistributionCacheBehaviorAllowedMethods :: Maybe (ValList Text)
+  , _cloudFrontDistributionCacheBehaviorCachedMethods :: Maybe (ValList Text)
   , _cloudFrontDistributionCacheBehaviorCompress :: Maybe (Val Bool')
   , _cloudFrontDistributionCacheBehaviorDefaultTTL :: Maybe (Val Integer')
   , _cloudFrontDistributionCacheBehaviorForwardedValues :: CloudFrontDistributionForwardedValues
@@ -28,7 +28,7 @@ data CloudFrontDistributionCacheBehavior =
   , _cloudFrontDistributionCacheBehaviorPathPattern :: Val Text
   , _cloudFrontDistributionCacheBehaviorSmoothStreaming :: Maybe (Val Bool')
   , _cloudFrontDistributionCacheBehaviorTargetOriginId :: Val Text
-  , _cloudFrontDistributionCacheBehaviorTrustedSigners :: Maybe [Val Text]
+  , _cloudFrontDistributionCacheBehaviorTrustedSigners :: Maybe (ValList Text)
   , _cloudFrontDistributionCacheBehaviorViewerProtocolPolicy :: Val Text
   } deriving (Show, Eq)
 
@@ -92,11 +92,11 @@ cloudFrontDistributionCacheBehavior forwardedValuesarg pathPatternarg targetOrig
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-cachebehavior.html#cfn-cloudfront-cachebehavior-allowedmethods
-cfdcbAllowedMethods :: Lens' CloudFrontDistributionCacheBehavior (Maybe [Val Text])
+cfdcbAllowedMethods :: Lens' CloudFrontDistributionCacheBehavior (Maybe (ValList Text))
 cfdcbAllowedMethods = lens _cloudFrontDistributionCacheBehaviorAllowedMethods (\s a -> s { _cloudFrontDistributionCacheBehaviorAllowedMethods = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-cachebehavior.html#cfn-cloudfront-cachebehavior-cachedmethods
-cfdcbCachedMethods :: Lens' CloudFrontDistributionCacheBehavior (Maybe [Val Text])
+cfdcbCachedMethods :: Lens' CloudFrontDistributionCacheBehavior (Maybe (ValList Text))
 cfdcbCachedMethods = lens _cloudFrontDistributionCacheBehaviorCachedMethods (\s a -> s { _cloudFrontDistributionCacheBehaviorCachedMethods = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-cachebehavior.html#cfn-cloudfront-cachebehavior-compress
@@ -132,7 +132,7 @@ cfdcbTargetOriginId :: Lens' CloudFrontDistributionCacheBehavior (Val Text)
 cfdcbTargetOriginId = lens _cloudFrontDistributionCacheBehaviorTargetOriginId (\s a -> s { _cloudFrontDistributionCacheBehaviorTargetOriginId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-cachebehavior.html#cfn-cloudfront-cachebehavior-trustedsigners
-cfdcbTrustedSigners :: Lens' CloudFrontDistributionCacheBehavior (Maybe [Val Text])
+cfdcbTrustedSigners :: Lens' CloudFrontDistributionCacheBehavior (Maybe (ValList Text))
 cfdcbTrustedSigners = lens _cloudFrontDistributionCacheBehaviorTrustedSigners (\s a -> s { _cloudFrontDistributionCacheBehaviorTrustedSigners = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-cachebehavior.html#cfn-cloudfront-cachebehavior-viewerprotocolpolicy

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCookies.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCookies.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data CloudFrontDistributionCookies =
   CloudFrontDistributionCookies
   { _cloudFrontDistributionCookiesForward :: Val Text
-  , _cloudFrontDistributionCookiesWhitelistedNames :: Maybe [Val Text]
+  , _cloudFrontDistributionCookiesWhitelistedNames :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON CloudFrontDistributionCookies where
@@ -53,5 +53,5 @@ cfdcForward :: Lens' CloudFrontDistributionCookies (Val Text)
 cfdcForward = lens _cloudFrontDistributionCookiesForward (\s a -> s { _cloudFrontDistributionCookiesForward = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-forwardedvalues-cookies.html#cfn-cloudfront-forwardedvalues-cookies-whitelistednames
-cfdcWhitelistedNames :: Lens' CloudFrontDistributionCookies (Maybe [Val Text])
+cfdcWhitelistedNames :: Lens' CloudFrontDistributionCookies (Maybe (ValList Text))
 cfdcWhitelistedNames = lens _cloudFrontDistributionCookiesWhitelistedNames (\s a -> s { _cloudFrontDistributionCookiesWhitelistedNames = a })

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCustomOriginConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCustomOriginConfig.hs
@@ -22,7 +22,7 @@ data CloudFrontDistributionCustomOriginConfig =
   { _cloudFrontDistributionCustomOriginConfigHTTPPort :: Maybe (Val Integer')
   , _cloudFrontDistributionCustomOriginConfigHTTPSPort :: Maybe (Val Integer')
   , _cloudFrontDistributionCustomOriginConfigOriginProtocolPolicy :: Val Text
-  , _cloudFrontDistributionCustomOriginConfigOriginSSLProtocols :: Maybe [Val Text]
+  , _cloudFrontDistributionCustomOriginConfigOriginSSLProtocols :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON CloudFrontDistributionCustomOriginConfig where
@@ -70,5 +70,5 @@ cfdcocOriginProtocolPolicy :: Lens' CloudFrontDistributionCustomOriginConfig (Va
 cfdcocOriginProtocolPolicy = lens _cloudFrontDistributionCustomOriginConfigOriginProtocolPolicy (\s a -> s { _cloudFrontDistributionCustomOriginConfigOriginProtocolPolicy = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-customorigin.html#cfn-cloudfront-customorigin-originsslprotocols
-cfdcocOriginSSLProtocols :: Lens' CloudFrontDistributionCustomOriginConfig (Maybe [Val Text])
+cfdcocOriginSSLProtocols :: Lens' CloudFrontDistributionCustomOriginConfig (Maybe (ValList Text))
 cfdcocOriginSSLProtocols = lens _cloudFrontDistributionCustomOriginConfigOriginSSLProtocols (\s a -> s { _cloudFrontDistributionCustomOriginConfigOriginSSLProtocols = a })

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDefaultCacheBehavior.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDefaultCacheBehavior.hs
@@ -19,8 +19,8 @@ import Stratosphere.ResourceProperties.CloudFrontDistributionForwardedValues
 -- constructor.
 data CloudFrontDistributionDefaultCacheBehavior =
   CloudFrontDistributionDefaultCacheBehavior
-  { _cloudFrontDistributionDefaultCacheBehaviorAllowedMethods :: Maybe [Val Text]
-  , _cloudFrontDistributionDefaultCacheBehaviorCachedMethods :: Maybe [Val Text]
+  { _cloudFrontDistributionDefaultCacheBehaviorAllowedMethods :: Maybe (ValList Text)
+  , _cloudFrontDistributionDefaultCacheBehaviorCachedMethods :: Maybe (ValList Text)
   , _cloudFrontDistributionDefaultCacheBehaviorCompress :: Maybe (Val Bool')
   , _cloudFrontDistributionDefaultCacheBehaviorDefaultTTL :: Maybe (Val Integer')
   , _cloudFrontDistributionDefaultCacheBehaviorForwardedValues :: CloudFrontDistributionForwardedValues
@@ -28,7 +28,7 @@ data CloudFrontDistributionDefaultCacheBehavior =
   , _cloudFrontDistributionDefaultCacheBehaviorMinTTL :: Maybe (Val Integer')
   , _cloudFrontDistributionDefaultCacheBehaviorSmoothStreaming :: Maybe (Val Bool')
   , _cloudFrontDistributionDefaultCacheBehaviorTargetOriginId :: Val Text
-  , _cloudFrontDistributionDefaultCacheBehaviorTrustedSigners :: Maybe [Val Text]
+  , _cloudFrontDistributionDefaultCacheBehaviorTrustedSigners :: Maybe (ValList Text)
   , _cloudFrontDistributionDefaultCacheBehaviorViewerProtocolPolicy :: Val Text
   } deriving (Show, Eq)
 
@@ -88,11 +88,11 @@ cloudFrontDistributionDefaultCacheBehavior forwardedValuesarg targetOriginIdarg 
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-defaultcachebehavior.html#cfn-cloudfront-defaultcachebehavior-allowedmethods
-cfddcbAllowedMethods :: Lens' CloudFrontDistributionDefaultCacheBehavior (Maybe [Val Text])
+cfddcbAllowedMethods :: Lens' CloudFrontDistributionDefaultCacheBehavior (Maybe (ValList Text))
 cfddcbAllowedMethods = lens _cloudFrontDistributionDefaultCacheBehaviorAllowedMethods (\s a -> s { _cloudFrontDistributionDefaultCacheBehaviorAllowedMethods = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-defaultcachebehavior.html#cfn-cloudfront-defaultcachebehavior-cachedmethods
-cfddcbCachedMethods :: Lens' CloudFrontDistributionDefaultCacheBehavior (Maybe [Val Text])
+cfddcbCachedMethods :: Lens' CloudFrontDistributionDefaultCacheBehavior (Maybe (ValList Text))
 cfddcbCachedMethods = lens _cloudFrontDistributionDefaultCacheBehaviorCachedMethods (\s a -> s { _cloudFrontDistributionDefaultCacheBehaviorCachedMethods = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-defaultcachebehavior.html#cfn-cloudfront-defaultcachebehavior-compress
@@ -124,7 +124,7 @@ cfddcbTargetOriginId :: Lens' CloudFrontDistributionDefaultCacheBehavior (Val Te
 cfddcbTargetOriginId = lens _cloudFrontDistributionDefaultCacheBehaviorTargetOriginId (\s a -> s { _cloudFrontDistributionDefaultCacheBehaviorTargetOriginId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-defaultcachebehavior.html#cfn-cloudfront-defaultcachebehavior-trustedsigners
-cfddcbTrustedSigners :: Lens' CloudFrontDistributionDefaultCacheBehavior (Maybe [Val Text])
+cfddcbTrustedSigners :: Lens' CloudFrontDistributionDefaultCacheBehavior (Maybe (ValList Text))
 cfddcbTrustedSigners = lens _cloudFrontDistributionDefaultCacheBehaviorTrustedSigners (\s a -> s { _cloudFrontDistributionDefaultCacheBehaviorTrustedSigners = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-defaultcachebehavior.html#cfn-cloudfront-defaultcachebehavior-viewerprotocolpolicy

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDistributionConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDistributionConfig.hs
@@ -25,7 +25,7 @@ import Stratosphere.ResourceProperties.CloudFrontDistributionViewerCertificate
 -- constructor.
 data CloudFrontDistributionDistributionConfig =
   CloudFrontDistributionDistributionConfig
-  { _cloudFrontDistributionDistributionConfigAliases :: Maybe [Val Text]
+  { _cloudFrontDistributionDistributionConfigAliases :: Maybe (ValList Text)
   , _cloudFrontDistributionDistributionConfigCacheBehaviors :: Maybe [CloudFrontDistributionCacheBehavior]
   , _cloudFrontDistributionDistributionConfigComment :: Maybe (Val Text)
   , _cloudFrontDistributionDistributionConfigCustomErrorResponses :: Maybe [CloudFrontDistributionCustomErrorResponse]
@@ -106,7 +106,7 @@ cloudFrontDistributionDistributionConfig defaultCacheBehaviorarg enabledarg orig
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig.html#cfn-cloudfront-distributionconfig-aliases
-cfddcAliases :: Lens' CloudFrontDistributionDistributionConfig (Maybe [Val Text])
+cfddcAliases :: Lens' CloudFrontDistributionDistributionConfig (Maybe (ValList Text))
 cfddcAliases = lens _cloudFrontDistributionDistributionConfigAliases (\s a -> s { _cloudFrontDistributionDistributionConfigAliases = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig.html#cfn-cloudfront-distributionconfig-cachebehaviors

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionForwardedValues.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionForwardedValues.hs
@@ -20,9 +20,9 @@ import Stratosphere.ResourceProperties.CloudFrontDistributionCookies
 data CloudFrontDistributionForwardedValues =
   CloudFrontDistributionForwardedValues
   { _cloudFrontDistributionForwardedValuesCookies :: Maybe CloudFrontDistributionCookies
-  , _cloudFrontDistributionForwardedValuesHeaders :: Maybe [Val Text]
+  , _cloudFrontDistributionForwardedValuesHeaders :: Maybe (ValList Text)
   , _cloudFrontDistributionForwardedValuesQueryString :: Val Bool'
-  , _cloudFrontDistributionForwardedValuesQueryStringCacheKeys :: Maybe [Val Text]
+  , _cloudFrontDistributionForwardedValuesQueryStringCacheKeys :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON CloudFrontDistributionForwardedValues where
@@ -62,7 +62,7 @@ cfdfvCookies :: Lens' CloudFrontDistributionForwardedValues (Maybe CloudFrontDis
 cfdfvCookies = lens _cloudFrontDistributionForwardedValuesCookies (\s a -> s { _cloudFrontDistributionForwardedValuesCookies = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-forwardedvalues.html#cfn-cloudfront-forwardedvalues-headers
-cfdfvHeaders :: Lens' CloudFrontDistributionForwardedValues (Maybe [Val Text])
+cfdfvHeaders :: Lens' CloudFrontDistributionForwardedValues (Maybe (ValList Text))
 cfdfvHeaders = lens _cloudFrontDistributionForwardedValuesHeaders (\s a -> s { _cloudFrontDistributionForwardedValuesHeaders = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-forwardedvalues.html#cfn-cloudfront-forwardedvalues-querystring
@@ -70,5 +70,5 @@ cfdfvQueryString :: Lens' CloudFrontDistributionForwardedValues (Val Bool')
 cfdfvQueryString = lens _cloudFrontDistributionForwardedValuesQueryString (\s a -> s { _cloudFrontDistributionForwardedValuesQueryString = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-forwardedvalues.html#cfn-cloudfront-forwardedvalues-querystringcachekeys
-cfdfvQueryStringCacheKeys :: Lens' CloudFrontDistributionForwardedValues (Maybe [Val Text])
+cfdfvQueryStringCacheKeys :: Lens' CloudFrontDistributionForwardedValues (Maybe (ValList Text))
 cfdfvQueryStringCacheKeys = lens _cloudFrontDistributionForwardedValuesQueryStringCacheKeys (\s a -> s { _cloudFrontDistributionForwardedValuesQueryStringCacheKeys = a })

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionGeoRestriction.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionGeoRestriction.hs
@@ -18,7 +18,7 @@ import Stratosphere.Values
 -- 'cloudFrontDistributionGeoRestriction' for a more convenient constructor.
 data CloudFrontDistributionGeoRestriction =
   CloudFrontDistributionGeoRestriction
-  { _cloudFrontDistributionGeoRestrictionLocations :: Maybe [Val Text]
+  { _cloudFrontDistributionGeoRestrictionLocations :: Maybe (ValList Text)
   , _cloudFrontDistributionGeoRestrictionRestrictionType :: Val Text
   } deriving (Show, Eq)
 
@@ -49,7 +49,7 @@ cloudFrontDistributionGeoRestriction restrictionTypearg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-restrictions-georestriction.html#cfn-cloudfront-distributionconfig-restrictions-georestriction-locations
-cfdgrLocations :: Lens' CloudFrontDistributionGeoRestriction (Maybe [Val Text])
+cfdgrLocations :: Lens' CloudFrontDistributionGeoRestriction (Maybe (ValList Text))
 cfdgrLocations = lens _cloudFrontDistributionGeoRestrictionLocations (\s a -> s { _cloudFrontDistributionGeoRestrictionLocations = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-restrictions-georestriction.html#cfn-cloudfront-distributionconfig-restrictions-georestriction-restrictiontype

--- a/library-gen/Stratosphere/ResourceProperties/CodeCommitRepositoryRepositoryTrigger.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeCommitRepositoryRepositoryTrigger.hs
@@ -19,10 +19,10 @@ import Stratosphere.Values
 -- constructor.
 data CodeCommitRepositoryRepositoryTrigger =
   CodeCommitRepositoryRepositoryTrigger
-  { _codeCommitRepositoryRepositoryTriggerBranches :: Maybe [Val Text]
+  { _codeCommitRepositoryRepositoryTriggerBranches :: Maybe (ValList Text)
   , _codeCommitRepositoryRepositoryTriggerCustomData :: Maybe (Val Text)
   , _codeCommitRepositoryRepositoryTriggerDestinationArn :: Maybe (Val Text)
-  , _codeCommitRepositoryRepositoryTriggerEvents :: Maybe [Val Text]
+  , _codeCommitRepositoryRepositoryTriggerEvents :: Maybe (ValList Text)
   , _codeCommitRepositoryRepositoryTriggerName :: Maybe (Val Text)
   } deriving (Show, Eq)
 
@@ -61,7 +61,7 @@ codeCommitRepositoryRepositoryTrigger  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codecommit-repository-repositorytrigger.html#cfn-codecommit-repository-repositorytrigger-branches
-ccrrtBranches :: Lens' CodeCommitRepositoryRepositoryTrigger (Maybe [Val Text])
+ccrrtBranches :: Lens' CodeCommitRepositoryRepositoryTrigger (Maybe (ValList Text))
 ccrrtBranches = lens _codeCommitRepositoryRepositoryTriggerBranches (\s a -> s { _codeCommitRepositoryRepositoryTriggerBranches = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codecommit-repository-repositorytrigger.html#cfn-codecommit-repository-repositorytrigger-customdata
@@ -73,7 +73,7 @@ ccrrtDestinationArn :: Lens' CodeCommitRepositoryRepositoryTrigger (Maybe (Val T
 ccrrtDestinationArn = lens _codeCommitRepositoryRepositoryTriggerDestinationArn (\s a -> s { _codeCommitRepositoryRepositoryTriggerDestinationArn = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codecommit-repository-repositorytrigger.html#cfn-codecommit-repository-repositorytrigger-events
-ccrrtEvents :: Lens' CodeCommitRepositoryRepositoryTrigger (Maybe [Val Text])
+ccrrtEvents :: Lens' CodeCommitRepositoryRepositoryTrigger (Maybe (ValList Text))
 ccrrtEvents = lens _codeCommitRepositoryRepositoryTriggerEvents (\s a -> s { _codeCommitRepositoryRepositoryTriggerEvents = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codecommit-repository-repositorytrigger.html#cfn-codecommit-repository-repositorytrigger-name

--- a/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupTriggerConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupTriggerConfig.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 -- constructor.
 data CodeDeployDeploymentGroupTriggerConfig =
   CodeDeployDeploymentGroupTriggerConfig
-  { _codeDeployDeploymentGroupTriggerConfigTriggerEvents :: Maybe [Val Text]
+  { _codeDeployDeploymentGroupTriggerConfigTriggerEvents :: Maybe (ValList Text)
   , _codeDeployDeploymentGroupTriggerConfigTriggerName :: Maybe (Val Text)
   , _codeDeployDeploymentGroupTriggerConfigTriggerTargetArn :: Maybe (Val Text)
   } deriving (Show, Eq)
@@ -53,7 +53,7 @@ codeDeployDeploymentGroupTriggerConfig  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggerevents
-cddgtcTriggerEvents :: Lens' CodeDeployDeploymentGroupTriggerConfig (Maybe [Val Text])
+cddgtcTriggerEvents :: Lens' CodeDeployDeploymentGroupTriggerConfig (Maybe (ValList Text))
 cddgtcTriggerEvents = lens _codeDeployDeploymentGroupTriggerConfigTriggerEvents (\s a -> s { _codeDeployDeploymentGroupTriggerConfigTriggerEvents = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername

--- a/library-gen/Stratosphere/ResourceProperties/CognitoIdentityPoolPushSync.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CognitoIdentityPoolPushSync.hs
@@ -18,7 +18,7 @@ import Stratosphere.Values
 -- 'cognitoIdentityPoolPushSync' for a more convenient constructor.
 data CognitoIdentityPoolPushSync =
   CognitoIdentityPoolPushSync
-  { _cognitoIdentityPoolPushSyncApplicationArns :: Maybe [Val Text]
+  { _cognitoIdentityPoolPushSyncApplicationArns :: Maybe (ValList Text)
   , _cognitoIdentityPoolPushSyncRoleArn :: Maybe (Val Text)
   } deriving (Show, Eq)
 
@@ -48,7 +48,7 @@ cognitoIdentityPoolPushSync  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-identitypool-pushsync.html#cfn-cognito-identitypool-pushsync-applicationarns
-cippsApplicationArns :: Lens' CognitoIdentityPoolPushSync (Maybe [Val Text])
+cippsApplicationArns :: Lens' CognitoIdentityPoolPushSync (Maybe (ValList Text))
 cippsApplicationArns = lens _cognitoIdentityPoolPushSyncApplicationArns (\s a -> s { _cognitoIdentityPoolPushSyncApplicationArns = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-identitypool-pushsync.html#cfn-cognito-identitypool-pushsync-rolearn

--- a/library-gen/Stratosphere/ResourceProperties/ConfigConfigRuleScope.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ConfigConfigRuleScope.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data ConfigConfigRuleScope =
   ConfigConfigRuleScope
   { _configConfigRuleScopeComplianceResourceId :: Maybe (Val Text)
-  , _configConfigRuleScopeComplianceResourceTypes :: Maybe [Val Text]
+  , _configConfigRuleScopeComplianceResourceTypes :: Maybe (ValList Text)
   , _configConfigRuleScopeTagKey :: Maybe (Val Text)
   , _configConfigRuleScopeTagValue :: Maybe (Val Text)
   } deriving (Show, Eq)
@@ -60,7 +60,7 @@ ccrsComplianceResourceId :: Lens' ConfigConfigRuleScope (Maybe (Val Text))
 ccrsComplianceResourceId = lens _configConfigRuleScopeComplianceResourceId (\s a -> s { _configConfigRuleScopeComplianceResourceId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-configrule-scope.html#cfn-config-configrule-scope-complianceresourcetypes
-ccrsComplianceResourceTypes :: Lens' ConfigConfigRuleScope (Maybe [Val Text])
+ccrsComplianceResourceTypes :: Lens' ConfigConfigRuleScope (Maybe (ValList Text))
 ccrsComplianceResourceTypes = lens _configConfigRuleScopeComplianceResourceTypes (\s a -> s { _configConfigRuleScopeComplianceResourceTypes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-configrule-scope.html#cfn-config-configrule-scope-tagkey

--- a/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationRecorderRecordingGroup.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationRecorderRecordingGroup.hs
@@ -21,7 +21,7 @@ data ConfigConfigurationRecorderRecordingGroup =
   ConfigConfigurationRecorderRecordingGroup
   { _configConfigurationRecorderRecordingGroupAllSupported :: Maybe (Val Bool')
   , _configConfigurationRecorderRecordingGroupIncludeGlobalResourceTypes :: Maybe (Val Bool')
-  , _configConfigurationRecorderRecordingGroupResourceTypes :: Maybe [Val Text]
+  , _configConfigurationRecorderRecordingGroupResourceTypes :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON ConfigConfigurationRecorderRecordingGroup where
@@ -61,5 +61,5 @@ ccrrgIncludeGlobalResourceTypes :: Lens' ConfigConfigurationRecorderRecordingGro
 ccrrgIncludeGlobalResourceTypes = lens _configConfigurationRecorderRecordingGroupIncludeGlobalResourceTypes (\s a -> s { _configConfigurationRecorderRecordingGroupIncludeGlobalResourceTypes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-configurationrecorder-recordinggroup.html#cfn-config-configurationrecorder-recordinggroup-resourcetypes
-ccrrgResourceTypes :: Lens' ConfigConfigurationRecorderRecordingGroup (Maybe [Val Text])
+ccrrgResourceTypes :: Lens' ConfigConfigurationRecorderRecordingGroup (Maybe (ValList Text))
 ccrrgResourceTypes = lens _configConfigurationRecorderRecordingGroupResourceTypes (\s a -> s { _configConfigurationRecorderRecordingGroupResourceTypes = a })

--- a/library-gen/Stratosphere/ResourceProperties/DirectoryServiceMicrosoftADVpcSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DirectoryServiceMicrosoftADVpcSettings.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 -- constructor.
 data DirectoryServiceMicrosoftADVpcSettings =
   DirectoryServiceMicrosoftADVpcSettings
-  { _directoryServiceMicrosoftADVpcSettingsSubnetIds :: [Val Text]
+  { _directoryServiceMicrosoftADVpcSettingsSubnetIds :: ValList Text
   , _directoryServiceMicrosoftADVpcSettingsVpcId :: Val Text
   } deriving (Show, Eq)
 
@@ -41,7 +41,7 @@ instance FromJSON DirectoryServiceMicrosoftADVpcSettings where
 -- | Constructor for 'DirectoryServiceMicrosoftADVpcSettings' containing
 -- required fields as arguments.
 directoryServiceMicrosoftADVpcSettings
-  :: [Val Text] -- ^ 'dsmadvsSubnetIds'
+  :: ValList Text -- ^ 'dsmadvsSubnetIds'
   -> Val Text -- ^ 'dsmadvsVpcId'
   -> DirectoryServiceMicrosoftADVpcSettings
 directoryServiceMicrosoftADVpcSettings subnetIdsarg vpcIdarg =
@@ -51,7 +51,7 @@ directoryServiceMicrosoftADVpcSettings subnetIdsarg vpcIdarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-directoryservice-microsoftad-vpcsettings.html#cfn-directoryservice-microsoftad-vpcsettings-subnetids
-dsmadvsSubnetIds :: Lens' DirectoryServiceMicrosoftADVpcSettings [Val Text]
+dsmadvsSubnetIds :: Lens' DirectoryServiceMicrosoftADVpcSettings (ValList Text)
 dsmadvsSubnetIds = lens _directoryServiceMicrosoftADVpcSettingsSubnetIds (\s a -> s { _directoryServiceMicrosoftADVpcSettingsSubnetIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-directoryservice-microsoftad-vpcsettings.html#cfn-directoryservice-microsoftad-vpcsettings-vpcid

--- a/library-gen/Stratosphere/ResourceProperties/DirectoryServiceSimpleADVpcSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DirectoryServiceSimpleADVpcSettings.hs
@@ -18,7 +18,7 @@ import Stratosphere.Values
 -- 'directoryServiceSimpleADVpcSettings' for a more convenient constructor.
 data DirectoryServiceSimpleADVpcSettings =
   DirectoryServiceSimpleADVpcSettings
-  { _directoryServiceSimpleADVpcSettingsSubnetIds :: [Val Text]
+  { _directoryServiceSimpleADVpcSettingsSubnetIds :: ValList Text
   , _directoryServiceSimpleADVpcSettingsVpcId :: Val Text
   } deriving (Show, Eq)
 
@@ -40,7 +40,7 @@ instance FromJSON DirectoryServiceSimpleADVpcSettings where
 -- | Constructor for 'DirectoryServiceSimpleADVpcSettings' containing required
 -- fields as arguments.
 directoryServiceSimpleADVpcSettings
-  :: [Val Text] -- ^ 'dssadvsSubnetIds'
+  :: ValList Text -- ^ 'dssadvsSubnetIds'
   -> Val Text -- ^ 'dssadvsVpcId'
   -> DirectoryServiceSimpleADVpcSettings
 directoryServiceSimpleADVpcSettings subnetIdsarg vpcIdarg =
@@ -50,7 +50,7 @@ directoryServiceSimpleADVpcSettings subnetIdsarg vpcIdarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-directoryservice-simplead-vpcsettings.html#cfn-directoryservice-simplead-vpcsettings-subnetids
-dssadvsSubnetIds :: Lens' DirectoryServiceSimpleADVpcSettings [Val Text]
+dssadvsSubnetIds :: Lens' DirectoryServiceSimpleADVpcSettings (ValList Text)
 dssadvsSubnetIds = lens _directoryServiceSimpleADVpcSettingsSubnetIds (\s a -> s { _directoryServiceSimpleADVpcSettingsSubnetIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-directoryservice-simplead-vpcsettings.html#cfn-directoryservice-simplead-vpcsettings-vpcid

--- a/library-gen/Stratosphere/ResourceProperties/DynamoDBTableProjection.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DynamoDBTableProjection.hs
@@ -18,7 +18,7 @@ import Stratosphere.Types
 -- 'dynamoDBTableProjection' for a more convenient constructor.
 data DynamoDBTableProjection =
   DynamoDBTableProjection
-  { _dynamoDBTableProjectionNonKeyAttributes :: Maybe [Val Text]
+  { _dynamoDBTableProjectionNonKeyAttributes :: Maybe (ValList Text)
   , _dynamoDBTableProjectionProjectionType :: Maybe (Val ProjectionType)
   } deriving (Show, Eq)
 
@@ -48,7 +48,7 @@ dynamoDBTableProjection  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-projectionobject.html#cfn-dynamodb-projectionobj-nonkeyatt
-ddbtpNonKeyAttributes :: Lens' DynamoDBTableProjection (Maybe [Val Text])
+ddbtpNonKeyAttributes :: Lens' DynamoDBTableProjection (Maybe (ValList Text))
 ddbtpNonKeyAttributes = lens _dynamoDBTableProjectionNonKeyAttributes (\s a -> s { _dynamoDBTableProjectionNonKeyAttributes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-projectionobject.html#cfn-dynamodb-projectionobj-projtype

--- a/library-gen/Stratosphere/ResourceProperties/EC2InstanceAssociationParameter.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2InstanceAssociationParameter.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data EC2InstanceAssociationParameter =
   EC2InstanceAssociationParameter
   { _eC2InstanceAssociationParameterKey :: Val Text
-  , _eC2InstanceAssociationParameterValue :: [Val Text]
+  , _eC2InstanceAssociationParameterValue :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON EC2InstanceAssociationParameter where
@@ -41,7 +41,7 @@ instance FromJSON EC2InstanceAssociationParameter where
 -- fields as arguments.
 ec2InstanceAssociationParameter
   :: Val Text -- ^ 'eciapKey'
-  -> [Val Text] -- ^ 'eciapValue'
+  -> ValList Text -- ^ 'eciapValue'
   -> EC2InstanceAssociationParameter
 ec2InstanceAssociationParameter keyarg valuearg =
   EC2InstanceAssociationParameter
@@ -54,5 +54,5 @@ eciapKey :: Lens' EC2InstanceAssociationParameter (Val Text)
 eciapKey = lens _eC2InstanceAssociationParameterKey (\s a -> s { _eC2InstanceAssociationParameterKey = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations-associationparameters.html#cfn-ec2-instance-ssmassociations-associationparameters-value
-eciapValue :: Lens' EC2InstanceAssociationParameter [Val Text]
+eciapValue :: Lens' EC2InstanceAssociationParameter (ValList Text)
 eciapValue = lens _eC2InstanceAssociationParameterValue (\s a -> s { _eC2InstanceAssociationParameterValue = a })

--- a/library-gen/Stratosphere/ResourceProperties/EC2InstanceNetworkInterface.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2InstanceNetworkInterface.hs
@@ -23,7 +23,7 @@ data EC2InstanceNetworkInterface =
   , _eC2InstanceNetworkInterfaceDeleteOnTermination :: Maybe (Val Bool')
   , _eC2InstanceNetworkInterfaceDescription :: Maybe (Val Text)
   , _eC2InstanceNetworkInterfaceDeviceIndex :: Val Text
-  , _eC2InstanceNetworkInterfaceGroupSet :: Maybe [Val Text]
+  , _eC2InstanceNetworkInterfaceGroupSet :: Maybe (ValList Text)
   , _eC2InstanceNetworkInterfaceIpv6AddressCount :: Maybe (Val Integer')
   , _eC2InstanceNetworkInterfaceIpv6Addresses :: Maybe [EC2InstanceInstanceIpv6Address]
   , _eC2InstanceNetworkInterfaceNetworkInterfaceId :: Maybe (Val Text)
@@ -106,7 +106,7 @@ eciniDeviceIndex :: Lens' EC2InstanceNetworkInterface (Val Text)
 eciniDeviceIndex = lens _eC2InstanceNetworkInterfaceDeviceIndex (\s a -> s { _eC2InstanceNetworkInterfaceDeviceIndex = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html#aws-properties-ec2-network-iface-embedded-groupset
-eciniGroupSet :: Lens' EC2InstanceNetworkInterface (Maybe [Val Text])
+eciniGroupSet :: Lens' EC2InstanceNetworkInterface (Maybe (ValList Text))
 eciniGroupSet = lens _eC2InstanceNetworkInterfaceGroupSet (\s a -> s { _eC2InstanceNetworkInterfaceGroupSet = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html#cfn-ec2-instance-networkinterface-ipv6addresscount

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetInstanceNetworkInterfaceSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetInstanceNetworkInterfaceSpecification.hs
@@ -25,7 +25,7 @@ data EC2SpotFleetInstanceNetworkInterfaceSpecification =
   , _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeleteOnTermination :: Maybe (Val Bool')
   , _eC2SpotFleetInstanceNetworkInterfaceSpecificationDescription :: Maybe (Val Text)
   , _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeviceIndex :: Maybe (Val Integer')
-  , _eC2SpotFleetInstanceNetworkInterfaceSpecificationGroups :: Maybe [Val Text]
+  , _eC2SpotFleetInstanceNetworkInterfaceSpecificationGroups :: Maybe (ValList Text)
   , _eC2SpotFleetInstanceNetworkInterfaceSpecificationIpv6AddressCount :: Maybe (Val Integer')
   , _eC2SpotFleetInstanceNetworkInterfaceSpecificationIpv6Addresses :: Maybe [EC2SpotFleetInstanceIpv6Address]
   , _eC2SpotFleetInstanceNetworkInterfaceSpecificationNetworkInterfaceId :: Maybe (Val Text)
@@ -103,7 +103,7 @@ ecsfinisDeviceIndex :: Lens' EC2SpotFleetInstanceNetworkInterfaceSpecification (
 ecsfinisDeviceIndex = lens _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeviceIndex (\s a -> s { _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeviceIndex = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications-networkinterfaces.html#cfn-ec2-spotfleet-instancenetworkinterfacespecification-groups
-ecsfinisGroups :: Lens' EC2SpotFleetInstanceNetworkInterfaceSpecification (Maybe [Val Text])
+ecsfinisGroups :: Lens' EC2SpotFleetInstanceNetworkInterfaceSpecification (Maybe (ValList Text))
 ecsfinisGroups = lens _eC2SpotFleetInstanceNetworkInterfaceSpecificationGroups (\s a -> s { _eC2SpotFleetInstanceNetworkInterfaceSpecificationGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications-networkinterfaces.html#cfn-ec2-spotfleet-instancenetworkinterfacespecification-ipv6addresscount

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionContainerDefinition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionContainerDefinition.hs
@@ -24,20 +24,20 @@ import Stratosphere.ResourceProperties.ECSTaskDefinitionVolumeFrom
 -- 'ecsTaskDefinitionContainerDefinition' for a more convenient constructor.
 data ECSTaskDefinitionContainerDefinition =
   ECSTaskDefinitionContainerDefinition
-  { _eCSTaskDefinitionContainerDefinitionCommand :: Maybe [Val Text]
+  { _eCSTaskDefinitionContainerDefinitionCommand :: Maybe (ValList Text)
   , _eCSTaskDefinitionContainerDefinitionCpu :: Maybe (Val Integer')
   , _eCSTaskDefinitionContainerDefinitionDisableNetworking :: Maybe (Val Bool')
-  , _eCSTaskDefinitionContainerDefinitionDnsSearchDomains :: Maybe [Val Text]
-  , _eCSTaskDefinitionContainerDefinitionDnsServers :: Maybe [Val Text]
+  , _eCSTaskDefinitionContainerDefinitionDnsSearchDomains :: Maybe (ValList Text)
+  , _eCSTaskDefinitionContainerDefinitionDnsServers :: Maybe (ValList Text)
   , _eCSTaskDefinitionContainerDefinitionDockerLabels :: Maybe Object
-  , _eCSTaskDefinitionContainerDefinitionDockerSecurityOptions :: Maybe [Val Text]
-  , _eCSTaskDefinitionContainerDefinitionEntryPoint :: Maybe [Val Text]
+  , _eCSTaskDefinitionContainerDefinitionDockerSecurityOptions :: Maybe (ValList Text)
+  , _eCSTaskDefinitionContainerDefinitionEntryPoint :: Maybe (ValList Text)
   , _eCSTaskDefinitionContainerDefinitionEnvironment :: Maybe [ECSTaskDefinitionKeyValuePair]
   , _eCSTaskDefinitionContainerDefinitionEssential :: Maybe (Val Bool')
   , _eCSTaskDefinitionContainerDefinitionExtraHosts :: Maybe [ECSTaskDefinitionHostEntry]
   , _eCSTaskDefinitionContainerDefinitionHostname :: Maybe (Val Text)
   , _eCSTaskDefinitionContainerDefinitionImage :: Val Text
-  , _eCSTaskDefinitionContainerDefinitionLinks :: Maybe [Val Text]
+  , _eCSTaskDefinitionContainerDefinitionLinks :: Maybe (ValList Text)
   , _eCSTaskDefinitionContainerDefinitionLogConfiguration :: Maybe ECSTaskDefinitionLogConfiguration
   , _eCSTaskDefinitionContainerDefinitionMemory :: Maybe (Val Integer')
   , _eCSTaskDefinitionContainerDefinitionMemoryReservation :: Maybe (Val Integer')
@@ -152,7 +152,7 @@ ecsTaskDefinitionContainerDefinition imagearg namearg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-command
-ecstdcdCommand :: Lens' ECSTaskDefinitionContainerDefinition (Maybe [Val Text])
+ecstdcdCommand :: Lens' ECSTaskDefinitionContainerDefinition (Maybe (ValList Text))
 ecstdcdCommand = lens _eCSTaskDefinitionContainerDefinitionCommand (\s a -> s { _eCSTaskDefinitionContainerDefinitionCommand = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-cpu
@@ -164,11 +164,11 @@ ecstdcdDisableNetworking :: Lens' ECSTaskDefinitionContainerDefinition (Maybe (V
 ecstdcdDisableNetworking = lens _eCSTaskDefinitionContainerDefinitionDisableNetworking (\s a -> s { _eCSTaskDefinitionContainerDefinitionDisableNetworking = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-dnssearchdomains
-ecstdcdDnsSearchDomains :: Lens' ECSTaskDefinitionContainerDefinition (Maybe [Val Text])
+ecstdcdDnsSearchDomains :: Lens' ECSTaskDefinitionContainerDefinition (Maybe (ValList Text))
 ecstdcdDnsSearchDomains = lens _eCSTaskDefinitionContainerDefinitionDnsSearchDomains (\s a -> s { _eCSTaskDefinitionContainerDefinitionDnsSearchDomains = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-dnsservers
-ecstdcdDnsServers :: Lens' ECSTaskDefinitionContainerDefinition (Maybe [Val Text])
+ecstdcdDnsServers :: Lens' ECSTaskDefinitionContainerDefinition (Maybe (ValList Text))
 ecstdcdDnsServers = lens _eCSTaskDefinitionContainerDefinitionDnsServers (\s a -> s { _eCSTaskDefinitionContainerDefinitionDnsServers = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-dockerlabels
@@ -176,11 +176,11 @@ ecstdcdDockerLabels :: Lens' ECSTaskDefinitionContainerDefinition (Maybe Object)
 ecstdcdDockerLabels = lens _eCSTaskDefinitionContainerDefinitionDockerLabels (\s a -> s { _eCSTaskDefinitionContainerDefinitionDockerLabels = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-dockersecurityoptions
-ecstdcdDockerSecurityOptions :: Lens' ECSTaskDefinitionContainerDefinition (Maybe [Val Text])
+ecstdcdDockerSecurityOptions :: Lens' ECSTaskDefinitionContainerDefinition (Maybe (ValList Text))
 ecstdcdDockerSecurityOptions = lens _eCSTaskDefinitionContainerDefinitionDockerSecurityOptions (\s a -> s { _eCSTaskDefinitionContainerDefinitionDockerSecurityOptions = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-entrypoint
-ecstdcdEntryPoint :: Lens' ECSTaskDefinitionContainerDefinition (Maybe [Val Text])
+ecstdcdEntryPoint :: Lens' ECSTaskDefinitionContainerDefinition (Maybe (ValList Text))
 ecstdcdEntryPoint = lens _eCSTaskDefinitionContainerDefinitionEntryPoint (\s a -> s { _eCSTaskDefinitionContainerDefinitionEntryPoint = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-environment
@@ -204,7 +204,7 @@ ecstdcdImage :: Lens' ECSTaskDefinitionContainerDefinition (Val Text)
 ecstdcdImage = lens _eCSTaskDefinitionContainerDefinitionImage (\s a -> s { _eCSTaskDefinitionContainerDefinitionImage = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-links
-ecstdcdLinks :: Lens' ECSTaskDefinitionContainerDefinition (Maybe [Val Text])
+ecstdcdLinks :: Lens' ECSTaskDefinitionContainerDefinition (Maybe (ValList Text))
 ecstdcdLinks = lens _eCSTaskDefinitionContainerDefinitionLinks (\s a -> s { _eCSTaskDefinitionContainerDefinitionLinks = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-logconfiguration

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterApplication.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterApplication.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data EMRClusterApplication =
   EMRClusterApplication
   { _eMRClusterApplicationAdditionalInfo :: Maybe Object
-  , _eMRClusterApplicationArgs :: Maybe [Val Text]
+  , _eMRClusterApplicationArgs :: Maybe (ValList Text)
   , _eMRClusterApplicationName :: Maybe (Val Text)
   , _eMRClusterApplicationVersion :: Maybe (Val Text)
   } deriving (Show, Eq)
@@ -60,7 +60,7 @@ emrcaAdditionalInfo :: Lens' EMRClusterApplication (Maybe Object)
 emrcaAdditionalInfo = lens _eMRClusterApplicationAdditionalInfo (\s a -> s { _eMRClusterApplicationAdditionalInfo = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-application.html#cfn-emr-cluster-application-args
-emrcaArgs :: Lens' EMRClusterApplication (Maybe [Val Text])
+emrcaArgs :: Lens' EMRClusterApplication (Maybe (ValList Text))
 emrcaArgs = lens _eMRClusterApplicationArgs (\s a -> s { _eMRClusterApplicationArgs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-application.html#cfn-emr-cluster-application-name

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterJobFlowInstancesConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterJobFlowInstancesConfig.hs
@@ -20,8 +20,8 @@ import Stratosphere.ResourceProperties.EMRClusterPlacementType
 -- 'emrClusterJobFlowInstancesConfig' for a more convenient constructor.
 data EMRClusterJobFlowInstancesConfig =
   EMRClusterJobFlowInstancesConfig
-  { _eMRClusterJobFlowInstancesConfigAdditionalMasterSecurityGroups :: Maybe [Val Text]
-  , _eMRClusterJobFlowInstancesConfigAdditionalSlaveSecurityGroups :: Maybe [Val Text]
+  { _eMRClusterJobFlowInstancesConfigAdditionalMasterSecurityGroups :: Maybe (ValList Text)
+  , _eMRClusterJobFlowInstancesConfigAdditionalSlaveSecurityGroups :: Maybe (ValList Text)
   , _eMRClusterJobFlowInstancesConfigCoreInstanceFleet :: Maybe EMRClusterInstanceFleetConfig
   , _eMRClusterJobFlowInstancesConfigCoreInstanceGroup :: Maybe EMRClusterInstanceGroupConfig
   , _eMRClusterJobFlowInstancesConfigEc2KeyName :: Maybe (Val Text)
@@ -98,11 +98,11 @@ emrClusterJobFlowInstancesConfig  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-jobflowinstancesconfig.html#cfn-emr-cluster-jobflowinstancesconfig-additionalmastersecuritygroups
-emrcjficAdditionalMasterSecurityGroups :: Lens' EMRClusterJobFlowInstancesConfig (Maybe [Val Text])
+emrcjficAdditionalMasterSecurityGroups :: Lens' EMRClusterJobFlowInstancesConfig (Maybe (ValList Text))
 emrcjficAdditionalMasterSecurityGroups = lens _eMRClusterJobFlowInstancesConfigAdditionalMasterSecurityGroups (\s a -> s { _eMRClusterJobFlowInstancesConfigAdditionalMasterSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-jobflowinstancesconfig.html#cfn-emr-cluster-jobflowinstancesconfig-additionalslavesecuritygroups
-emrcjficAdditionalSlaveSecurityGroups :: Lens' EMRClusterJobFlowInstancesConfig (Maybe [Val Text])
+emrcjficAdditionalSlaveSecurityGroups :: Lens' EMRClusterJobFlowInstancesConfig (Maybe (ValList Text))
 emrcjficAdditionalSlaveSecurityGroups = lens _eMRClusterJobFlowInstancesConfigAdditionalSlaveSecurityGroups (\s a -> s { _eMRClusterJobFlowInstancesConfigAdditionalSlaveSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-jobflowinstancesconfig.html#cfn-elasticmapreduce-cluster-jobflowinstancesconfig-coreinstancefleet

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterScriptBootstrapActionConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterScriptBootstrapActionConfig.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 -- constructor.
 data EMRClusterScriptBootstrapActionConfig =
   EMRClusterScriptBootstrapActionConfig
-  { _eMRClusterScriptBootstrapActionConfigArgs :: Maybe [Val Text]
+  { _eMRClusterScriptBootstrapActionConfigArgs :: Maybe (ValList Text)
   , _eMRClusterScriptBootstrapActionConfigPath :: Val Text
   } deriving (Show, Eq)
 
@@ -50,7 +50,7 @@ emrClusterScriptBootstrapActionConfig patharg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-bootstrapactionconfig-scriptbootstrapactionconfig.html#cfn-emr-cluster-bootstrapactionconfig-scriptbootstrapaction-args
-emrcsbacArgs :: Lens' EMRClusterScriptBootstrapActionConfig (Maybe [Val Text])
+emrcsbacArgs :: Lens' EMRClusterScriptBootstrapActionConfig (Maybe (ValList Text))
 emrcsbacArgs = lens _eMRClusterScriptBootstrapActionConfigArgs (\s a -> s { _eMRClusterScriptBootstrapActionConfigArgs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-bootstrapactionconfig-scriptbootstrapactionconfig.html#cfn-emr-cluster-bootstrapactionconfig-scriptbootstrapaction-path

--- a/library-gen/Stratosphere/ResourceProperties/EMRStepHadoopJarStepConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRStepHadoopJarStepConfig.hs
@@ -18,7 +18,7 @@ import Stratosphere.ResourceProperties.EMRStepKeyValue
 -- 'emrStepHadoopJarStepConfig' for a more convenient constructor.
 data EMRStepHadoopJarStepConfig =
   EMRStepHadoopJarStepConfig
-  { _eMRStepHadoopJarStepConfigArgs :: Maybe [Val Text]
+  { _eMRStepHadoopJarStepConfigArgs :: Maybe (ValList Text)
   , _eMRStepHadoopJarStepConfigJar :: Val Text
   , _eMRStepHadoopJarStepConfigMainClass :: Maybe (Val Text)
   , _eMRStepHadoopJarStepConfigStepProperties :: Maybe [EMRStepKeyValue]
@@ -57,7 +57,7 @@ emrStepHadoopJarStepConfig jararg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-step-hadoopjarstepconfig.html#cfn-elasticmapreduce-step-hadoopjarstepconfig-args
-emrshjscArgs :: Lens' EMRStepHadoopJarStepConfig (Maybe [Val Text])
+emrshjscArgs :: Lens' EMRStepHadoopJarStepConfig (Maybe (ValList Text))
 emrshjscArgs = lens _eMRStepHadoopJarStepConfigArgs (\s a -> s { _eMRStepHadoopJarStepConfigArgs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-step-hadoopjarstepconfig.html#cfn-elasticmapreduce-step-hadoopjarstepconfig-jar

--- a/library-gen/Stratosphere/ResourceProperties/ElastiCacheReplicationGroupNodeGroupConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElastiCacheReplicationGroupNodeGroupConfiguration.hs
@@ -21,7 +21,7 @@ import Stratosphere.Values
 data ElastiCacheReplicationGroupNodeGroupConfiguration =
   ElastiCacheReplicationGroupNodeGroupConfiguration
   { _elastiCacheReplicationGroupNodeGroupConfigurationPrimaryAvailabilityZone :: Maybe (Val Text)
-  , _elastiCacheReplicationGroupNodeGroupConfigurationReplicaAvailabilityZones :: Maybe [Val Text]
+  , _elastiCacheReplicationGroupNodeGroupConfigurationReplicaAvailabilityZones :: Maybe (ValList Text)
   , _elastiCacheReplicationGroupNodeGroupConfigurationReplicaCount :: Maybe (Val Integer')
   , _elastiCacheReplicationGroupNodeGroupConfigurationSlots :: Maybe (Val Text)
   } deriving (Show, Eq)
@@ -62,7 +62,7 @@ ecrgngcPrimaryAvailabilityZone :: Lens' ElastiCacheReplicationGroupNodeGroupConf
 ecrgngcPrimaryAvailabilityZone = lens _elastiCacheReplicationGroupNodeGroupConfigurationPrimaryAvailabilityZone (\s a -> s { _elastiCacheReplicationGroupNodeGroupConfigurationPrimaryAvailabilityZone = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-replicationgroup-nodegroupconfiguration.html#cfn-elasticache-replicationgroup-nodegroupconfiguration-replicaavailabilityzones
-ecrgngcReplicaAvailabilityZones :: Lens' ElastiCacheReplicationGroupNodeGroupConfiguration (Maybe [Val Text])
+ecrgngcReplicaAvailabilityZones :: Lens' ElastiCacheReplicationGroupNodeGroupConfiguration (Maybe (ValList Text))
 ecrgngcReplicaAvailabilityZones = lens _elastiCacheReplicationGroupNodeGroupConfigurationReplicaAvailabilityZones (\s a -> s { _elastiCacheReplicationGroupNodeGroupConfigurationReplicaAvailabilityZones = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-replicationgroup-nodegroupconfiguration.html#cfn-elasticache-replicationgroup-nodegroupconfiguration-replicacount

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerListeners.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerListeners.hs
@@ -22,7 +22,7 @@ data ElasticLoadBalancingLoadBalancerListeners =
   { _elasticLoadBalancingLoadBalancerListenersInstancePort :: Val Text
   , _elasticLoadBalancingLoadBalancerListenersInstanceProtocol :: Maybe (Val Text)
   , _elasticLoadBalancingLoadBalancerListenersLoadBalancerPort :: Val Text
-  , _elasticLoadBalancingLoadBalancerListenersPolicyNames :: Maybe [Val Text]
+  , _elasticLoadBalancingLoadBalancerListenersPolicyNames :: Maybe (ValList Text)
   , _elasticLoadBalancingLoadBalancerListenersProtocol :: Val Text
   , _elasticLoadBalancingLoadBalancerListenersSSLCertificateId :: Maybe (Val Text)
   } deriving (Show, Eq)
@@ -80,7 +80,7 @@ elblblLoadBalancerPort :: Lens' ElasticLoadBalancingLoadBalancerListeners (Val T
 elblblLoadBalancerPort = lens _elasticLoadBalancingLoadBalancerListenersLoadBalancerPort (\s a -> s { _elasticLoadBalancingLoadBalancerListenersLoadBalancerPort = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-listener.html#cfn-ec2-elb-listener-policynames
-elblblPolicyNames :: Lens' ElasticLoadBalancingLoadBalancerListeners (Maybe [Val Text])
+elblblPolicyNames :: Lens' ElasticLoadBalancingLoadBalancerListeners (Maybe (ValList Text))
 elblblPolicyNames = lens _elasticLoadBalancingLoadBalancerListenersPolicyNames (\s a -> s { _elasticLoadBalancingLoadBalancerListenersPolicyNames = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-listener.html#cfn-ec2-elb-listener-protocol

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerPolicies.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerPolicies.hs
@@ -20,8 +20,8 @@ import Stratosphere.Values
 data ElasticLoadBalancingLoadBalancerPolicies =
   ElasticLoadBalancingLoadBalancerPolicies
   { _elasticLoadBalancingLoadBalancerPoliciesAttributes :: [Object]
-  , _elasticLoadBalancingLoadBalancerPoliciesInstancePorts :: Maybe [Val Text]
-  , _elasticLoadBalancingLoadBalancerPoliciesLoadBalancerPorts :: Maybe [Val Text]
+  , _elasticLoadBalancingLoadBalancerPoliciesInstancePorts :: Maybe (ValList Text)
+  , _elasticLoadBalancingLoadBalancerPoliciesLoadBalancerPorts :: Maybe (ValList Text)
   , _elasticLoadBalancingLoadBalancerPoliciesPolicyName :: Val Text
   , _elasticLoadBalancingLoadBalancerPoliciesPolicyType :: Val Text
   } deriving (Show, Eq)
@@ -68,11 +68,11 @@ elblbpAttributes :: Lens' ElasticLoadBalancingLoadBalancerPolicies [Object]
 elblbpAttributes = lens _elasticLoadBalancingLoadBalancerPoliciesAttributes (\s a -> s { _elasticLoadBalancingLoadBalancerPoliciesAttributes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-policy.html#cfn-ec2-elb-policy-instanceports
-elblbpInstancePorts :: Lens' ElasticLoadBalancingLoadBalancerPolicies (Maybe [Val Text])
+elblbpInstancePorts :: Lens' ElasticLoadBalancingLoadBalancerPolicies (Maybe (ValList Text))
 elblbpInstancePorts = lens _elasticLoadBalancingLoadBalancerPoliciesInstancePorts (\s a -> s { _elasticLoadBalancingLoadBalancerPoliciesInstancePorts = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-policy.html#cfn-ec2-elb-policy-loadbalancerports
-elblbpLoadBalancerPorts :: Lens' ElasticLoadBalancingLoadBalancerPolicies (Maybe [Val Text])
+elblbpLoadBalancerPorts :: Lens' ElasticLoadBalancingLoadBalancerPolicies (Maybe (ValList Text))
 elblbpLoadBalancerPorts = lens _elasticLoadBalancingLoadBalancerPoliciesLoadBalancerPorts (\s a -> s { _elasticLoadBalancingLoadBalancerPoliciesLoadBalancerPorts = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-policy.html#cfn-ec2-elb-policy-policyname

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleRuleCondition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleRuleCondition.hs
@@ -21,7 +21,7 @@ import Stratosphere.Values
 data ElasticLoadBalancingV2ListenerRuleRuleCondition =
   ElasticLoadBalancingV2ListenerRuleRuleCondition
   { _elasticLoadBalancingV2ListenerRuleRuleConditionField :: Maybe (Val Text)
-  , _elasticLoadBalancingV2ListenerRuleRuleConditionValues :: Maybe [Val Text]
+  , _elasticLoadBalancingV2ListenerRuleRuleConditionValues :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON ElasticLoadBalancingV2ListenerRuleRuleCondition where
@@ -54,5 +54,5 @@ elbvlrrcField :: Lens' ElasticLoadBalancingV2ListenerRuleRuleCondition (Maybe (V
 elbvlrrcField = lens _elasticLoadBalancingV2ListenerRuleRuleConditionField (\s a -> s { _elasticLoadBalancingV2ListenerRuleRuleConditionField = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-conditions.html#cfn-elasticloadbalancingv2-listenerrule-conditions-values
-elbvlrrcValues :: Lens' ElasticLoadBalancingV2ListenerRuleRuleCondition (Maybe [Val Text])
+elbvlrrcValues :: Lens' ElasticLoadBalancingV2ListenerRuleRuleCondition (Maybe (ValList Text))
 elbvlrrcValues = lens _elasticLoadBalancingV2ListenerRuleRuleConditionValues (\s a -> s { _elasticLoadBalancingV2ListenerRuleRuleConditionValues = a })

--- a/library-gen/Stratosphere/ResourceProperties/LambdaFunctionVpcConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/LambdaFunctionVpcConfig.hs
@@ -18,8 +18,8 @@ import Stratosphere.Values
 -- 'lambdaFunctionVpcConfig' for a more convenient constructor.
 data LambdaFunctionVpcConfig =
   LambdaFunctionVpcConfig
-  { _lambdaFunctionVpcConfigSecurityGroupIds :: [Val Text]
-  , _lambdaFunctionVpcConfigSubnetIds :: [Val Text]
+  { _lambdaFunctionVpcConfigSecurityGroupIds :: ValList Text
+  , _lambdaFunctionVpcConfigSubnetIds :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON LambdaFunctionVpcConfig where
@@ -40,8 +40,8 @@ instance FromJSON LambdaFunctionVpcConfig where
 -- | Constructor for 'LambdaFunctionVpcConfig' containing required fields as
 -- arguments.
 lambdaFunctionVpcConfig
-  :: [Val Text] -- ^ 'lfvcSecurityGroupIds'
-  -> [Val Text] -- ^ 'lfvcSubnetIds'
+  :: ValList Text -- ^ 'lfvcSecurityGroupIds'
+  -> ValList Text -- ^ 'lfvcSubnetIds'
   -> LambdaFunctionVpcConfig
 lambdaFunctionVpcConfig securityGroupIdsarg subnetIdsarg =
   LambdaFunctionVpcConfig
@@ -50,9 +50,9 @@ lambdaFunctionVpcConfig securityGroupIdsarg subnetIdsarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-vpcconfig.html#cfn-lambda-function-vpcconfig-securitygroupids
-lfvcSecurityGroupIds :: Lens' LambdaFunctionVpcConfig [Val Text]
+lfvcSecurityGroupIds :: Lens' LambdaFunctionVpcConfig (ValList Text)
 lfvcSecurityGroupIds = lens _lambdaFunctionVpcConfigSecurityGroupIds (\s a -> s { _lambdaFunctionVpcConfigSecurityGroupIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-vpcconfig.html#cfn-lambda-function-vpcconfig-subnetids
-lfvcSubnetIds :: Lens' LambdaFunctionVpcConfig [Val Text]
+lfvcSubnetIds :: Lens' LambdaFunctionVpcConfig (ValList Text)
 lfvcSubnetIds = lens _lambdaFunctionVpcConfigSubnetIds (\s a -> s { _lambdaFunctionVpcConfigSubnetIds = a })

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerRecipes.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerRecipes.hs
@@ -18,11 +18,11 @@ import Stratosphere.Values
 -- 'opsWorksLayerRecipes' for a more convenient constructor.
 data OpsWorksLayerRecipes =
   OpsWorksLayerRecipes
-  { _opsWorksLayerRecipesConfigure :: Maybe [Val Text]
-  , _opsWorksLayerRecipesDeploy :: Maybe [Val Text]
-  , _opsWorksLayerRecipesSetup :: Maybe [Val Text]
-  , _opsWorksLayerRecipesShutdown :: Maybe [Val Text]
-  , _opsWorksLayerRecipesUndeploy :: Maybe [Val Text]
+  { _opsWorksLayerRecipesConfigure :: Maybe (ValList Text)
+  , _opsWorksLayerRecipesDeploy :: Maybe (ValList Text)
+  , _opsWorksLayerRecipesSetup :: Maybe (ValList Text)
+  , _opsWorksLayerRecipesShutdown :: Maybe (ValList Text)
+  , _opsWorksLayerRecipesUndeploy :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON OpsWorksLayerRecipes where
@@ -60,21 +60,21 @@ opsWorksLayerRecipes  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-opsworks-layer-recipes.html#cfn-opsworks-layer-customrecipes-configure
-owlrConfigure :: Lens' OpsWorksLayerRecipes (Maybe [Val Text])
+owlrConfigure :: Lens' OpsWorksLayerRecipes (Maybe (ValList Text))
 owlrConfigure = lens _opsWorksLayerRecipesConfigure (\s a -> s { _opsWorksLayerRecipesConfigure = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-opsworks-layer-recipes.html#cfn-opsworks-layer-customrecipes-deploy
-owlrDeploy :: Lens' OpsWorksLayerRecipes (Maybe [Val Text])
+owlrDeploy :: Lens' OpsWorksLayerRecipes (Maybe (ValList Text))
 owlrDeploy = lens _opsWorksLayerRecipesDeploy (\s a -> s { _opsWorksLayerRecipesDeploy = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-opsworks-layer-recipes.html#cfn-opsworks-layer-customrecipes-setup
-owlrSetup :: Lens' OpsWorksLayerRecipes (Maybe [Val Text])
+owlrSetup :: Lens' OpsWorksLayerRecipes (Maybe (ValList Text))
 owlrSetup = lens _opsWorksLayerRecipesSetup (\s a -> s { _opsWorksLayerRecipesSetup = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-opsworks-layer-recipes.html#cfn-opsworks-layer-customrecipes-shutdown
-owlrShutdown :: Lens' OpsWorksLayerRecipes (Maybe [Val Text])
+owlrShutdown :: Lens' OpsWorksLayerRecipes (Maybe (ValList Text))
 owlrShutdown = lens _opsWorksLayerRecipesShutdown (\s a -> s { _opsWorksLayerRecipesShutdown = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-opsworks-layer-recipes.html#cfn-opsworks-layer-customrecipes-undeploy
-owlrUndeploy :: Lens' OpsWorksLayerRecipes (Maybe [Val Text])
+owlrUndeploy :: Lens' OpsWorksLayerRecipes (Maybe (ValList Text))
 owlrUndeploy = lens _opsWorksLayerRecipesUndeploy (\s a -> s { _opsWorksLayerRecipesUndeploy = a })

--- a/library-gen/Stratosphere/ResourceProperties/RDSOptionGroupOptionConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/RDSOptionGroupOptionConfiguration.hs
@@ -18,11 +18,11 @@ import Stratosphere.ResourceProperties.RDSOptionGroupOptionSetting
 -- 'rdsOptionGroupOptionConfiguration' for a more convenient constructor.
 data RDSOptionGroupOptionConfiguration =
   RDSOptionGroupOptionConfiguration
-  { _rDSOptionGroupOptionConfigurationDBSecurityGroupMemberships :: Maybe [Val Text]
+  { _rDSOptionGroupOptionConfigurationDBSecurityGroupMemberships :: Maybe (ValList Text)
   , _rDSOptionGroupOptionConfigurationOptionName :: Val Text
   , _rDSOptionGroupOptionConfigurationOptionSettings :: Maybe RDSOptionGroupOptionSetting
   , _rDSOptionGroupOptionConfigurationPort :: Maybe (Val Integer')
-  , _rDSOptionGroupOptionConfigurationVpcSecurityGroupMemberships :: Maybe [Val Text]
+  , _rDSOptionGroupOptionConfigurationVpcSecurityGroupMemberships :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON RDSOptionGroupOptionConfiguration where
@@ -61,7 +61,7 @@ rdsOptionGroupOptionConfiguration optionNamearg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-optiongroup-optionconfigurations.html#cfn-rds-optiongroup-optionconfigurations-dbsecuritygroupmemberships
-rdsogocDBSecurityGroupMemberships :: Lens' RDSOptionGroupOptionConfiguration (Maybe [Val Text])
+rdsogocDBSecurityGroupMemberships :: Lens' RDSOptionGroupOptionConfiguration (Maybe (ValList Text))
 rdsogocDBSecurityGroupMemberships = lens _rDSOptionGroupOptionConfigurationDBSecurityGroupMemberships (\s a -> s { _rDSOptionGroupOptionConfigurationDBSecurityGroupMemberships = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-optiongroup-optionconfigurations.html#cfn-rds-optiongroup-optionconfigurations-optionname
@@ -77,5 +77,5 @@ rdsogocPort :: Lens' RDSOptionGroupOptionConfiguration (Maybe (Val Integer'))
 rdsogocPort = lens _rDSOptionGroupOptionConfigurationPort (\s a -> s { _rDSOptionGroupOptionConfigurationPort = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-optiongroup-optionconfigurations.html#cfn-rds-optiongroup-optionconfigurations-vpcsecuritygroupmemberships
-rdsogocVpcSecurityGroupMemberships :: Lens' RDSOptionGroupOptionConfiguration (Maybe [Val Text])
+rdsogocVpcSecurityGroupMemberships :: Lens' RDSOptionGroupOptionConfiguration (Maybe (ValList Text))
 rdsogocVpcSecurityGroupMemberships = lens _rDSOptionGroupOptionConfigurationVpcSecurityGroupMemberships (\s a -> s { _rDSOptionGroupOptionConfigurationVpcSecurityGroupMemberships = a })

--- a/library-gen/Stratosphere/ResourceProperties/Route53HealthCheckHealthCheckConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/Route53HealthCheckHealthCheckConfig.hs
@@ -19,7 +19,7 @@ import Stratosphere.ResourceProperties.Route53HealthCheckAlarmIdentifier
 data Route53HealthCheckHealthCheckConfig =
   Route53HealthCheckHealthCheckConfig
   { _route53HealthCheckHealthCheckConfigAlarmIdentifier :: Maybe Route53HealthCheckAlarmIdentifier
-  , _route53HealthCheckHealthCheckConfigChildHealthChecks :: Maybe [Val Text]
+  , _route53HealthCheckHealthCheckConfigChildHealthChecks :: Maybe (ValList Text)
   , _route53HealthCheckHealthCheckConfigEnableSNI :: Maybe (Val Bool')
   , _route53HealthCheckHealthCheckConfigFailureThreshold :: Maybe (Val Integer')
   , _route53HealthCheckHealthCheckConfigFullyQualifiedDomainName :: Maybe (Val Text)
@@ -105,7 +105,7 @@ rhchccAlarmIdentifier :: Lens' Route53HealthCheckHealthCheckConfig (Maybe Route5
 rhchccAlarmIdentifier = lens _route53HealthCheckHealthCheckConfigAlarmIdentifier (\s a -> s { _route53HealthCheckHealthCheckConfigAlarmIdentifier = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-childhealthchecks
-rhchccChildHealthChecks :: Lens' Route53HealthCheckHealthCheckConfig (Maybe [Val Text])
+rhchccChildHealthChecks :: Lens' Route53HealthCheckHealthCheckConfig (Maybe (ValList Text))
 rhchccChildHealthChecks = lens _route53HealthCheckHealthCheckConfigChildHealthChecks (\s a -> s { _route53HealthCheckHealthCheckConfigChildHealthChecks = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-enablesni

--- a/library-gen/Stratosphere/ResourceProperties/Route53RecordSetGroupRecordSet.hs
+++ b/library-gen/Stratosphere/ResourceProperties/Route53RecordSetGroupRecordSet.hs
@@ -28,7 +28,7 @@ data Route53RecordSetGroupRecordSet =
   , _route53RecordSetGroupRecordSetHostedZoneName :: Maybe (Val Text)
   , _route53RecordSetGroupRecordSetName :: Val Text
   , _route53RecordSetGroupRecordSetRegion :: Maybe (Val Text)
-  , _route53RecordSetGroupRecordSetResourceRecords :: Maybe [Val Text]
+  , _route53RecordSetGroupRecordSetResourceRecords :: Maybe (ValList Text)
   , _route53RecordSetGroupRecordSetSetIdentifier :: Maybe (Val Text)
   , _route53RecordSetGroupRecordSetTTL :: Maybe (Val Text)
   , _route53RecordSetGroupRecordSetType :: Val Text
@@ -135,7 +135,7 @@ rrsgrsRegion :: Lens' Route53RecordSetGroupRecordSet (Maybe (Val Text))
 rrsgrsRegion = lens _route53RecordSetGroupRecordSetRegion (\s a -> s { _route53RecordSetGroupRecordSetRegion = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-resourcerecords
-rrsgrsResourceRecords :: Lens' Route53RecordSetGroupRecordSet (Maybe [Val Text])
+rrsgrsResourceRecords :: Lens' Route53RecordSetGroupRecordSet (Maybe (ValList Text))
 rrsgrsResourceRecords = lens _route53RecordSetGroupRecordSetResourceRecords (\s a -> s { _route53RecordSetGroupRecordSetResourceRecords = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-setidentifier

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketCorsRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketCorsRule.hs
@@ -18,10 +18,10 @@ import Stratosphere.Values
 -- for a more convenient constructor.
 data S3BucketCorsRule =
   S3BucketCorsRule
-  { _s3BucketCorsRuleAllowedHeaders :: Maybe [Val Text]
-  , _s3BucketCorsRuleAllowedMethods :: [Val Text]
-  , _s3BucketCorsRuleAllowedOrigins :: [Val Text]
-  , _s3BucketCorsRuleExposedHeaders :: Maybe [Val Text]
+  { _s3BucketCorsRuleAllowedHeaders :: Maybe (ValList Text)
+  , _s3BucketCorsRuleAllowedMethods :: ValList Text
+  , _s3BucketCorsRuleAllowedOrigins :: ValList Text
+  , _s3BucketCorsRuleExposedHeaders :: Maybe (ValList Text)
   , _s3BucketCorsRuleId :: Maybe (Val Text)
   , _s3BucketCorsRuleMaxAge :: Maybe (Val Integer')
   } deriving (Show, Eq)
@@ -52,8 +52,8 @@ instance FromJSON S3BucketCorsRule where
 -- | Constructor for 'S3BucketCorsRule' containing required fields as
 -- arguments.
 s3BucketCorsRule
-  :: [Val Text] -- ^ 'sbcrAllowedMethods'
-  -> [Val Text] -- ^ 'sbcrAllowedOrigins'
+  :: ValList Text -- ^ 'sbcrAllowedMethods'
+  -> ValList Text -- ^ 'sbcrAllowedOrigins'
   -> S3BucketCorsRule
 s3BucketCorsRule allowedMethodsarg allowedOriginsarg =
   S3BucketCorsRule
@@ -66,19 +66,19 @@ s3BucketCorsRule allowedMethodsarg allowedOriginsarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors-corsrule.html#cfn-s3-bucket-cors-corsrule-allowedheaders
-sbcrAllowedHeaders :: Lens' S3BucketCorsRule (Maybe [Val Text])
+sbcrAllowedHeaders :: Lens' S3BucketCorsRule (Maybe (ValList Text))
 sbcrAllowedHeaders = lens _s3BucketCorsRuleAllowedHeaders (\s a -> s { _s3BucketCorsRuleAllowedHeaders = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors-corsrule.html#cfn-s3-bucket-cors-corsrule-allowedmethods
-sbcrAllowedMethods :: Lens' S3BucketCorsRule [Val Text]
+sbcrAllowedMethods :: Lens' S3BucketCorsRule (ValList Text)
 sbcrAllowedMethods = lens _s3BucketCorsRuleAllowedMethods (\s a -> s { _s3BucketCorsRuleAllowedMethods = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors-corsrule.html#cfn-s3-bucket-cors-corsrule-allowedorigins
-sbcrAllowedOrigins :: Lens' S3BucketCorsRule [Val Text]
+sbcrAllowedOrigins :: Lens' S3BucketCorsRule (ValList Text)
 sbcrAllowedOrigins = lens _s3BucketCorsRuleAllowedOrigins (\s a -> s { _s3BucketCorsRuleAllowedOrigins = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors-corsrule.html#cfn-s3-bucket-cors-corsrule-exposedheaders
-sbcrExposedHeaders :: Lens' S3BucketCorsRule (Maybe [Val Text])
+sbcrExposedHeaders :: Lens' S3BucketCorsRule (Maybe (ValList Text))
 sbcrExposedHeaders = lens _s3BucketCorsRuleExposedHeaders (\s a -> s { _s3BucketCorsRuleExposedHeaders = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors-corsrule.html#cfn-s3-bucket-cors-corsrule-id

--- a/library-gen/Stratosphere/ResourceProperties/SSMAssociationParameterValues.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SSMAssociationParameterValues.hs
@@ -18,7 +18,7 @@ import Stratosphere.Values
 -- 'ssmAssociationParameterValues' for a more convenient constructor.
 data SSMAssociationParameterValues =
   SSMAssociationParameterValues
-  { _sSMAssociationParameterValuesParameterValues :: [Val Text]
+  { _sSMAssociationParameterValuesParameterValues :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON SSMAssociationParameterValues where
@@ -37,7 +37,7 @@ instance FromJSON SSMAssociationParameterValues where
 -- | Constructor for 'SSMAssociationParameterValues' containing required
 -- fields as arguments.
 ssmAssociationParameterValues
-  :: [Val Text] -- ^ 'ssmapvParameterValues'
+  :: ValList Text -- ^ 'ssmapvParameterValues'
   -> SSMAssociationParameterValues
 ssmAssociationParameterValues parameterValuesarg =
   SSMAssociationParameterValues
@@ -45,5 +45,5 @@ ssmAssociationParameterValues parameterValuesarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssm-association-parametervalues.html#cfn-ssm-association-parametervalues-parametervalues
-ssmapvParameterValues :: Lens' SSMAssociationParameterValues [Val Text]
+ssmapvParameterValues :: Lens' SSMAssociationParameterValues (ValList Text)
 ssmapvParameterValues = lens _sSMAssociationParameterValuesParameterValues (\s a -> s { _sSMAssociationParameterValuesParameterValues = a })

--- a/library-gen/Stratosphere/ResourceProperties/SSMAssociationTarget.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SSMAssociationTarget.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data SSMAssociationTarget =
   SSMAssociationTarget
   { _sSMAssociationTargetKey :: Val Text
-  , _sSMAssociationTargetValues :: [Val Text]
+  , _sSMAssociationTargetValues :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON SSMAssociationTarget where
@@ -41,7 +41,7 @@ instance FromJSON SSMAssociationTarget where
 -- arguments.
 ssmAssociationTarget
   :: Val Text -- ^ 'ssmatKey'
-  -> [Val Text] -- ^ 'ssmatValues'
+  -> ValList Text -- ^ 'ssmatValues'
   -> SSMAssociationTarget
 ssmAssociationTarget keyarg valuesarg =
   SSMAssociationTarget
@@ -54,5 +54,5 @@ ssmatKey :: Lens' SSMAssociationTarget (Val Text)
 ssmatKey = lens _sSMAssociationTargetKey (\s a -> s { _sSMAssociationTargetKey = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssm-association-target.html#cfn-ssm-association-target-values
-ssmatValues :: Lens' SSMAssociationTarget [Val Text]
+ssmatValues :: Lens' SSMAssociationTarget (ValList Text)
 ssmatValues = lens _sSMAssociationTargetValues (\s a -> s { _sSMAssociationTargetValues = a })

--- a/library-gen/Stratosphere/Resources/ApiGatewayAuthorizer.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayAuthorizer.hs
@@ -24,7 +24,7 @@ data ApiGatewayAuthorizer =
   , _apiGatewayAuthorizerIdentitySource :: Maybe (Val Text)
   , _apiGatewayAuthorizerIdentityValidationExpression :: Maybe (Val Text)
   , _apiGatewayAuthorizerName :: Maybe (Val Text)
-  , _apiGatewayAuthorizerProviderARNs :: Maybe [Val Text]
+  , _apiGatewayAuthorizerProviderARNs :: Maybe (ValList Text)
   , _apiGatewayAuthorizerRestApiId :: Maybe (Val Text)
   , _apiGatewayAuthorizerType :: Maybe (Val AuthorizerType)
   } deriving (Show, Eq)
@@ -100,7 +100,7 @@ agaName :: Lens' ApiGatewayAuthorizer (Maybe (Val Text))
 agaName = lens _apiGatewayAuthorizerName (\s a -> s { _apiGatewayAuthorizerName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-authorizer.html#cfn-apigateway-authorizer-providerarns
-agaProviderARNs :: Lens' ApiGatewayAuthorizer (Maybe [Val Text])
+agaProviderARNs :: Lens' ApiGatewayAuthorizer (Maybe (ValList Text))
 agaProviderARNs = lens _apiGatewayAuthorizerProviderARNs (\s a -> s { _apiGatewayAuthorizerProviderARNs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-authorizer.html#cfn-apigateway-authorizer-restapiid

--- a/library-gen/Stratosphere/Resources/ApiGatewayRestApi.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayRestApi.hs
@@ -18,7 +18,7 @@ import Stratosphere.ResourceProperties.ApiGatewayRestApiS3Location
 -- for a more convenient constructor.
 data ApiGatewayRestApi =
   ApiGatewayRestApi
-  { _apiGatewayRestApiBinaryMediaTypes :: Maybe [Val Text]
+  { _apiGatewayRestApiBinaryMediaTypes :: Maybe (ValList Text)
   , _apiGatewayRestApiBody :: Maybe Object
   , _apiGatewayRestApiBodyS3Location :: Maybe ApiGatewayRestApiS3Location
   , _apiGatewayRestApiCloneFrom :: Maybe (Val Text)
@@ -76,7 +76,7 @@ apiGatewayRestApi  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-binarymediatypes
-agraBinaryMediaTypes :: Lens' ApiGatewayRestApi (Maybe [Val Text])
+agraBinaryMediaTypes :: Lens' ApiGatewayRestApi (Maybe (ValList Text))
 agraBinaryMediaTypes = lens _apiGatewayRestApiBinaryMediaTypes (\s a -> s { _apiGatewayRestApiBinaryMediaTypes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-body

--- a/library-gen/Stratosphere/Resources/AutoScalingAutoScalingGroup.hs
+++ b/library-gen/Stratosphere/Resources/AutoScalingAutoScalingGroup.hs
@@ -20,23 +20,23 @@ import Stratosphere.ResourceProperties.AutoScalingAutoScalingGroupTagProperty
 -- 'autoScalingAutoScalingGroup' for a more convenient constructor.
 data AutoScalingAutoScalingGroup =
   AutoScalingAutoScalingGroup
-  { _autoScalingAutoScalingGroupAvailabilityZones :: Maybe [Val Text]
+  { _autoScalingAutoScalingGroupAvailabilityZones :: Maybe (ValList Text)
   , _autoScalingAutoScalingGroupCooldown :: Maybe (Val Text)
   , _autoScalingAutoScalingGroupDesiredCapacity :: Maybe (Val Text)
   , _autoScalingAutoScalingGroupHealthCheckGracePeriod :: Maybe (Val Integer')
   , _autoScalingAutoScalingGroupHealthCheckType :: Maybe (Val Text)
   , _autoScalingAutoScalingGroupInstanceId :: Maybe (Val Text)
   , _autoScalingAutoScalingGroupLaunchConfigurationName :: Maybe (Val Text)
-  , _autoScalingAutoScalingGroupLoadBalancerNames :: Maybe [Val Text]
+  , _autoScalingAutoScalingGroupLoadBalancerNames :: Maybe (ValList Text)
   , _autoScalingAutoScalingGroupMaxSize :: Val Text
   , _autoScalingAutoScalingGroupMetricsCollection :: Maybe [AutoScalingAutoScalingGroupMetricsCollection]
   , _autoScalingAutoScalingGroupMinSize :: Val Text
   , _autoScalingAutoScalingGroupNotificationConfigurations :: Maybe [AutoScalingAutoScalingGroupNotificationConfiguration]
   , _autoScalingAutoScalingGroupPlacementGroup :: Maybe (Val Text)
   , _autoScalingAutoScalingGroupTags :: Maybe [AutoScalingAutoScalingGroupTagProperty]
-  , _autoScalingAutoScalingGroupTargetGroupARNs :: Maybe [Val Text]
-  , _autoScalingAutoScalingGroupTerminationPolicies :: Maybe [Val Text]
-  , _autoScalingAutoScalingGroupVPCZoneIdentifier :: Maybe [Val Text]
+  , _autoScalingAutoScalingGroupTargetGroupARNs :: Maybe (ValList Text)
+  , _autoScalingAutoScalingGroupTerminationPolicies :: Maybe (ValList Text)
+  , _autoScalingAutoScalingGroupVPCZoneIdentifier :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON AutoScalingAutoScalingGroup where
@@ -112,7 +112,7 @@ autoScalingAutoScalingGroup maxSizearg minSizearg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-availabilityzones
-asasgAvailabilityZones :: Lens' AutoScalingAutoScalingGroup (Maybe [Val Text])
+asasgAvailabilityZones :: Lens' AutoScalingAutoScalingGroup (Maybe (ValList Text))
 asasgAvailabilityZones = lens _autoScalingAutoScalingGroupAvailabilityZones (\s a -> s { _autoScalingAutoScalingGroupAvailabilityZones = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-cooldown
@@ -140,7 +140,7 @@ asasgLaunchConfigurationName :: Lens' AutoScalingAutoScalingGroup (Maybe (Val Te
 asasgLaunchConfigurationName = lens _autoScalingAutoScalingGroupLaunchConfigurationName (\s a -> s { _autoScalingAutoScalingGroupLaunchConfigurationName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-loadbalancernames
-asasgLoadBalancerNames :: Lens' AutoScalingAutoScalingGroup (Maybe [Val Text])
+asasgLoadBalancerNames :: Lens' AutoScalingAutoScalingGroup (Maybe (ValList Text))
 asasgLoadBalancerNames = lens _autoScalingAutoScalingGroupLoadBalancerNames (\s a -> s { _autoScalingAutoScalingGroupLoadBalancerNames = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-maxsize
@@ -168,13 +168,13 @@ asasgTags :: Lens' AutoScalingAutoScalingGroup (Maybe [AutoScalingAutoScalingGro
 asasgTags = lens _autoScalingAutoScalingGroupTags (\s a -> s { _autoScalingAutoScalingGroupTags = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-targetgrouparns
-asasgTargetGroupARNs :: Lens' AutoScalingAutoScalingGroup (Maybe [Val Text])
+asasgTargetGroupARNs :: Lens' AutoScalingAutoScalingGroup (Maybe (ValList Text))
 asasgTargetGroupARNs = lens _autoScalingAutoScalingGroupTargetGroupARNs (\s a -> s { _autoScalingAutoScalingGroupTargetGroupARNs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-termpolicy
-asasgTerminationPolicies :: Lens' AutoScalingAutoScalingGroup (Maybe [Val Text])
+asasgTerminationPolicies :: Lens' AutoScalingAutoScalingGroup (Maybe (ValList Text))
 asasgTerminationPolicies = lens _autoScalingAutoScalingGroupTerminationPolicies (\s a -> s { _autoScalingAutoScalingGroupTerminationPolicies = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-vpczoneidentifier
-asasgVPCZoneIdentifier :: Lens' AutoScalingAutoScalingGroup (Maybe [Val Text])
+asasgVPCZoneIdentifier :: Lens' AutoScalingAutoScalingGroup (Maybe (ValList Text))
 asasgVPCZoneIdentifier = lens _autoScalingAutoScalingGroupVPCZoneIdentifier (\s a -> s { _autoScalingAutoScalingGroupVPCZoneIdentifier = a })

--- a/library-gen/Stratosphere/Resources/AutoScalingLaunchConfiguration.hs
+++ b/library-gen/Stratosphere/Resources/AutoScalingLaunchConfiguration.hs
@@ -21,7 +21,7 @@ data AutoScalingLaunchConfiguration =
   { _autoScalingLaunchConfigurationAssociatePublicIpAddress :: Maybe (Val Bool')
   , _autoScalingLaunchConfigurationBlockDeviceMappings :: Maybe [AutoScalingLaunchConfigurationBlockDeviceMapping]
   , _autoScalingLaunchConfigurationClassicLinkVPCId :: Maybe (Val Text)
-  , _autoScalingLaunchConfigurationClassicLinkVPCSecurityGroups :: Maybe [Val Text]
+  , _autoScalingLaunchConfigurationClassicLinkVPCSecurityGroups :: Maybe (ValList Text)
   , _autoScalingLaunchConfigurationEbsOptimized :: Maybe (Val Bool')
   , _autoScalingLaunchConfigurationIamInstanceProfile :: Maybe (Val Text)
   , _autoScalingLaunchConfigurationImageId :: Val Text
@@ -32,7 +32,7 @@ data AutoScalingLaunchConfiguration =
   , _autoScalingLaunchConfigurationKeyName :: Maybe (Val Text)
   , _autoScalingLaunchConfigurationPlacementTenancy :: Maybe (Val Text)
   , _autoScalingLaunchConfigurationRamDiskId :: Maybe (Val Text)
-  , _autoScalingLaunchConfigurationSecurityGroups :: Maybe [Val Text]
+  , _autoScalingLaunchConfigurationSecurityGroups :: Maybe (ValList Text)
   , _autoScalingLaunchConfigurationSpotPrice :: Maybe (Val Text)
   , _autoScalingLaunchConfigurationUserData :: Maybe (Val Text)
   } deriving (Show, Eq)
@@ -122,7 +122,7 @@ aslcClassicLinkVPCId :: Lens' AutoScalingLaunchConfiguration (Maybe (Val Text))
 aslcClassicLinkVPCId = lens _autoScalingLaunchConfigurationClassicLinkVPCId (\s a -> s { _autoScalingLaunchConfigurationClassicLinkVPCId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-classiclinkvpcsecuritygroups
-aslcClassicLinkVPCSecurityGroups :: Lens' AutoScalingLaunchConfiguration (Maybe [Val Text])
+aslcClassicLinkVPCSecurityGroups :: Lens' AutoScalingLaunchConfiguration (Maybe (ValList Text))
 aslcClassicLinkVPCSecurityGroups = lens _autoScalingLaunchConfigurationClassicLinkVPCSecurityGroups (\s a -> s { _autoScalingLaunchConfigurationClassicLinkVPCSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ebsoptimized
@@ -166,7 +166,7 @@ aslcRamDiskId :: Lens' AutoScalingLaunchConfiguration (Maybe (Val Text))
 aslcRamDiskId = lens _autoScalingLaunchConfigurationRamDiskId (\s a -> s { _autoScalingLaunchConfigurationRamDiskId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-securitygroups
-aslcSecurityGroups :: Lens' AutoScalingLaunchConfiguration (Maybe [Val Text])
+aslcSecurityGroups :: Lens' AutoScalingLaunchConfiguration (Maybe (ValList Text))
 aslcSecurityGroups = lens _autoScalingLaunchConfigurationSecurityGroups (\s a -> s { _autoScalingLaunchConfigurationSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-spotprice

--- a/library-gen/Stratosphere/Resources/CertificateManagerCertificate.hs
+++ b/library-gen/Stratosphere/Resources/CertificateManagerCertificate.hs
@@ -21,7 +21,7 @@ data CertificateManagerCertificate =
   CertificateManagerCertificate
   { _certificateManagerCertificateDomainName :: Val Text
   , _certificateManagerCertificateDomainValidationOptions :: Maybe [CertificateManagerCertificateDomainValidationOption]
-  , _certificateManagerCertificateSubjectAlternativeNames :: Maybe [Val Text]
+  , _certificateManagerCertificateSubjectAlternativeNames :: Maybe (ValList Text)
   , _certificateManagerCertificateTags :: Maybe [Tag]
   } deriving (Show, Eq)
 
@@ -66,7 +66,7 @@ cmcDomainValidationOptions :: Lens' CertificateManagerCertificate (Maybe [Certif
 cmcDomainValidationOptions = lens _certificateManagerCertificateDomainValidationOptions (\s a -> s { _certificateManagerCertificateDomainValidationOptions = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-subjectalternativenames
-cmcSubjectAlternativeNames :: Lens' CertificateManagerCertificate (Maybe [Val Text])
+cmcSubjectAlternativeNames :: Lens' CertificateManagerCertificate (Maybe (ValList Text))
 cmcSubjectAlternativeNames = lens _certificateManagerCertificateSubjectAlternativeNames (\s a -> s { _certificateManagerCertificateSubjectAlternativeNames = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-tags

--- a/library-gen/Stratosphere/Resources/CloudFormationStack.hs
+++ b/library-gen/Stratosphere/Resources/CloudFormationStack.hs
@@ -18,7 +18,7 @@ import Stratosphere.ResourceProperties.Tag
 -- 'cloudFormationStack' for a more convenient constructor.
 data CloudFormationStack =
   CloudFormationStack
-  { _cloudFormationStackNotificationARNs :: Maybe [Val Text]
+  { _cloudFormationStackNotificationARNs :: Maybe (ValList Text)
   , _cloudFormationStackParameters :: Maybe Object
   , _cloudFormationStackTags :: Maybe [Tag]
   , _cloudFormationStackTemplateURL :: Val Text
@@ -61,7 +61,7 @@ cloudFormationStack templateURLarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html#cfn-cloudformation-stack-notificationarns
-cfsNotificationARNs :: Lens' CloudFormationStack (Maybe [Val Text])
+cfsNotificationARNs :: Lens' CloudFormationStack (Maybe (ValList Text))
 cfsNotificationARNs = lens _cloudFormationStackNotificationARNs (\s a -> s { _cloudFormationStackNotificationARNs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html#cfn-cloudformation-stack-parameters

--- a/library-gen/Stratosphere/Resources/CloudWatchAlarm.hs
+++ b/library-gen/Stratosphere/Resources/CloudWatchAlarm.hs
@@ -19,7 +19,7 @@ import Stratosphere.ResourceProperties.CloudWatchAlarmDimension
 data CloudWatchAlarm =
   CloudWatchAlarm
   { _cloudWatchAlarmActionsEnabled :: Maybe (Val Bool')
-  , _cloudWatchAlarmAlarmActions :: Maybe [Val Text]
+  , _cloudWatchAlarmAlarmActions :: Maybe (ValList Text)
   , _cloudWatchAlarmAlarmDescription :: Maybe (Val Text)
   , _cloudWatchAlarmAlarmName :: Maybe (Val Text)
   , _cloudWatchAlarmComparisonOperator :: Val Text
@@ -27,10 +27,10 @@ data CloudWatchAlarm =
   , _cloudWatchAlarmEvaluateLowSampleCountPercentile :: Maybe (Val Text)
   , _cloudWatchAlarmEvaluationPeriods :: Val Integer'
   , _cloudWatchAlarmExtendedStatistic :: Maybe (Val Text)
-  , _cloudWatchAlarmInsufficientDataActions :: Maybe [Val Text]
+  , _cloudWatchAlarmInsufficientDataActions :: Maybe (ValList Text)
   , _cloudWatchAlarmMetricName :: Val Text
   , _cloudWatchAlarmNamespace :: Val Text
-  , _cloudWatchAlarmOKActions :: Maybe [Val Text]
+  , _cloudWatchAlarmOKActions :: Maybe (ValList Text)
   , _cloudWatchAlarmPeriod :: Val Integer'
   , _cloudWatchAlarmStatistic :: Maybe (Val Text)
   , _cloudWatchAlarmThreshold :: Val Double'
@@ -122,7 +122,7 @@ cwaActionsEnabled :: Lens' CloudWatchAlarm (Maybe (Val Bool'))
 cwaActionsEnabled = lens _cloudWatchAlarmActionsEnabled (\s a -> s { _cloudWatchAlarmActionsEnabled = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-alarmactions
-cwaAlarmActions :: Lens' CloudWatchAlarm (Maybe [Val Text])
+cwaAlarmActions :: Lens' CloudWatchAlarm (Maybe (ValList Text))
 cwaAlarmActions = lens _cloudWatchAlarmAlarmActions (\s a -> s { _cloudWatchAlarmAlarmActions = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-alarmdescription
@@ -154,7 +154,7 @@ cwaExtendedStatistic :: Lens' CloudWatchAlarm (Maybe (Val Text))
 cwaExtendedStatistic = lens _cloudWatchAlarmExtendedStatistic (\s a -> s { _cloudWatchAlarmExtendedStatistic = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-insufficientdataactions
-cwaInsufficientDataActions :: Lens' CloudWatchAlarm (Maybe [Val Text])
+cwaInsufficientDataActions :: Lens' CloudWatchAlarm (Maybe (ValList Text))
 cwaInsufficientDataActions = lens _cloudWatchAlarmInsufficientDataActions (\s a -> s { _cloudWatchAlarmInsufficientDataActions = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-metricname
@@ -166,7 +166,7 @@ cwaNamespace :: Lens' CloudWatchAlarm (Val Text)
 cwaNamespace = lens _cloudWatchAlarmNamespace (\s a -> s { _cloudWatchAlarmNamespace = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-okactions
-cwaOKActions :: Lens' CloudWatchAlarm (Maybe [Val Text])
+cwaOKActions :: Lens' CloudWatchAlarm (Maybe (ValList Text))
 cwaOKActions = lens _cloudWatchAlarmOKActions (\s a -> s { _cloudWatchAlarmOKActions = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-period

--- a/library-gen/Stratosphere/Resources/CodeDeployDeploymentGroup.hs
+++ b/library-gen/Stratosphere/Resources/CodeDeployDeploymentGroup.hs
@@ -24,7 +24,7 @@ data CodeDeployDeploymentGroup =
   CodeDeployDeploymentGroup
   { _codeDeployDeploymentGroupAlarmConfiguration :: Maybe CodeDeployDeploymentGroupAlarmConfiguration
   , _codeDeployDeploymentGroupApplicationName :: Val Text
-  , _codeDeployDeploymentGroupAutoScalingGroups :: Maybe [Val Text]
+  , _codeDeployDeploymentGroupAutoScalingGroups :: Maybe (ValList Text)
   , _codeDeployDeploymentGroupDeployment :: Maybe CodeDeployDeploymentGroupDeployment
   , _codeDeployDeploymentGroupDeploymentConfigName :: Maybe (Val Text)
   , _codeDeployDeploymentGroupDeploymentGroupName :: Maybe (Val Text)
@@ -94,7 +94,7 @@ cddgApplicationName :: Lens' CodeDeployDeploymentGroup (Val Text)
 cddgApplicationName = lens _codeDeployDeploymentGroupApplicationName (\s a -> s { _codeDeployDeploymentGroupApplicationName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html#cfn-codedeploy-deploymentgroup-autoscalinggroups
-cddgAutoScalingGroups :: Lens' CodeDeployDeploymentGroup (Maybe [Val Text])
+cddgAutoScalingGroups :: Lens' CodeDeployDeploymentGroup (Maybe (ValList Text))
 cddgAutoScalingGroups = lens _codeDeployDeploymentGroupAutoScalingGroups (\s a -> s { _codeDeployDeploymentGroupAutoScalingGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html#cfn-codedeploy-deploymentgroup-deployment

--- a/library-gen/Stratosphere/Resources/CognitoIdentityPool.hs
+++ b/library-gen/Stratosphere/Resources/CognitoIdentityPool.hs
@@ -26,9 +26,9 @@ data CognitoIdentityPool =
   , _cognitoIdentityPoolCognitoStreams :: Maybe CognitoIdentityPoolCognitoStreams
   , _cognitoIdentityPoolDeveloperProviderName :: Maybe (Val Text)
   , _cognitoIdentityPoolIdentityPoolName :: Maybe (Val Text)
-  , _cognitoIdentityPoolOpenIdConnectProviderARNs :: Maybe [Val Text]
+  , _cognitoIdentityPoolOpenIdConnectProviderARNs :: Maybe (ValList Text)
   , _cognitoIdentityPoolPushSync :: Maybe CognitoIdentityPoolPushSync
-  , _cognitoIdentityPoolSamlProviderARNs :: Maybe [Val Text]
+  , _cognitoIdentityPoolSamlProviderARNs :: Maybe (ValList Text)
   , _cognitoIdentityPoolSupportedLoginProviders :: Maybe Object
   } deriving (Show, Eq)
 
@@ -107,7 +107,7 @@ cipIdentityPoolName :: Lens' CognitoIdentityPool (Maybe (Val Text))
 cipIdentityPoolName = lens _cognitoIdentityPoolIdentityPoolName (\s a -> s { _cognitoIdentityPoolIdentityPoolName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html#cfn-cognito-identitypool-openidconnectproviderarns
-cipOpenIdConnectProviderARNs :: Lens' CognitoIdentityPool (Maybe [Val Text])
+cipOpenIdConnectProviderARNs :: Lens' CognitoIdentityPool (Maybe (ValList Text))
 cipOpenIdConnectProviderARNs = lens _cognitoIdentityPoolOpenIdConnectProviderARNs (\s a -> s { _cognitoIdentityPoolOpenIdConnectProviderARNs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html#cfn-cognito-identitypool-pushsync
@@ -115,7 +115,7 @@ cipPushSync :: Lens' CognitoIdentityPool (Maybe CognitoIdentityPoolPushSync)
 cipPushSync = lens _cognitoIdentityPoolPushSync (\s a -> s { _cognitoIdentityPoolPushSync = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html#cfn-cognito-identitypool-samlproviderarns
-cipSamlProviderARNs :: Lens' CognitoIdentityPool (Maybe [Val Text])
+cipSamlProviderARNs :: Lens' CognitoIdentityPool (Maybe (ValList Text))
 cipSamlProviderARNs = lens _cognitoIdentityPoolSamlProviderARNs (\s a -> s { _cognitoIdentityPoolSamlProviderARNs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html#cfn-cognito-identitypool-supportedloginproviders

--- a/library-gen/Stratosphere/Resources/CognitoUserPool.hs
+++ b/library-gen/Stratosphere/Resources/CognitoUserPool.hs
@@ -25,8 +25,8 @@ import Stratosphere.ResourceProperties.CognitoUserPoolSmsConfiguration
 data CognitoUserPool =
   CognitoUserPool
   { _cognitoUserPoolAdminCreateUserConfig :: Maybe CognitoUserPoolAdminCreateUserConfig
-  , _cognitoUserPoolAliasAttributes :: Maybe [Val Text]
-  , _cognitoUserPoolAutoVerifiedAttributes :: Maybe [Val Text]
+  , _cognitoUserPoolAliasAttributes :: Maybe (ValList Text)
+  , _cognitoUserPoolAutoVerifiedAttributes :: Maybe (ValList Text)
   , _cognitoUserPoolDeviceConfiguration :: Maybe CognitoUserPoolDeviceConfiguration
   , _cognitoUserPoolEmailConfiguration :: Maybe CognitoUserPoolEmailConfiguration
   , _cognitoUserPoolEmailVerificationMessage :: Maybe (Val Text)
@@ -114,11 +114,11 @@ cupAdminCreateUserConfig :: Lens' CognitoUserPool (Maybe CognitoUserPoolAdminCre
 cupAdminCreateUserConfig = lens _cognitoUserPoolAdminCreateUserConfig (\s a -> s { _cognitoUserPoolAdminCreateUserConfig = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-aliasattributes
-cupAliasAttributes :: Lens' CognitoUserPool (Maybe [Val Text])
+cupAliasAttributes :: Lens' CognitoUserPool (Maybe (ValList Text))
 cupAliasAttributes = lens _cognitoUserPoolAliasAttributes (\s a -> s { _cognitoUserPoolAliasAttributes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-autoverifiedattributes
-cupAutoVerifiedAttributes :: Lens' CognitoUserPool (Maybe [Val Text])
+cupAutoVerifiedAttributes :: Lens' CognitoUserPool (Maybe (ValList Text))
 cupAutoVerifiedAttributes = lens _cognitoUserPoolAutoVerifiedAttributes (\s a -> s { _cognitoUserPoolAutoVerifiedAttributes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-deviceconfiguration

--- a/library-gen/Stratosphere/Resources/CognitoUserPoolClient.hs
+++ b/library-gen/Stratosphere/Resources/CognitoUserPoolClient.hs
@@ -19,12 +19,12 @@ import Stratosphere.Values
 data CognitoUserPoolClient =
   CognitoUserPoolClient
   { _cognitoUserPoolClientClientName :: Maybe (Val Text)
-  , _cognitoUserPoolClientExplicitAuthFlows :: Maybe [Val Text]
+  , _cognitoUserPoolClientExplicitAuthFlows :: Maybe (ValList Text)
   , _cognitoUserPoolClientGenerateSecret :: Maybe (Val Bool')
-  , _cognitoUserPoolClientReadAttributes :: Maybe [Val Text]
+  , _cognitoUserPoolClientReadAttributes :: Maybe (ValList Text)
   , _cognitoUserPoolClientRefreshTokenValidity :: Maybe (Val Double')
   , _cognitoUserPoolClientUserPoolId :: Val Text
-  , _cognitoUserPoolClientWriteAttributes :: Maybe [Val Text]
+  , _cognitoUserPoolClientWriteAttributes :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON CognitoUserPoolClient where
@@ -73,7 +73,7 @@ cupcClientName :: Lens' CognitoUserPoolClient (Maybe (Val Text))
 cupcClientName = lens _cognitoUserPoolClientClientName (\s a -> s { _cognitoUserPoolClientClientName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-explicitauthflows
-cupcExplicitAuthFlows :: Lens' CognitoUserPoolClient (Maybe [Val Text])
+cupcExplicitAuthFlows :: Lens' CognitoUserPoolClient (Maybe (ValList Text))
 cupcExplicitAuthFlows = lens _cognitoUserPoolClientExplicitAuthFlows (\s a -> s { _cognitoUserPoolClientExplicitAuthFlows = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-generatesecret
@@ -81,7 +81,7 @@ cupcGenerateSecret :: Lens' CognitoUserPoolClient (Maybe (Val Bool'))
 cupcGenerateSecret = lens _cognitoUserPoolClientGenerateSecret (\s a -> s { _cognitoUserPoolClientGenerateSecret = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-readattributes
-cupcReadAttributes :: Lens' CognitoUserPoolClient (Maybe [Val Text])
+cupcReadAttributes :: Lens' CognitoUserPoolClient (Maybe (ValList Text))
 cupcReadAttributes = lens _cognitoUserPoolClientReadAttributes (\s a -> s { _cognitoUserPoolClientReadAttributes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-refreshtokenvalidity
@@ -93,5 +93,5 @@ cupcUserPoolId :: Lens' CognitoUserPoolClient (Val Text)
 cupcUserPoolId = lens _cognitoUserPoolClientUserPoolId (\s a -> s { _cognitoUserPoolClientUserPoolId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-writeattributes
-cupcWriteAttributes :: Lens' CognitoUserPoolClient (Maybe [Val Text])
+cupcWriteAttributes :: Lens' CognitoUserPoolClient (Maybe (ValList Text))
 cupcWriteAttributes = lens _cognitoUserPoolClientWriteAttributes (\s a -> s { _cognitoUserPoolClientWriteAttributes = a })

--- a/library-gen/Stratosphere/Resources/CognitoUserPoolUser.hs
+++ b/library-gen/Stratosphere/Resources/CognitoUserPoolUser.hs
@@ -18,7 +18,7 @@ import Stratosphere.ResourceProperties.CognitoUserPoolUserAttributeType
 -- 'cognitoUserPoolUser' for a more convenient constructor.
 data CognitoUserPoolUser =
   CognitoUserPoolUser
-  { _cognitoUserPoolUserDesiredDeliveryMediums :: Maybe [Val Text]
+  { _cognitoUserPoolUserDesiredDeliveryMediums :: Maybe (ValList Text)
   , _cognitoUserPoolUserForceAliasCreation :: Maybe (Val Bool')
   , _cognitoUserPoolUserMessageAction :: Maybe (Val Text)
   , _cognitoUserPoolUserUserAttributes :: Maybe [CognitoUserPoolUserAttributeType]
@@ -69,7 +69,7 @@ cognitoUserPoolUser userPoolIdarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooluser.html#cfn-cognito-userpooluser-desireddeliverymediums
-cupuDesiredDeliveryMediums :: Lens' CognitoUserPoolUser (Maybe [Val Text])
+cupuDesiredDeliveryMediums :: Lens' CognitoUserPoolUser (Maybe (ValList Text))
 cupuDesiredDeliveryMediums = lens _cognitoUserPoolUserDesiredDeliveryMediums (\s a -> s { _cognitoUserPoolUserDesiredDeliveryMediums = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooluser.html#cfn-cognito-userpooluser-forcealiascreation

--- a/library-gen/Stratosphere/Resources/DMSEventSubscription.hs
+++ b/library-gen/Stratosphere/Resources/DMSEventSubscription.hs
@@ -19,9 +19,9 @@ import Stratosphere.ResourceProperties.Tag
 data DMSEventSubscription =
   DMSEventSubscription
   { _dMSEventSubscriptionEnabled :: Maybe (Val Bool')
-  , _dMSEventSubscriptionEventCategories :: Maybe [Val Text]
+  , _dMSEventSubscriptionEventCategories :: Maybe (ValList Text)
   , _dMSEventSubscriptionSnsTopicArn :: Val Text
-  , _dMSEventSubscriptionSourceIds :: Maybe [Val Text]
+  , _dMSEventSubscriptionSourceIds :: Maybe (ValList Text)
   , _dMSEventSubscriptionSourceType :: Maybe (Val Text)
   , _dMSEventSubscriptionSubscriptionName :: Maybe (Val Text)
   , _dMSEventSubscriptionTags :: Maybe [Tag]
@@ -73,7 +73,7 @@ dmsesEnabled :: Lens' DMSEventSubscription (Maybe (Val Bool'))
 dmsesEnabled = lens _dMSEventSubscriptionEnabled (\s a -> s { _dMSEventSubscriptionEnabled = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-eventsubscription.html#cfn-dms-eventsubscription-eventcategories
-dmsesEventCategories :: Lens' DMSEventSubscription (Maybe [Val Text])
+dmsesEventCategories :: Lens' DMSEventSubscription (Maybe (ValList Text))
 dmsesEventCategories = lens _dMSEventSubscriptionEventCategories (\s a -> s { _dMSEventSubscriptionEventCategories = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-eventsubscription.html#cfn-dms-eventsubscription-snstopicarn
@@ -81,7 +81,7 @@ dmsesSnsTopicArn :: Lens' DMSEventSubscription (Val Text)
 dmsesSnsTopicArn = lens _dMSEventSubscriptionSnsTopicArn (\s a -> s { _dMSEventSubscriptionSnsTopicArn = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-eventsubscription.html#cfn-dms-eventsubscription-sourceids
-dmsesSourceIds :: Lens' DMSEventSubscription (Maybe [Val Text])
+dmsesSourceIds :: Lens' DMSEventSubscription (Maybe (ValList Text))
 dmsesSourceIds = lens _dMSEventSubscriptionSourceIds (\s a -> s { _dMSEventSubscriptionSourceIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-eventsubscription.html#cfn-dms-eventsubscription-sourcetype

--- a/library-gen/Stratosphere/Resources/DMSReplicationInstance.hs
+++ b/library-gen/Stratosphere/Resources/DMSReplicationInstance.hs
@@ -31,7 +31,7 @@ data DMSReplicationInstance =
   , _dMSReplicationInstanceReplicationInstanceIdentifier :: Maybe (Val Text)
   , _dMSReplicationInstanceReplicationSubnetGroupIdentifier :: Maybe (Val Text)
   , _dMSReplicationInstanceTags :: Maybe [Tag]
-  , _dMSReplicationInstanceVpcSecurityGroupIds :: Maybe [Val Text]
+  , _dMSReplicationInstanceVpcSecurityGroupIds :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON DMSReplicationInstance where
@@ -149,5 +149,5 @@ dmsriTags :: Lens' DMSReplicationInstance (Maybe [Tag])
 dmsriTags = lens _dMSReplicationInstanceTags (\s a -> s { _dMSReplicationInstanceTags = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationinstance.html#cfn-dms-replicationinstance-vpcsecuritygroupids
-dmsriVpcSecurityGroupIds :: Lens' DMSReplicationInstance (Maybe [Val Text])
+dmsriVpcSecurityGroupIds :: Lens' DMSReplicationInstance (Maybe (ValList Text))
 dmsriVpcSecurityGroupIds = lens _dMSReplicationInstanceVpcSecurityGroupIds (\s a -> s { _dMSReplicationInstanceVpcSecurityGroupIds = a })

--- a/library-gen/Stratosphere/Resources/DMSReplicationSubnetGroup.hs
+++ b/library-gen/Stratosphere/Resources/DMSReplicationSubnetGroup.hs
@@ -20,7 +20,7 @@ data DMSReplicationSubnetGroup =
   DMSReplicationSubnetGroup
   { _dMSReplicationSubnetGroupReplicationSubnetGroupDescription :: Val Text
   , _dMSReplicationSubnetGroupReplicationSubnetGroupIdentifier :: Maybe (Val Text)
-  , _dMSReplicationSubnetGroupSubnetIds :: [Val Text]
+  , _dMSReplicationSubnetGroupSubnetIds :: ValList Text
   , _dMSReplicationSubnetGroupTags :: Maybe [Tag]
   } deriving (Show, Eq)
 
@@ -47,7 +47,7 @@ instance FromJSON DMSReplicationSubnetGroup where
 -- arguments.
 dmsReplicationSubnetGroup
   :: Val Text -- ^ 'dmsrsgReplicationSubnetGroupDescription'
-  -> [Val Text] -- ^ 'dmsrsgSubnetIds'
+  -> ValList Text -- ^ 'dmsrsgSubnetIds'
   -> DMSReplicationSubnetGroup
 dmsReplicationSubnetGroup replicationSubnetGroupDescriptionarg subnetIdsarg =
   DMSReplicationSubnetGroup
@@ -66,7 +66,7 @@ dmsrsgReplicationSubnetGroupIdentifier :: Lens' DMSReplicationSubnetGroup (Maybe
 dmsrsgReplicationSubnetGroupIdentifier = lens _dMSReplicationSubnetGroupReplicationSubnetGroupIdentifier (\s a -> s { _dMSReplicationSubnetGroupReplicationSubnetGroupIdentifier = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationsubnetgroup.html#cfn-dms-replicationsubnetgroup-subnetids
-dmsrsgSubnetIds :: Lens' DMSReplicationSubnetGroup [Val Text]
+dmsrsgSubnetIds :: Lens' DMSReplicationSubnetGroup (ValList Text)
 dmsrsgSubnetIds = lens _dMSReplicationSubnetGroupSubnetIds (\s a -> s { _dMSReplicationSubnetGroupSubnetIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationsubnetgroup.html#cfn-dms-replicationsubnetgroup-tags

--- a/library-gen/Stratosphere/Resources/EC2DHCPOptions.hs
+++ b/library-gen/Stratosphere/Resources/EC2DHCPOptions.hs
@@ -19,10 +19,10 @@ import Stratosphere.ResourceProperties.Tag
 data EC2DHCPOptions =
   EC2DHCPOptions
   { _eC2DHCPOptionsDomainName :: Maybe (Val Text)
-  , _eC2DHCPOptionsDomainNameServers :: Maybe [Val Text]
-  , _eC2DHCPOptionsNetbiosNameServers :: Maybe [Val Text]
+  , _eC2DHCPOptionsDomainNameServers :: Maybe (ValList Text)
+  , _eC2DHCPOptionsNetbiosNameServers :: Maybe (ValList Text)
   , _eC2DHCPOptionsNetbiosNodeType :: Maybe (Val Integer')
-  , _eC2DHCPOptionsNtpServers :: Maybe [Val Text]
+  , _eC2DHCPOptionsNtpServers :: Maybe (ValList Text)
   , _eC2DHCPOptionsTags :: Maybe [Tag]
   } deriving (Show, Eq)
 
@@ -67,11 +67,11 @@ ecdhcpoDomainName :: Lens' EC2DHCPOptions (Maybe (Val Text))
 ecdhcpoDomainName = lens _eC2DHCPOptionsDomainName (\s a -> s { _eC2DHCPOptionsDomainName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-domainnameservers
-ecdhcpoDomainNameServers :: Lens' EC2DHCPOptions (Maybe [Val Text])
+ecdhcpoDomainNameServers :: Lens' EC2DHCPOptions (Maybe (ValList Text))
 ecdhcpoDomainNameServers = lens _eC2DHCPOptionsDomainNameServers (\s a -> s { _eC2DHCPOptionsDomainNameServers = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnameservers
-ecdhcpoNetbiosNameServers :: Lens' EC2DHCPOptions (Maybe [Val Text])
+ecdhcpoNetbiosNameServers :: Lens' EC2DHCPOptions (Maybe (ValList Text))
 ecdhcpoNetbiosNameServers = lens _eC2DHCPOptionsNetbiosNameServers (\s a -> s { _eC2DHCPOptionsNetbiosNameServers = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype
@@ -79,7 +79,7 @@ ecdhcpoNetbiosNodeType :: Lens' EC2DHCPOptions (Maybe (Val Integer'))
 ecdhcpoNetbiosNodeType = lens _eC2DHCPOptionsNetbiosNodeType (\s a -> s { _eC2DHCPOptionsNetbiosNodeType = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers
-ecdhcpoNtpServers :: Lens' EC2DHCPOptions (Maybe [Val Text])
+ecdhcpoNtpServers :: Lens' EC2DHCPOptions (Maybe (ValList Text))
 ecdhcpoNtpServers = lens _eC2DHCPOptionsNtpServers (\s a -> s { _eC2DHCPOptionsNtpServers = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-tags

--- a/library-gen/Stratosphere/Resources/EC2Instance.hs
+++ b/library-gen/Stratosphere/Resources/EC2Instance.hs
@@ -43,8 +43,8 @@ data EC2Instance =
   , _eC2InstancePlacementGroupName :: Maybe (Val Text)
   , _eC2InstancePrivateIpAddress :: Maybe (Val Text)
   , _eC2InstanceRamdiskId :: Maybe (Val Text)
-  , _eC2InstanceSecurityGroupIds :: Maybe [Val Text]
-  , _eC2InstanceSecurityGroups :: Maybe [Val Text]
+  , _eC2InstanceSecurityGroupIds :: Maybe (ValList Text)
+  , _eC2InstanceSecurityGroups :: Maybe (ValList Text)
   , _eC2InstanceSourceDestCheck :: Maybe (Val Bool')
   , _eC2InstanceSsmAssociations :: Maybe [EC2InstanceSsmAssociation]
   , _eC2InstanceSubnetId :: Maybe (Val Text)
@@ -241,11 +241,11 @@ eciRamdiskId :: Lens' EC2Instance (Maybe (Val Text))
 eciRamdiskId = lens _eC2InstanceRamdiskId (\s a -> s { _eC2InstanceRamdiskId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-securitygroupids
-eciSecurityGroupIds :: Lens' EC2Instance (Maybe [Val Text])
+eciSecurityGroupIds :: Lens' EC2Instance (Maybe (ValList Text))
 eciSecurityGroupIds = lens _eC2InstanceSecurityGroupIds (\s a -> s { _eC2InstanceSecurityGroupIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-securitygroups
-eciSecurityGroups :: Lens' EC2Instance (Maybe [Val Text])
+eciSecurityGroups :: Lens' EC2Instance (Maybe (ValList Text))
 eciSecurityGroups = lens _eC2InstanceSecurityGroups (\s a -> s { _eC2InstanceSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-sourcedestcheck

--- a/library-gen/Stratosphere/Resources/EC2NetworkInterface.hs
+++ b/library-gen/Stratosphere/Resources/EC2NetworkInterface.hs
@@ -21,7 +21,7 @@ import Stratosphere.ResourceProperties.Tag
 data EC2NetworkInterface =
   EC2NetworkInterface
   { _eC2NetworkInterfaceDescription :: Maybe (Val Text)
-  , _eC2NetworkInterfaceGroupSet :: Maybe [Val Text]
+  , _eC2NetworkInterfaceGroupSet :: Maybe (ValList Text)
   , _eC2NetworkInterfaceInterfaceType :: Maybe (Val Text)
   , _eC2NetworkInterfaceIpv6AddressCount :: Maybe (Val Integer')
   , _eC2NetworkInterfaceIpv6Addresses :: Maybe EC2NetworkInterfaceInstanceIpv6Address
@@ -91,7 +91,7 @@ ecniDescription :: Lens' EC2NetworkInterface (Maybe (Val Text))
 ecniDescription = lens _eC2NetworkInterfaceDescription (\s a -> s { _eC2NetworkInterfaceDescription = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html#cfn-awsec2networkinterface-groupset
-ecniGroupSet :: Lens' EC2NetworkInterface (Maybe [Val Text])
+ecniGroupSet :: Lens' EC2NetworkInterface (Maybe (ValList Text))
 ecniGroupSet = lens _eC2NetworkInterfaceGroupSet (\s a -> s { _eC2NetworkInterfaceGroupSet = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html#cfn-ec2-networkinterface-interfacetype

--- a/library-gen/Stratosphere/Resources/EC2VPCEndpoint.hs
+++ b/library-gen/Stratosphere/Resources/EC2VPCEndpoint.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data EC2VPCEndpoint =
   EC2VPCEndpoint
   { _eC2VPCEndpointPolicyDocument :: Maybe Object
-  , _eC2VPCEndpointRouteTableIds :: Maybe [Val Text]
+  , _eC2VPCEndpointRouteTableIds :: Maybe (ValList Text)
   , _eC2VPCEndpointServiceName :: Val Text
   , _eC2VPCEndpointVpcId :: Val Text
   } deriving (Show, Eq)
@@ -61,7 +61,7 @@ ecvpcePolicyDocument :: Lens' EC2VPCEndpoint (Maybe Object)
 ecvpcePolicyDocument = lens _eC2VPCEndpointPolicyDocument (\s a -> s { _eC2VPCEndpointPolicyDocument = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpoint.html#cfn-ec2-vpcendpoint-routetableids
-ecvpceRouteTableIds :: Lens' EC2VPCEndpoint (Maybe [Val Text])
+ecvpceRouteTableIds :: Lens' EC2VPCEndpoint (Maybe (ValList Text))
 ecvpceRouteTableIds = lens _eC2VPCEndpointRouteTableIds (\s a -> s { _eC2VPCEndpointRouteTableIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpoint.html#cfn-ec2-vpcendpoint-servicename

--- a/library-gen/Stratosphere/Resources/EC2VPNGatewayRoutePropagation.hs
+++ b/library-gen/Stratosphere/Resources/EC2VPNGatewayRoutePropagation.hs
@@ -18,7 +18,7 @@ import Stratosphere.Values
 -- 'ec2VPNGatewayRoutePropagation' for a more convenient constructor.
 data EC2VPNGatewayRoutePropagation =
   EC2VPNGatewayRoutePropagation
-  { _eC2VPNGatewayRoutePropagationRouteTableIds :: [Val Text]
+  { _eC2VPNGatewayRoutePropagationRouteTableIds :: ValList Text
   , _eC2VPNGatewayRoutePropagationVpnGatewayId :: Val Text
   } deriving (Show, Eq)
 
@@ -40,7 +40,7 @@ instance FromJSON EC2VPNGatewayRoutePropagation where
 -- | Constructor for 'EC2VPNGatewayRoutePropagation' containing required
 -- fields as arguments.
 ec2VPNGatewayRoutePropagation
-  :: [Val Text] -- ^ 'ecvpngrpRouteTableIds'
+  :: ValList Text -- ^ 'ecvpngrpRouteTableIds'
   -> Val Text -- ^ 'ecvpngrpVpnGatewayId'
   -> EC2VPNGatewayRoutePropagation
 ec2VPNGatewayRoutePropagation routeTableIdsarg vpnGatewayIdarg =
@@ -50,7 +50,7 @@ ec2VPNGatewayRoutePropagation routeTableIdsarg vpnGatewayIdarg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-gatewayrouteprop.html#cfn-ec2-vpngatewayrouteprop-routetableids
-ecvpngrpRouteTableIds :: Lens' EC2VPNGatewayRoutePropagation [Val Text]
+ecvpngrpRouteTableIds :: Lens' EC2VPNGatewayRoutePropagation (ValList Text)
 ecvpngrpRouteTableIds = lens _eC2VPNGatewayRoutePropagationRouteTableIds (\s a -> s { _eC2VPNGatewayRoutePropagationRouteTableIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-gatewayrouteprop.html#cfn-ec2-vpngatewayrouteprop-vpngatewayid

--- a/library-gen/Stratosphere/Resources/EFSMountTarget.hs
+++ b/library-gen/Stratosphere/Resources/EFSMountTarget.hs
@@ -20,7 +20,7 @@ data EFSMountTarget =
   EFSMountTarget
   { _eFSMountTargetFileSystemId :: Val Text
   , _eFSMountTargetIpAddress :: Maybe (Val Text)
-  , _eFSMountTargetSecurityGroups :: [Val Text]
+  , _eFSMountTargetSecurityGroups :: ValList Text
   , _eFSMountTargetSubnetId :: Val Text
   } deriving (Show, Eq)
 
@@ -46,7 +46,7 @@ instance FromJSON EFSMountTarget where
 -- | Constructor for 'EFSMountTarget' containing required fields as arguments.
 efsMountTarget
   :: Val Text -- ^ 'efsmtFileSystemId'
-  -> [Val Text] -- ^ 'efsmtSecurityGroups'
+  -> ValList Text -- ^ 'efsmtSecurityGroups'
   -> Val Text -- ^ 'efsmtSubnetId'
   -> EFSMountTarget
 efsMountTarget fileSystemIdarg securityGroupsarg subnetIdarg =
@@ -66,7 +66,7 @@ efsmtIpAddress :: Lens' EFSMountTarget (Maybe (Val Text))
 efsmtIpAddress = lens _eFSMountTargetIpAddress (\s a -> s { _eFSMountTargetIpAddress = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html#cfn-efs-mounttarget-securitygroups
-efsmtSecurityGroups :: Lens' EFSMountTarget [Val Text]
+efsmtSecurityGroups :: Lens' EFSMountTarget (ValList Text)
 efsmtSecurityGroups = lens _eFSMountTargetSecurityGroups (\s a -> s { _eFSMountTargetSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html#cfn-efs-mounttarget-subnetid

--- a/library-gen/Stratosphere/Resources/ElastiCacheCacheCluster.hs
+++ b/library-gen/Stratosphere/Resources/ElastiCacheCacheCluster.hs
@@ -22,7 +22,7 @@ data ElastiCacheCacheCluster =
   , _elastiCacheCacheClusterAutoMinorVersionUpgrade :: Maybe (Val Bool')
   , _elastiCacheCacheClusterCacheNodeType :: Val Text
   , _elastiCacheCacheClusterCacheParameterGroupName :: Maybe (Val Text)
-  , _elastiCacheCacheClusterCacheSecurityGroupNames :: Maybe [Val Text]
+  , _elastiCacheCacheClusterCacheSecurityGroupNames :: Maybe (ValList Text)
   , _elastiCacheCacheClusterCacheSubnetGroupName :: Maybe (Val Text)
   , _elastiCacheCacheClusterClusterName :: Maybe (Val Text)
   , _elastiCacheCacheClusterEngine :: Val Text
@@ -31,14 +31,14 @@ data ElastiCacheCacheCluster =
   , _elastiCacheCacheClusterNumCacheNodes :: Val Integer'
   , _elastiCacheCacheClusterPort :: Maybe (Val Integer')
   , _elastiCacheCacheClusterPreferredAvailabilityZone :: Maybe (Val Text)
-  , _elastiCacheCacheClusterPreferredAvailabilityZones :: Maybe [Val Text]
+  , _elastiCacheCacheClusterPreferredAvailabilityZones :: Maybe (ValList Text)
   , _elastiCacheCacheClusterPreferredMaintenanceWindow :: Maybe (Val Text)
-  , _elastiCacheCacheClusterSnapshotArns :: Maybe [Val Text]
+  , _elastiCacheCacheClusterSnapshotArns :: Maybe (ValList Text)
   , _elastiCacheCacheClusterSnapshotName :: Maybe (Val Text)
   , _elastiCacheCacheClusterSnapshotRetentionLimit :: Maybe (Val Integer')
   , _elastiCacheCacheClusterSnapshotWindow :: Maybe (Val Text)
   , _elastiCacheCacheClusterTags :: Maybe [Tag]
-  , _elastiCacheCacheClusterVpcSecurityGroupIds :: Maybe [Val Text]
+  , _elastiCacheCacheClusterVpcSecurityGroupIds :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON ElastiCacheCacheCluster where
@@ -143,7 +143,7 @@ ecccCacheParameterGroupName :: Lens' ElastiCacheCacheCluster (Maybe (Val Text))
 ecccCacheParameterGroupName = lens _elastiCacheCacheClusterCacheParameterGroupName (\s a -> s { _elastiCacheCacheClusterCacheParameterGroupName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-cachesecuritygroupnames
-ecccCacheSecurityGroupNames :: Lens' ElastiCacheCacheCluster (Maybe [Val Text])
+ecccCacheSecurityGroupNames :: Lens' ElastiCacheCacheCluster (Maybe (ValList Text))
 ecccCacheSecurityGroupNames = lens _elastiCacheCacheClusterCacheSecurityGroupNames (\s a -> s { _elastiCacheCacheClusterCacheSecurityGroupNames = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-cachesubnetgroupname
@@ -179,7 +179,7 @@ ecccPreferredAvailabilityZone :: Lens' ElastiCacheCacheCluster (Maybe (Val Text)
 ecccPreferredAvailabilityZone = lens _elastiCacheCacheClusterPreferredAvailabilityZone (\s a -> s { _elastiCacheCacheClusterPreferredAvailabilityZone = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-preferredavailabilityzones
-ecccPreferredAvailabilityZones :: Lens' ElastiCacheCacheCluster (Maybe [Val Text])
+ecccPreferredAvailabilityZones :: Lens' ElastiCacheCacheCluster (Maybe (ValList Text))
 ecccPreferredAvailabilityZones = lens _elastiCacheCacheClusterPreferredAvailabilityZones (\s a -> s { _elastiCacheCacheClusterPreferredAvailabilityZones = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-preferredmaintenancewindow
@@ -187,7 +187,7 @@ ecccPreferredMaintenanceWindow :: Lens' ElastiCacheCacheCluster (Maybe (Val Text
 ecccPreferredMaintenanceWindow = lens _elastiCacheCacheClusterPreferredMaintenanceWindow (\s a -> s { _elastiCacheCacheClusterPreferredMaintenanceWindow = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-snapshotarns
-ecccSnapshotArns :: Lens' ElastiCacheCacheCluster (Maybe [Val Text])
+ecccSnapshotArns :: Lens' ElastiCacheCacheCluster (Maybe (ValList Text))
 ecccSnapshotArns = lens _elastiCacheCacheClusterSnapshotArns (\s a -> s { _elastiCacheCacheClusterSnapshotArns = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-snapshotname
@@ -207,5 +207,5 @@ ecccTags :: Lens' ElastiCacheCacheCluster (Maybe [Tag])
 ecccTags = lens _elastiCacheCacheClusterTags (\s a -> s { _elastiCacheCacheClusterTags = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-vpcsecuritygroupids
-ecccVpcSecurityGroupIds :: Lens' ElastiCacheCacheCluster (Maybe [Val Text])
+ecccVpcSecurityGroupIds :: Lens' ElastiCacheCacheCluster (Maybe (ValList Text))
 ecccVpcSecurityGroupIds = lens _elastiCacheCacheClusterVpcSecurityGroupIds (\s a -> s { _elastiCacheCacheClusterVpcSecurityGroupIds = a })

--- a/library-gen/Stratosphere/Resources/ElastiCacheReplicationGroup.hs
+++ b/library-gen/Stratosphere/Resources/ElastiCacheReplicationGroup.hs
@@ -23,7 +23,7 @@ data ElastiCacheReplicationGroup =
   , _elastiCacheReplicationGroupAutomaticFailoverEnabled :: Maybe (Val Bool')
   , _elastiCacheReplicationGroupCacheNodeType :: Maybe (Val Text)
   , _elastiCacheReplicationGroupCacheParameterGroupName :: Maybe (Val Text)
-  , _elastiCacheReplicationGroupCacheSecurityGroupNames :: Maybe [Val Text]
+  , _elastiCacheReplicationGroupCacheSecurityGroupNames :: Maybe (ValList Text)
   , _elastiCacheReplicationGroupCacheSubnetGroupName :: Maybe (Val Text)
   , _elastiCacheReplicationGroupEngine :: Maybe (Val Text)
   , _elastiCacheReplicationGroupEngineVersion :: Maybe (Val Text)
@@ -32,14 +32,14 @@ data ElastiCacheReplicationGroup =
   , _elastiCacheReplicationGroupNumCacheClusters :: Maybe (Val Integer')
   , _elastiCacheReplicationGroupNumNodeGroups :: Maybe (Val Integer')
   , _elastiCacheReplicationGroupPort :: Maybe (Val Integer')
-  , _elastiCacheReplicationGroupPreferredCacheClusterAZs :: Maybe [Val Text]
+  , _elastiCacheReplicationGroupPreferredCacheClusterAZs :: Maybe (ValList Text)
   , _elastiCacheReplicationGroupPreferredMaintenanceWindow :: Maybe (Val Text)
   , _elastiCacheReplicationGroupPrimaryClusterId :: Maybe (Val Text)
   , _elastiCacheReplicationGroupReplicasPerNodeGroup :: Maybe (Val Integer')
   , _elastiCacheReplicationGroupReplicationGroupDescription :: Val Text
   , _elastiCacheReplicationGroupReplicationGroupId :: Maybe (Val Text)
-  , _elastiCacheReplicationGroupSecurityGroupIds :: Maybe [Val Text]
-  , _elastiCacheReplicationGroupSnapshotArns :: Maybe [Val Text]
+  , _elastiCacheReplicationGroupSecurityGroupIds :: Maybe (ValList Text)
+  , _elastiCacheReplicationGroupSnapshotArns :: Maybe (ValList Text)
   , _elastiCacheReplicationGroupSnapshotName :: Maybe (Val Text)
   , _elastiCacheReplicationGroupSnapshotRetentionLimit :: Maybe (Val Integer')
   , _elastiCacheReplicationGroupSnapshotWindow :: Maybe (Val Text)
@@ -162,7 +162,7 @@ ecrgCacheParameterGroupName :: Lens' ElastiCacheReplicationGroup (Maybe (Val Tex
 ecrgCacheParameterGroupName = lens _elastiCacheReplicationGroupCacheParameterGroupName (\s a -> s { _elastiCacheReplicationGroupCacheParameterGroupName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-cachesecuritygroupnames
-ecrgCacheSecurityGroupNames :: Lens' ElastiCacheReplicationGroup (Maybe [Val Text])
+ecrgCacheSecurityGroupNames :: Lens' ElastiCacheReplicationGroup (Maybe (ValList Text))
 ecrgCacheSecurityGroupNames = lens _elastiCacheReplicationGroupCacheSecurityGroupNames (\s a -> s { _elastiCacheReplicationGroupCacheSecurityGroupNames = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-cachesubnetgroupname
@@ -198,7 +198,7 @@ ecrgPort :: Lens' ElastiCacheReplicationGroup (Maybe (Val Integer'))
 ecrgPort = lens _elastiCacheReplicationGroupPort (\s a -> s { _elastiCacheReplicationGroupPort = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-preferredcacheclusterazs
-ecrgPreferredCacheClusterAZs :: Lens' ElastiCacheReplicationGroup (Maybe [Val Text])
+ecrgPreferredCacheClusterAZs :: Lens' ElastiCacheReplicationGroup (Maybe (ValList Text))
 ecrgPreferredCacheClusterAZs = lens _elastiCacheReplicationGroupPreferredCacheClusterAZs (\s a -> s { _elastiCacheReplicationGroupPreferredCacheClusterAZs = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-preferredmaintenancewindow
@@ -222,11 +222,11 @@ ecrgReplicationGroupId :: Lens' ElastiCacheReplicationGroup (Maybe (Val Text))
 ecrgReplicationGroupId = lens _elastiCacheReplicationGroupReplicationGroupId (\s a -> s { _elastiCacheReplicationGroupReplicationGroupId = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-securitygroupids
-ecrgSecurityGroupIds :: Lens' ElastiCacheReplicationGroup (Maybe [Val Text])
+ecrgSecurityGroupIds :: Lens' ElastiCacheReplicationGroup (Maybe (ValList Text))
 ecrgSecurityGroupIds = lens _elastiCacheReplicationGroupSecurityGroupIds (\s a -> s { _elastiCacheReplicationGroupSecurityGroupIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-snapshotarns
-ecrgSnapshotArns :: Lens' ElastiCacheReplicationGroup (Maybe [Val Text])
+ecrgSnapshotArns :: Lens' ElastiCacheReplicationGroup (Maybe (ValList Text))
 ecrgSnapshotArns = lens _elastiCacheReplicationGroupSnapshotArns (\s a -> s { _elastiCacheReplicationGroupSnapshotArns = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-snapshotname

--- a/library-gen/Stratosphere/Resources/ElastiCacheSubnetGroup.hs
+++ b/library-gen/Stratosphere/Resources/ElastiCacheSubnetGroup.hs
@@ -20,7 +20,7 @@ data ElastiCacheSubnetGroup =
   ElastiCacheSubnetGroup
   { _elastiCacheSubnetGroupCacheSubnetGroupName :: Maybe (Val Text)
   , _elastiCacheSubnetGroupDescription :: Val Text
-  , _elastiCacheSubnetGroupSubnetIds :: [Val Text]
+  , _elastiCacheSubnetGroupSubnetIds :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON ElastiCacheSubnetGroup where
@@ -44,7 +44,7 @@ instance FromJSON ElastiCacheSubnetGroup where
 -- arguments.
 elastiCacheSubnetGroup
   :: Val Text -- ^ 'ecsugDescription'
-  -> [Val Text] -- ^ 'ecsugSubnetIds'
+  -> ValList Text -- ^ 'ecsugSubnetIds'
   -> ElastiCacheSubnetGroup
 elastiCacheSubnetGroup descriptionarg subnetIdsarg =
   ElastiCacheSubnetGroup
@@ -62,5 +62,5 @@ ecsugDescription :: Lens' ElastiCacheSubnetGroup (Val Text)
 ecsugDescription = lens _elastiCacheSubnetGroupDescription (\s a -> s { _elastiCacheSubnetGroupDescription = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-subnetgroup.html#cfn-elasticache-subnetgroup-subnetids
-ecsugSubnetIds :: Lens' ElastiCacheSubnetGroup [Val Text]
+ecsugSubnetIds :: Lens' ElastiCacheSubnetGroup (ValList Text)
 ecsugSubnetIds = lens _elastiCacheSubnetGroupSubnetIds (\s a -> s { _elastiCacheSubnetGroupSubnetIds = a })

--- a/library-gen/Stratosphere/Resources/ElasticLoadBalancingLoadBalancer.hs
+++ b/library-gen/Stratosphere/Resources/ElasticLoadBalancingLoadBalancer.hs
@@ -28,19 +28,19 @@ data ElasticLoadBalancingLoadBalancer =
   ElasticLoadBalancingLoadBalancer
   { _elasticLoadBalancingLoadBalancerAccessLoggingPolicy :: Maybe ElasticLoadBalancingLoadBalancerAccessLoggingPolicy
   , _elasticLoadBalancingLoadBalancerAppCookieStickinessPolicy :: Maybe [ElasticLoadBalancingLoadBalancerAppCookieStickinessPolicy]
-  , _elasticLoadBalancingLoadBalancerAvailabilityZones :: Maybe [Val Text]
+  , _elasticLoadBalancingLoadBalancerAvailabilityZones :: Maybe (ValList Text)
   , _elasticLoadBalancingLoadBalancerConnectionDrainingPolicy :: Maybe ElasticLoadBalancingLoadBalancerConnectionDrainingPolicy
   , _elasticLoadBalancingLoadBalancerConnectionSettings :: Maybe ElasticLoadBalancingLoadBalancerConnectionSettings
   , _elasticLoadBalancingLoadBalancerCrossZone :: Maybe (Val Bool')
   , _elasticLoadBalancingLoadBalancerHealthCheck :: Maybe ElasticLoadBalancingLoadBalancerHealthCheck
-  , _elasticLoadBalancingLoadBalancerInstances :: Maybe [Val Text]
+  , _elasticLoadBalancingLoadBalancerInstances :: Maybe (ValList Text)
   , _elasticLoadBalancingLoadBalancerLBCookieStickinessPolicy :: Maybe [ElasticLoadBalancingLoadBalancerLBCookieStickinessPolicy]
   , _elasticLoadBalancingLoadBalancerListeners :: [ElasticLoadBalancingLoadBalancerListeners]
   , _elasticLoadBalancingLoadBalancerLoadBalancerName :: Maybe (Val Text)
   , _elasticLoadBalancingLoadBalancerPolicies :: Maybe [ElasticLoadBalancingLoadBalancerPolicies]
   , _elasticLoadBalancingLoadBalancerScheme :: Maybe (Val Text)
-  , _elasticLoadBalancingLoadBalancerSecurityGroups :: Maybe [Val Text]
-  , _elasticLoadBalancingLoadBalancerSubnets :: Maybe [Val Text]
+  , _elasticLoadBalancingLoadBalancerSecurityGroups :: Maybe (ValList Text)
+  , _elasticLoadBalancingLoadBalancerSubnets :: Maybe (ValList Text)
   , _elasticLoadBalancingLoadBalancerTags :: Maybe [Tag]
   } deriving (Show, Eq)
 
@@ -121,7 +121,7 @@ elblbAppCookieStickinessPolicy :: Lens' ElasticLoadBalancingLoadBalancer (Maybe 
 elblbAppCookieStickinessPolicy = lens _elasticLoadBalancingLoadBalancerAppCookieStickinessPolicy (\s a -> s { _elasticLoadBalancingLoadBalancerAppCookieStickinessPolicy = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-availabilityzones
-elblbAvailabilityZones :: Lens' ElasticLoadBalancingLoadBalancer (Maybe [Val Text])
+elblbAvailabilityZones :: Lens' ElasticLoadBalancingLoadBalancer (Maybe (ValList Text))
 elblbAvailabilityZones = lens _elasticLoadBalancingLoadBalancerAvailabilityZones (\s a -> s { _elasticLoadBalancingLoadBalancerAvailabilityZones = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-connectiondrainingpolicy
@@ -141,7 +141,7 @@ elblbHealthCheck :: Lens' ElasticLoadBalancingLoadBalancer (Maybe ElasticLoadBal
 elblbHealthCheck = lens _elasticLoadBalancingLoadBalancerHealthCheck (\s a -> s { _elasticLoadBalancingLoadBalancerHealthCheck = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-instances
-elblbInstances :: Lens' ElasticLoadBalancingLoadBalancer (Maybe [Val Text])
+elblbInstances :: Lens' ElasticLoadBalancingLoadBalancer (Maybe (ValList Text))
 elblbInstances = lens _elasticLoadBalancingLoadBalancerInstances (\s a -> s { _elasticLoadBalancingLoadBalancerInstances = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-lbcookiestickinesspolicy
@@ -165,11 +165,11 @@ elblbScheme :: Lens' ElasticLoadBalancingLoadBalancer (Maybe (Val Text))
 elblbScheme = lens _elasticLoadBalancingLoadBalancerScheme (\s a -> s { _elasticLoadBalancingLoadBalancerScheme = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-securitygroups
-elblbSecurityGroups :: Lens' ElasticLoadBalancingLoadBalancer (Maybe [Val Text])
+elblbSecurityGroups :: Lens' ElasticLoadBalancingLoadBalancer (Maybe (ValList Text))
 elblbSecurityGroups = lens _elasticLoadBalancingLoadBalancerSecurityGroups (\s a -> s { _elasticLoadBalancingLoadBalancerSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-subnets
-elblbSubnets :: Lens' ElasticLoadBalancingLoadBalancer (Maybe [Val Text])
+elblbSubnets :: Lens' ElasticLoadBalancingLoadBalancer (Maybe (ValList Text))
 elblbSubnets = lens _elasticLoadBalancingLoadBalancerSubnets (\s a -> s { _elasticLoadBalancingLoadBalancerSubnets = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-elasticloadbalancing-loadbalancer-tags

--- a/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2LoadBalancer.hs
+++ b/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2LoadBalancer.hs
@@ -23,8 +23,8 @@ data ElasticLoadBalancingV2LoadBalancer =
   , _elasticLoadBalancingV2LoadBalancerLoadBalancerAttributes :: Maybe [ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute]
   , _elasticLoadBalancingV2LoadBalancerName :: Maybe (Val Text)
   , _elasticLoadBalancingV2LoadBalancerScheme :: Maybe (Val Text)
-  , _elasticLoadBalancingV2LoadBalancerSecurityGroups :: Maybe [Val Text]
-  , _elasticLoadBalancingV2LoadBalancerSubnets :: Maybe [Val Text]
+  , _elasticLoadBalancingV2LoadBalancerSecurityGroups :: Maybe (ValList Text)
+  , _elasticLoadBalancingV2LoadBalancerSubnets :: Maybe (ValList Text)
   , _elasticLoadBalancingV2LoadBalancerTags :: Maybe [Tag]
   } deriving (Show, Eq)
 
@@ -85,11 +85,11 @@ elbvlbScheme :: Lens' ElasticLoadBalancingV2LoadBalancer (Maybe (Val Text))
 elbvlbScheme = lens _elasticLoadBalancingV2LoadBalancerScheme (\s a -> s { _elasticLoadBalancingV2LoadBalancerScheme = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-securitygroups
-elbvlbSecurityGroups :: Lens' ElasticLoadBalancingV2LoadBalancer (Maybe [Val Text])
+elbvlbSecurityGroups :: Lens' ElasticLoadBalancingV2LoadBalancer (Maybe (ValList Text))
 elbvlbSecurityGroups = lens _elasticLoadBalancingV2LoadBalancerSecurityGroups (\s a -> s { _elasticLoadBalancingV2LoadBalancerSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-subnets
-elbvlbSubnets :: Lens' ElasticLoadBalancingV2LoadBalancer (Maybe [Val Text])
+elbvlbSubnets :: Lens' ElasticLoadBalancingV2LoadBalancer (Maybe (ValList Text))
 elbvlbSubnets = lens _elasticLoadBalancingV2LoadBalancerSubnets (\s a -> s { _elasticLoadBalancingV2LoadBalancerSubnets = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-tags

--- a/library-gen/Stratosphere/Resources/GameLiftFleet.hs
+++ b/library-gen/Stratosphere/Resources/GameLiftFleet.hs
@@ -23,7 +23,7 @@ data GameLiftFleet =
   , _gameLiftFleetDesiredEC2Instances :: Val Integer'
   , _gameLiftFleetEC2InboundPermissions :: Maybe [GameLiftFleetIpPermission]
   , _gameLiftFleetEC2InstanceType :: Val Text
-  , _gameLiftFleetLogPaths :: Maybe [Val Text]
+  , _gameLiftFleetLogPaths :: Maybe (ValList Text)
   , _gameLiftFleetMaxSize :: Maybe (Val Integer')
   , _gameLiftFleetMinSize :: Maybe (Val Integer')
   , _gameLiftFleetName :: Val Text
@@ -108,7 +108,7 @@ glfEC2InstanceType :: Lens' GameLiftFleet (Val Text)
 glfEC2InstanceType = lens _gameLiftFleetEC2InstanceType (\s a -> s { _gameLiftFleetEC2InstanceType = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-fleet.html#cfn-gamelift-fleet-logpaths
-glfLogPaths :: Lens' GameLiftFleet (Maybe [Val Text])
+glfLogPaths :: Lens' GameLiftFleet (Maybe (ValList Text))
 glfLogPaths = lens _gameLiftFleetLogPaths (\s a -> s { _gameLiftFleetLogPaths = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-fleet.html#cfn-gamelift-fleet-maxsize

--- a/library-gen/Stratosphere/Resources/IAMGroup.hs
+++ b/library-gen/Stratosphere/Resources/IAMGroup.hs
@@ -19,7 +19,7 @@ import Stratosphere.ResourceProperties.IAMGroupPolicy
 data IAMGroup =
   IAMGroup
   { _iAMGroupGroupName :: Maybe (Val Text)
-  , _iAMGroupManagedPolicyArns :: Maybe [Val Text]
+  , _iAMGroupManagedPolicyArns :: Maybe (ValList Text)
   , _iAMGroupPath :: Maybe (Val Text)
   , _iAMGroupPolicies :: Maybe [IAMGroupPolicy]
   } deriving (Show, Eq)
@@ -59,7 +59,7 @@ iamgGroupName :: Lens' IAMGroup (Maybe (Val Text))
 iamgGroupName = lens _iAMGroupGroupName (\s a -> s { _iAMGroupGroupName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html#cfn-iam-group-managepolicyarns
-iamgManagedPolicyArns :: Lens' IAMGroup (Maybe [Val Text])
+iamgManagedPolicyArns :: Lens' IAMGroup (Maybe (ValList Text))
 iamgManagedPolicyArns = lens _iAMGroupManagedPolicyArns (\s a -> s { _iAMGroupManagedPolicyArns = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html#cfn-iam-group-path

--- a/library-gen/Stratosphere/Resources/IAMInstanceProfile.hs
+++ b/library-gen/Stratosphere/Resources/IAMInstanceProfile.hs
@@ -20,7 +20,7 @@ data IAMInstanceProfile =
   IAMInstanceProfile
   { _iAMInstanceProfileInstanceProfileName :: Maybe (Val Text)
   , _iAMInstanceProfilePath :: Maybe (Val Text)
-  , _iAMInstanceProfileRoles :: [Val Text]
+  , _iAMInstanceProfileRoles :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON IAMInstanceProfile where
@@ -43,7 +43,7 @@ instance FromJSON IAMInstanceProfile where
 -- | Constructor for 'IAMInstanceProfile' containing required fields as
 -- arguments.
 iamInstanceProfile
-  :: [Val Text] -- ^ 'iamipRoles'
+  :: ValList Text -- ^ 'iamipRoles'
   -> IAMInstanceProfile
 iamInstanceProfile rolesarg =
   IAMInstanceProfile
@@ -61,5 +61,5 @@ iamipPath :: Lens' IAMInstanceProfile (Maybe (Val Text))
 iamipPath = lens _iAMInstanceProfilePath (\s a -> s { _iAMInstanceProfilePath = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html#cfn-iam-instanceprofile-roles
-iamipRoles :: Lens' IAMInstanceProfile [Val Text]
+iamipRoles :: Lens' IAMInstanceProfile (ValList Text)
 iamipRoles = lens _iAMInstanceProfileRoles (\s a -> s { _iAMInstanceProfileRoles = a })

--- a/library-gen/Stratosphere/Resources/IAMManagedPolicy.hs
+++ b/library-gen/Stratosphere/Resources/IAMManagedPolicy.hs
@@ -19,12 +19,12 @@ import Stratosphere.Values
 data IAMManagedPolicy =
   IAMManagedPolicy
   { _iAMManagedPolicyDescription :: Maybe (Val Text)
-  , _iAMManagedPolicyGroups :: Maybe [Val Text]
+  , _iAMManagedPolicyGroups :: Maybe (ValList Text)
   , _iAMManagedPolicyManagedPolicyName :: Maybe (Val Text)
   , _iAMManagedPolicyPath :: Maybe (Val Text)
   , _iAMManagedPolicyPolicyDocument :: Object
-  , _iAMManagedPolicyRoles :: Maybe [Val Text]
-  , _iAMManagedPolicyUsers :: Maybe [Val Text]
+  , _iAMManagedPolicyRoles :: Maybe (ValList Text)
+  , _iAMManagedPolicyUsers :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON IAMManagedPolicy where
@@ -73,7 +73,7 @@ iammpDescription :: Lens' IAMManagedPolicy (Maybe (Val Text))
 iammpDescription = lens _iAMManagedPolicyDescription (\s a -> s { _iAMManagedPolicyDescription = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-groups
-iammpGroups :: Lens' IAMManagedPolicy (Maybe [Val Text])
+iammpGroups :: Lens' IAMManagedPolicy (Maybe (ValList Text))
 iammpGroups = lens _iAMManagedPolicyGroups (\s a -> s { _iAMManagedPolicyGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-managedpolicyname
@@ -89,9 +89,9 @@ iammpPolicyDocument :: Lens' IAMManagedPolicy Object
 iammpPolicyDocument = lens _iAMManagedPolicyPolicyDocument (\s a -> s { _iAMManagedPolicyPolicyDocument = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles
-iammpRoles :: Lens' IAMManagedPolicy (Maybe [Val Text])
+iammpRoles :: Lens' IAMManagedPolicy (Maybe (ValList Text))
 iammpRoles = lens _iAMManagedPolicyRoles (\s a -> s { _iAMManagedPolicyRoles = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-users
-iammpUsers :: Lens' IAMManagedPolicy (Maybe [Val Text])
+iammpUsers :: Lens' IAMManagedPolicy (Maybe (ValList Text))
 iammpUsers = lens _iAMManagedPolicyUsers (\s a -> s { _iAMManagedPolicyUsers = a })

--- a/library-gen/Stratosphere/Resources/IAMPolicy.hs
+++ b/library-gen/Stratosphere/Resources/IAMPolicy.hs
@@ -18,11 +18,11 @@ import Stratosphere.Values
 -- convenient constructor.
 data IAMPolicy =
   IAMPolicy
-  { _iAMPolicyGroups :: Maybe [Val Text]
+  { _iAMPolicyGroups :: Maybe (ValList Text)
   , _iAMPolicyPolicyDocument :: Object
   , _iAMPolicyPolicyName :: Val Text
-  , _iAMPolicyRoles :: Maybe [Val Text]
-  , _iAMPolicyUsers :: Maybe [Val Text]
+  , _iAMPolicyRoles :: Maybe (ValList Text)
+  , _iAMPolicyUsers :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON IAMPolicy where
@@ -61,7 +61,7 @@ iamPolicy policyDocumentarg policyNamearg =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-groups
-iampGroups :: Lens' IAMPolicy (Maybe [Val Text])
+iampGroups :: Lens' IAMPolicy (Maybe (ValList Text))
 iampGroups = lens _iAMPolicyGroups (\s a -> s { _iAMPolicyGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policydocument
@@ -73,9 +73,9 @@ iampPolicyName :: Lens' IAMPolicy (Val Text)
 iampPolicyName = lens _iAMPolicyPolicyName (\s a -> s { _iAMPolicyPolicyName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles
-iampRoles :: Lens' IAMPolicy (Maybe [Val Text])
+iampRoles :: Lens' IAMPolicy (Maybe (ValList Text))
 iampRoles = lens _iAMPolicyRoles (\s a -> s { _iAMPolicyRoles = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-users
-iampUsers :: Lens' IAMPolicy (Maybe [Val Text])
+iampUsers :: Lens' IAMPolicy (Maybe (ValList Text))
 iampUsers = lens _iAMPolicyUsers (\s a -> s { _iAMPolicyUsers = a })

--- a/library-gen/Stratosphere/Resources/IAMRole.hs
+++ b/library-gen/Stratosphere/Resources/IAMRole.hs
@@ -19,7 +19,7 @@ import Stratosphere.ResourceProperties.IAMRolePolicy
 data IAMRole =
   IAMRole
   { _iAMRoleAssumeRolePolicyDocument :: Object
-  , _iAMRoleManagedPolicyArns :: Maybe [Val Text]
+  , _iAMRoleManagedPolicyArns :: Maybe (ValList Text)
   , _iAMRolePath :: Maybe (Val Text)
   , _iAMRolePolicies :: Maybe [IAMRolePolicy]
   , _iAMRoleRoleName :: Maybe (Val Text)
@@ -64,7 +64,7 @@ iamrAssumeRolePolicyDocument :: Lens' IAMRole Object
 iamrAssumeRolePolicyDocument = lens _iAMRoleAssumeRolePolicyDocument (\s a -> s { _iAMRoleAssumeRolePolicyDocument = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-managepolicyarns
-iamrManagedPolicyArns :: Lens' IAMRole (Maybe [Val Text])
+iamrManagedPolicyArns :: Lens' IAMRole (Maybe (ValList Text))
 iamrManagedPolicyArns = lens _iAMRoleManagedPolicyArns (\s a -> s { _iAMRoleManagedPolicyArns = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-path

--- a/library-gen/Stratosphere/Resources/IAMUser.hs
+++ b/library-gen/Stratosphere/Resources/IAMUser.hs
@@ -19,9 +19,9 @@ import Stratosphere.ResourceProperties.IAMUserPolicy
 -- convenient constructor.
 data IAMUser =
   IAMUser
-  { _iAMUserGroups :: Maybe [Val Text]
+  { _iAMUserGroups :: Maybe (ValList Text)
   , _iAMUserLoginProfile :: Maybe IAMUserLoginProfile
-  , _iAMUserManagedPolicyArns :: Maybe [Val Text]
+  , _iAMUserManagedPolicyArns :: Maybe (ValList Text)
   , _iAMUserPath :: Maybe (Val Text)
   , _iAMUserPolicies :: Maybe [IAMUserPolicy]
   , _iAMUserUserName :: Maybe (Val Text)
@@ -64,7 +64,7 @@ iamUser  =
   }
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html#cfn-iam-user-groups
-iamuGroups :: Lens' IAMUser (Maybe [Val Text])
+iamuGroups :: Lens' IAMUser (Maybe (ValList Text))
 iamuGroups = lens _iAMUserGroups (\s a -> s { _iAMUserGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html#cfn-iam-user-loginprofile
@@ -72,7 +72,7 @@ iamuLoginProfile :: Lens' IAMUser (Maybe IAMUserLoginProfile)
 iamuLoginProfile = lens _iAMUserLoginProfile (\s a -> s { _iAMUserLoginProfile = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html#cfn-iam-user-managepolicyarns
-iamuManagedPolicyArns :: Lens' IAMUser (Maybe [Val Text])
+iamuManagedPolicyArns :: Lens' IAMUser (Maybe (ValList Text))
 iamuManagedPolicyArns = lens _iAMUserManagedPolicyArns (\s a -> s { _iAMUserManagedPolicyArns = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html#cfn-iam-user-path

--- a/library-gen/Stratosphere/Resources/IAMUserToGroupAddition.hs
+++ b/library-gen/Stratosphere/Resources/IAMUserToGroupAddition.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data IAMUserToGroupAddition =
   IAMUserToGroupAddition
   { _iAMUserToGroupAdditionGroupName :: Val Text
-  , _iAMUserToGroupAdditionUsers :: [Val Text]
+  , _iAMUserToGroupAdditionUsers :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON IAMUserToGroupAddition where
@@ -41,7 +41,7 @@ instance FromJSON IAMUserToGroupAddition where
 -- arguments.
 iamUserToGroupAddition
   :: Val Text -- ^ 'iamutgaGroupName'
-  -> [Val Text] -- ^ 'iamutgaUsers'
+  -> ValList Text -- ^ 'iamutgaUsers'
   -> IAMUserToGroupAddition
 iamUserToGroupAddition groupNamearg usersarg =
   IAMUserToGroupAddition
@@ -54,5 +54,5 @@ iamutgaGroupName :: Lens' IAMUserToGroupAddition (Val Text)
 iamutgaGroupName = lens _iAMUserToGroupAdditionGroupName (\s a -> s { _iAMUserToGroupAdditionGroupName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html#cfn-iam-addusertogroup-users
-iamutgaUsers :: Lens' IAMUserToGroupAddition [Val Text]
+iamutgaUsers :: Lens' IAMUserToGroupAddition (ValList Text)
 iamutgaUsers = lens _iAMUserToGroupAdditionUsers (\s a -> s { _iAMUserToGroupAdditionUsers = a })

--- a/library-gen/Stratosphere/Resources/OpsWorksApp.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksApp.hs
@@ -25,7 +25,7 @@ data OpsWorksApp =
   , _opsWorksAppAttributes :: Maybe Object
   , _opsWorksAppDataSources :: Maybe [OpsWorksAppDataSource]
   , _opsWorksAppDescription :: Maybe (Val Text)
-  , _opsWorksAppDomains :: Maybe [Val Text]
+  , _opsWorksAppDomains :: Maybe (ValList Text)
   , _opsWorksAppEnableSsl :: Maybe (Val Bool')
   , _opsWorksAppEnvironment :: Maybe [OpsWorksAppEnvironmentVariable]
   , _opsWorksAppName :: Val Text
@@ -109,7 +109,7 @@ owaDescription :: Lens' OpsWorksApp (Maybe (Val Text))
 owaDescription = lens _opsWorksAppDescription (\s a -> s { _opsWorksAppDescription = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-app.html#cfn-opsworks-app-domains
-owaDomains :: Lens' OpsWorksApp (Maybe [Val Text])
+owaDomains :: Lens' OpsWorksApp (Maybe (ValList Text))
 owaDomains = lens _opsWorksAppDomains (\s a -> s { _opsWorksAppDomains = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-app.html#cfn-opsworks-app-enablessl

--- a/library-gen/Stratosphere/Resources/OpsWorksInstance.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksInstance.hs
@@ -26,11 +26,11 @@ data OpsWorksInstance =
   , _opsWorksInstanceAvailabilityZone :: Maybe (Val Text)
   , _opsWorksInstanceBlockDeviceMappings :: Maybe [OpsWorksInstanceBlockDeviceMapping]
   , _opsWorksInstanceEbsOptimized :: Maybe (Val Bool')
-  , _opsWorksInstanceElasticIps :: Maybe [Val Text]
+  , _opsWorksInstanceElasticIps :: Maybe (ValList Text)
   , _opsWorksInstanceHostname :: Maybe (Val Text)
   , _opsWorksInstanceInstallUpdatesOnBoot :: Maybe (Val Bool')
   , _opsWorksInstanceInstanceType :: Val Text
-  , _opsWorksInstanceLayerIds :: [Val Text]
+  , _opsWorksInstanceLayerIds :: ValList Text
   , _opsWorksInstanceOs :: Maybe (Val Text)
   , _opsWorksInstanceRootDeviceType :: Maybe (Val Text)
   , _opsWorksInstanceSshKeyName :: Maybe (Val Text)
@@ -39,7 +39,7 @@ data OpsWorksInstance =
   , _opsWorksInstanceTenancy :: Maybe (Val Text)
   , _opsWorksInstanceTimeBasedAutoScaling :: Maybe OpsWorksInstanceTimeBasedAutoScaling
   , _opsWorksInstanceVirtualizationType :: Maybe (Val Text)
-  , _opsWorksInstanceVolumes :: Maybe [Val Text]
+  , _opsWorksInstanceVolumes :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON OpsWorksInstance where
@@ -99,7 +99,7 @@ instance FromJSON OpsWorksInstance where
 -- arguments.
 opsWorksInstance
   :: Val Text -- ^ 'owiInstanceType'
-  -> [Val Text] -- ^ 'owiLayerIds'
+  -> ValList Text -- ^ 'owiLayerIds'
   -> Val Text -- ^ 'owiStackId'
   -> OpsWorksInstance
 opsWorksInstance instanceTypearg layerIdsarg stackIdarg =
@@ -156,7 +156,7 @@ owiEbsOptimized :: Lens' OpsWorksInstance (Maybe (Val Bool'))
 owiEbsOptimized = lens _opsWorksInstanceEbsOptimized (\s a -> s { _opsWorksInstanceEbsOptimized = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-instance.html#cfn-opsworks-instance-elasticips
-owiElasticIps :: Lens' OpsWorksInstance (Maybe [Val Text])
+owiElasticIps :: Lens' OpsWorksInstance (Maybe (ValList Text))
 owiElasticIps = lens _opsWorksInstanceElasticIps (\s a -> s { _opsWorksInstanceElasticIps = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-instance.html#cfn-opsworks-instance-hostname
@@ -172,7 +172,7 @@ owiInstanceType :: Lens' OpsWorksInstance (Val Text)
 owiInstanceType = lens _opsWorksInstanceInstanceType (\s a -> s { _opsWorksInstanceInstanceType = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-instance.html#cfn-opsworks-instance-layerids
-owiLayerIds :: Lens' OpsWorksInstance [Val Text]
+owiLayerIds :: Lens' OpsWorksInstance (ValList Text)
 owiLayerIds = lens _opsWorksInstanceLayerIds (\s a -> s { _opsWorksInstanceLayerIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-instance.html#cfn-opsworks-instance-os
@@ -208,5 +208,5 @@ owiVirtualizationType :: Lens' OpsWorksInstance (Maybe (Val Text))
 owiVirtualizationType = lens _opsWorksInstanceVirtualizationType (\s a -> s { _opsWorksInstanceVirtualizationType = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-instance.html#cfn-opsworks-instance-volumes
-owiVolumes :: Lens' OpsWorksInstance (Maybe [Val Text])
+owiVolumes :: Lens' OpsWorksInstance (Maybe (ValList Text))
 owiVolumes = lens _opsWorksInstanceVolumes (\s a -> s { _opsWorksInstanceVolumes = a })

--- a/library-gen/Stratosphere/Resources/OpsWorksLayer.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksLayer.hs
@@ -27,13 +27,13 @@ data OpsWorksLayer =
   , _opsWorksLayerCustomInstanceProfileArn :: Maybe (Val Text)
   , _opsWorksLayerCustomJson :: Maybe Object
   , _opsWorksLayerCustomRecipes :: Maybe OpsWorksLayerRecipes
-  , _opsWorksLayerCustomSecurityGroupIds :: Maybe [Val Text]
+  , _opsWorksLayerCustomSecurityGroupIds :: Maybe (ValList Text)
   , _opsWorksLayerEnableAutoHealing :: Val Bool'
   , _opsWorksLayerInstallUpdatesOnBoot :: Maybe (Val Bool')
   , _opsWorksLayerLifecycleEventConfiguration :: Maybe OpsWorksLayerLifecycleEventConfiguration
   , _opsWorksLayerLoadBasedAutoScaling :: Maybe OpsWorksLayerLoadBasedAutoScaling
   , _opsWorksLayerName :: Val Text
-  , _opsWorksLayerPackages :: Maybe [Val Text]
+  , _opsWorksLayerPackages :: Maybe (ValList Text)
   , _opsWorksLayerShortname :: Val Text
   , _opsWorksLayerStackId :: Val Text
   , _opsWorksLayerType :: Val Text
@@ -145,7 +145,7 @@ owlCustomRecipes :: Lens' OpsWorksLayer (Maybe OpsWorksLayerRecipes)
 owlCustomRecipes = lens _opsWorksLayerCustomRecipes (\s a -> s { _opsWorksLayerCustomRecipes = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html#cfn-opsworks-layer-customsecuritygroupids
-owlCustomSecurityGroupIds :: Lens' OpsWorksLayer (Maybe [Val Text])
+owlCustomSecurityGroupIds :: Lens' OpsWorksLayer (Maybe (ValList Text))
 owlCustomSecurityGroupIds = lens _opsWorksLayerCustomSecurityGroupIds (\s a -> s { _opsWorksLayerCustomSecurityGroupIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html#cfn-opsworks-layer-enableautohealing
@@ -169,7 +169,7 @@ owlName :: Lens' OpsWorksLayer (Val Text)
 owlName = lens _opsWorksLayerName (\s a -> s { _opsWorksLayerName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html#cfn-opsworks-layer-packages
-owlPackages :: Lens' OpsWorksLayer (Maybe [Val Text])
+owlPackages :: Lens' OpsWorksLayer (Maybe (ValList Text))
 owlPackages = lens _opsWorksLayerPackages (\s a -> s { _opsWorksLayerPackages = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html#cfn-opsworks-layer-shortname

--- a/library-gen/Stratosphere/Resources/OpsWorksStack.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksStack.hs
@@ -25,7 +25,7 @@ data OpsWorksStack =
   { _opsWorksStackAgentVersion :: Maybe (Val Text)
   , _opsWorksStackAttributes :: Maybe Object
   , _opsWorksStackChefConfiguration :: Maybe OpsWorksStackChefConfiguration
-  , _opsWorksStackCloneAppIds :: Maybe [Val Text]
+  , _opsWorksStackCloneAppIds :: Maybe (ValList Text)
   , _opsWorksStackClonePermissions :: Maybe (Val Bool')
   , _opsWorksStackConfigurationManager :: Maybe OpsWorksStackStackConfigurationManager
   , _opsWorksStackCustomCookbooksSource :: Maybe OpsWorksStackSource
@@ -154,7 +154,7 @@ owsChefConfiguration :: Lens' OpsWorksStack (Maybe OpsWorksStackChefConfiguratio
 owsChefConfiguration = lens _opsWorksStackChefConfiguration (\s a -> s { _opsWorksStackChefConfiguration = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-stack.html#cfn-opsworks-stack-cloneappids
-owsCloneAppIds :: Lens' OpsWorksStack (Maybe [Val Text])
+owsCloneAppIds :: Lens' OpsWorksStack (Maybe (ValList Text))
 owsCloneAppIds = lens _opsWorksStackCloneAppIds (\s a -> s { _opsWorksStackCloneAppIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-stack.html#cfn-opsworks-stack-clonepermissions

--- a/library-gen/Stratosphere/Resources/RDSDBCluster.hs
+++ b/library-gen/Stratosphere/Resources/RDSDBCluster.hs
@@ -35,7 +35,7 @@ data RDSDBCluster =
   , _rDSDBClusterSnapshotIdentifier :: Maybe (Val Text)
   , _rDSDBClusterStorageEncrypted :: Maybe (Val Bool')
   , _rDSDBClusterTags :: Maybe [Tag]
-  , _rDSDBClusterVpcSecurityGroupIds :: Maybe [Val Text]
+  , _rDSDBClusterVpcSecurityGroupIds :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON RDSDBCluster where
@@ -180,5 +180,5 @@ rdsdbcTags :: Lens' RDSDBCluster (Maybe [Tag])
 rdsdbcTags = lens _rDSDBClusterTags (\s a -> s { _rDSDBClusterTags = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-vpcsecuritygroupids
-rdsdbcVpcSecurityGroupIds :: Lens' RDSDBCluster (Maybe [Val Text])
+rdsdbcVpcSecurityGroupIds :: Lens' RDSDBCluster (Maybe (ValList Text))
 rdsdbcVpcSecurityGroupIds = lens _rDSDBClusterVpcSecurityGroupIds (\s a -> s { _rDSDBClusterVpcSecurityGroupIds = a })

--- a/library-gen/Stratosphere/Resources/RDSDBInstance.hs
+++ b/library-gen/Stratosphere/Resources/RDSDBInstance.hs
@@ -30,7 +30,7 @@ data RDSDBInstance =
   , _rDSDBInstanceDBInstanceIdentifier :: Maybe (Val Text)
   , _rDSDBInstanceDBName :: Maybe (Val Text)
   , _rDSDBInstanceDBParameterGroupName :: Maybe (Val Text)
-  , _rDSDBInstanceDBSecurityGroups :: Maybe [Val Text]
+  , _rDSDBInstanceDBSecurityGroups :: Maybe (ValList Text)
   , _rDSDBInstanceDBSnapshotIdentifier :: Maybe (Val Text)
   , _rDSDBInstanceDBSubnetGroupName :: Maybe (Val Text)
   , _rDSDBInstanceDomain :: Maybe (Val Text)
@@ -55,7 +55,7 @@ data RDSDBInstance =
   , _rDSDBInstanceStorageType :: Maybe (Val Text)
   , _rDSDBInstanceTags :: Maybe [Tag]
   , _rDSDBInstanceTimezone :: Maybe (Val Text)
-  , _rDSDBInstanceVPCSecurityGroups :: Maybe [Val Text]
+  , _rDSDBInstanceVPCSecurityGroups :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON RDSDBInstance where
@@ -240,7 +240,7 @@ rdsdbiDBParameterGroupName :: Lens' RDSDBInstance (Maybe (Val Text))
 rdsdbiDBParameterGroupName = lens _rDSDBInstanceDBParameterGroupName (\s a -> s { _rDSDBInstanceDBParameterGroupName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-dbsecuritygroups
-rdsdbiDBSecurityGroups :: Lens' RDSDBInstance (Maybe [Val Text])
+rdsdbiDBSecurityGroups :: Lens' RDSDBInstance (Maybe (ValList Text))
 rdsdbiDBSecurityGroups = lens _rDSDBInstanceDBSecurityGroups (\s a -> s { _rDSDBInstanceDBSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-dbsnapshotidentifier
@@ -340,5 +340,5 @@ rdsdbiTimezone :: Lens' RDSDBInstance (Maybe (Val Text))
 rdsdbiTimezone = lens _rDSDBInstanceTimezone (\s a -> s { _rDSDBInstanceTimezone = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-vpcsecuritygroups
-rdsdbiVPCSecurityGroups :: Lens' RDSDBInstance (Maybe [Val Text])
+rdsdbiVPCSecurityGroups :: Lens' RDSDBInstance (Maybe (ValList Text))
 rdsdbiVPCSecurityGroups = lens _rDSDBInstanceVPCSecurityGroups (\s a -> s { _rDSDBInstanceVPCSecurityGroups = a })

--- a/library-gen/Stratosphere/Resources/RDSDBSubnetGroup.hs
+++ b/library-gen/Stratosphere/Resources/RDSDBSubnetGroup.hs
@@ -19,7 +19,7 @@ import Stratosphere.ResourceProperties.Tag
 data RDSDBSubnetGroup =
   RDSDBSubnetGroup
   { _rDSDBSubnetGroupDBSubnetGroupDescription :: Val Text
-  , _rDSDBSubnetGroupSubnetIds :: [Val Text]
+  , _rDSDBSubnetGroupSubnetIds :: ValList Text
   , _rDSDBSubnetGroupTags :: Maybe [Tag]
   } deriving (Show, Eq)
 
@@ -44,7 +44,7 @@ instance FromJSON RDSDBSubnetGroup where
 -- arguments.
 rdsdbSubnetGroup
   :: Val Text -- ^ 'rdsdbsugDBSubnetGroupDescription'
-  -> [Val Text] -- ^ 'rdsdbsugSubnetIds'
+  -> ValList Text -- ^ 'rdsdbsugSubnetIds'
   -> RDSDBSubnetGroup
 rdsdbSubnetGroup dBSubnetGroupDescriptionarg subnetIdsarg =
   RDSDBSubnetGroup
@@ -58,7 +58,7 @@ rdsdbsugDBSubnetGroupDescription :: Lens' RDSDBSubnetGroup (Val Text)
 rdsdbsugDBSubnetGroupDescription = lens _rDSDBSubnetGroupDBSubnetGroupDescription (\s a -> s { _rDSDBSubnetGroupDBSubnetGroupDescription = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsubnet-group.html#cfn-rds-dbsubnetgroup-subnetids
-rdsdbsugSubnetIds :: Lens' RDSDBSubnetGroup [Val Text]
+rdsdbsugSubnetIds :: Lens' RDSDBSubnetGroup (ValList Text)
 rdsdbsugSubnetIds = lens _rDSDBSubnetGroupSubnetIds (\s a -> s { _rDSDBSubnetGroupSubnetIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsubnet-group.html#cfn-rds-dbsubnetgroup-tags

--- a/library-gen/Stratosphere/Resources/RDSEventSubscription.hs
+++ b/library-gen/Stratosphere/Resources/RDSEventSubscription.hs
@@ -19,9 +19,9 @@ import Stratosphere.Values
 data RDSEventSubscription =
   RDSEventSubscription
   { _rDSEventSubscriptionEnabled :: Maybe (Val Bool')
-  , _rDSEventSubscriptionEventCategories :: Maybe [Val Text]
+  , _rDSEventSubscriptionEventCategories :: Maybe (ValList Text)
   , _rDSEventSubscriptionSnsTopicArn :: Val Text
-  , _rDSEventSubscriptionSourceIds :: Maybe [Val Text]
+  , _rDSEventSubscriptionSourceIds :: Maybe (ValList Text)
   , _rDSEventSubscriptionSourceType :: Maybe (Val Text)
   } deriving (Show, Eq)
 
@@ -65,7 +65,7 @@ rdsesEnabled :: Lens' RDSEventSubscription (Maybe (Val Bool'))
 rdsesEnabled = lens _rDSEventSubscriptionEnabled (\s a -> s { _rDSEventSubscriptionEnabled = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-eventsubscription.html#cfn-rds-eventsubscription-eventcategories
-rdsesEventCategories :: Lens' RDSEventSubscription (Maybe [Val Text])
+rdsesEventCategories :: Lens' RDSEventSubscription (Maybe (ValList Text))
 rdsesEventCategories = lens _rDSEventSubscriptionEventCategories (\s a -> s { _rDSEventSubscriptionEventCategories = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-eventsubscription.html#cfn-rds-eventsubscription-snstopicarn
@@ -73,7 +73,7 @@ rdsesSnsTopicArn :: Lens' RDSEventSubscription (Val Text)
 rdsesSnsTopicArn = lens _rDSEventSubscriptionSnsTopicArn (\s a -> s { _rDSEventSubscriptionSnsTopicArn = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-eventsubscription.html#cfn-rds-eventsubscription-sourceids
-rdsesSourceIds :: Lens' RDSEventSubscription (Maybe [Val Text])
+rdsesSourceIds :: Lens' RDSEventSubscription (Maybe (ValList Text))
 rdsesSourceIds = lens _rDSEventSubscriptionSourceIds (\s a -> s { _rDSEventSubscriptionSourceIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-eventsubscription.html#cfn-rds-eventsubscription-sourcetype

--- a/library-gen/Stratosphere/Resources/RedshiftCluster.hs
+++ b/library-gen/Stratosphere/Resources/RedshiftCluster.hs
@@ -23,7 +23,7 @@ data RedshiftCluster =
   , _redshiftClusterAutomatedSnapshotRetentionPeriod :: Maybe (Val Integer')
   , _redshiftClusterAvailabilityZone :: Maybe (Val Text)
   , _redshiftClusterClusterParameterGroupName :: Maybe (Val Text)
-  , _redshiftClusterClusterSecurityGroups :: Maybe [Val Text]
+  , _redshiftClusterClusterSecurityGroups :: Maybe (ValList Text)
   , _redshiftClusterClusterSubnetGroupName :: Maybe (Val Text)
   , _redshiftClusterClusterType :: Val Text
   , _redshiftClusterClusterVersion :: Maybe (Val Text)
@@ -32,7 +32,7 @@ data RedshiftCluster =
   , _redshiftClusterEncrypted :: Maybe (Val Bool')
   , _redshiftClusterHsmClientCertificateIdentifier :: Maybe (Val Text)
   , _redshiftClusterHsmConfigurationIdentifier :: Maybe (Val Text)
-  , _redshiftClusterIamRoles :: Maybe [Val Text]
+  , _redshiftClusterIamRoles :: Maybe (ValList Text)
   , _redshiftClusterKmsKeyId :: Maybe (Val Text)
   , _redshiftClusterLoggingProperties :: Maybe RedshiftClusterLoggingProperties
   , _redshiftClusterMasterUserPassword :: Val Text
@@ -46,7 +46,7 @@ data RedshiftCluster =
   , _redshiftClusterSnapshotClusterIdentifier :: Maybe (Val Text)
   , _redshiftClusterSnapshotIdentifier :: Maybe (Val Text)
   , _redshiftClusterTags :: Maybe [Tag]
-  , _redshiftClusterVpcSecurityGroupIds :: Maybe [Val Text]
+  , _redshiftClusterVpcSecurityGroupIds :: Maybe (ValList Text)
   } deriving (Show, Eq)
 
 instance ToJSON RedshiftCluster where
@@ -174,7 +174,7 @@ rcClusterParameterGroupName :: Lens' RedshiftCluster (Maybe (Val Text))
 rcClusterParameterGroupName = lens _redshiftClusterClusterParameterGroupName (\s a -> s { _redshiftClusterClusterParameterGroupName = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html#cfn-redshift-cluster-clustersecuritygroups
-rcClusterSecurityGroups :: Lens' RedshiftCluster (Maybe [Val Text])
+rcClusterSecurityGroups :: Lens' RedshiftCluster (Maybe (ValList Text))
 rcClusterSecurityGroups = lens _redshiftClusterClusterSecurityGroups (\s a -> s { _redshiftClusterClusterSecurityGroups = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html#cfn-redshift-cluster-clustersubnetgroupname
@@ -210,7 +210,7 @@ rcHsmConfigurationIdentifier :: Lens' RedshiftCluster (Maybe (Val Text))
 rcHsmConfigurationIdentifier = lens _redshiftClusterHsmConfigurationIdentifier (\s a -> s { _redshiftClusterHsmConfigurationIdentifier = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html#cfn-redshift-cluster-iamroles
-rcIamRoles :: Lens' RedshiftCluster (Maybe [Val Text])
+rcIamRoles :: Lens' RedshiftCluster (Maybe (ValList Text))
 rcIamRoles = lens _redshiftClusterIamRoles (\s a -> s { _redshiftClusterIamRoles = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html#cfn-redshift-cluster-kmskeyid
@@ -266,5 +266,5 @@ rcTags :: Lens' RedshiftCluster (Maybe [Tag])
 rcTags = lens _redshiftClusterTags (\s a -> s { _redshiftClusterTags = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html#cfn-redshift-cluster-vpcsecuritygroupids
-rcVpcSecurityGroupIds :: Lens' RedshiftCluster (Maybe [Val Text])
+rcVpcSecurityGroupIds :: Lens' RedshiftCluster (Maybe (ValList Text))
 rcVpcSecurityGroupIds = lens _redshiftClusterVpcSecurityGroupIds (\s a -> s { _redshiftClusterVpcSecurityGroupIds = a })

--- a/library-gen/Stratosphere/Resources/RedshiftClusterSubnetGroup.hs
+++ b/library-gen/Stratosphere/Resources/RedshiftClusterSubnetGroup.hs
@@ -19,7 +19,7 @@ import Stratosphere.ResourceProperties.Tag
 data RedshiftClusterSubnetGroup =
   RedshiftClusterSubnetGroup
   { _redshiftClusterSubnetGroupDescription :: Val Text
-  , _redshiftClusterSubnetGroupSubnetIds :: [Val Text]
+  , _redshiftClusterSubnetGroupSubnetIds :: ValList Text
   , _redshiftClusterSubnetGroupTags :: Maybe [Tag]
   } deriving (Show, Eq)
 
@@ -44,7 +44,7 @@ instance FromJSON RedshiftClusterSubnetGroup where
 -- as arguments.
 redshiftClusterSubnetGroup
   :: Val Text -- ^ 'rcsugDescription'
-  -> [Val Text] -- ^ 'rcsugSubnetIds'
+  -> ValList Text -- ^ 'rcsugSubnetIds'
   -> RedshiftClusterSubnetGroup
 redshiftClusterSubnetGroup descriptionarg subnetIdsarg =
   RedshiftClusterSubnetGroup
@@ -58,7 +58,7 @@ rcsugDescription :: Lens' RedshiftClusterSubnetGroup (Val Text)
 rcsugDescription = lens _redshiftClusterSubnetGroupDescription (\s a -> s { _redshiftClusterSubnetGroupDescription = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersubnetgroup.html#cfn-redshift-clustersubnetgroup-subnetids
-rcsugSubnetIds :: Lens' RedshiftClusterSubnetGroup [Val Text]
+rcsugSubnetIds :: Lens' RedshiftClusterSubnetGroup (ValList Text)
 rcsugSubnetIds = lens _redshiftClusterSubnetGroupSubnetIds (\s a -> s { _redshiftClusterSubnetGroupSubnetIds = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersubnetgroup.html#cfn-redshift-clustersubnetgroup-tags

--- a/library-gen/Stratosphere/Resources/Route53RecordSet.hs
+++ b/library-gen/Stratosphere/Resources/Route53RecordSet.hs
@@ -28,7 +28,7 @@ data Route53RecordSet =
   , _route53RecordSetHostedZoneName :: Maybe (Val Text)
   , _route53RecordSetName :: Val Text
   , _route53RecordSetRegion :: Maybe (Val Text)
-  , _route53RecordSetResourceRecords :: Maybe [Val Text]
+  , _route53RecordSetResourceRecords :: Maybe (ValList Text)
   , _route53RecordSetSetIdentifier :: Maybe (Val Text)
   , _route53RecordSetTTL :: Maybe (Val Text)
   , _route53RecordSetType :: Val Text
@@ -135,7 +135,7 @@ rrsRegion :: Lens' Route53RecordSet (Maybe (Val Text))
 rrsRegion = lens _route53RecordSetRegion (\s a -> s { _route53RecordSetRegion = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-resourcerecords
-rrsResourceRecords :: Lens' Route53RecordSet (Maybe [Val Text])
+rrsResourceRecords :: Lens' Route53RecordSet (Maybe (ValList Text))
 rrsResourceRecords = lens _route53RecordSetResourceRecords (\s a -> s { _route53RecordSetResourceRecords = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-setidentifier

--- a/library-gen/Stratosphere/Resources/SNSTopicPolicy.hs
+++ b/library-gen/Stratosphere/Resources/SNSTopicPolicy.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data SNSTopicPolicy =
   SNSTopicPolicy
   { _sNSTopicPolicyPolicyDocument :: Object
-  , _sNSTopicPolicyTopics :: [Val Text]
+  , _sNSTopicPolicyTopics :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON SNSTopicPolicy where
@@ -40,7 +40,7 @@ instance FromJSON SNSTopicPolicy where
 -- | Constructor for 'SNSTopicPolicy' containing required fields as arguments.
 snsTopicPolicy
   :: Object -- ^ 'snstpPolicyDocument'
-  -> [Val Text] -- ^ 'snstpTopics'
+  -> ValList Text -- ^ 'snstpTopics'
   -> SNSTopicPolicy
 snsTopicPolicy policyDocumentarg topicsarg =
   SNSTopicPolicy
@@ -53,5 +53,5 @@ snstpPolicyDocument :: Lens' SNSTopicPolicy Object
 snstpPolicyDocument = lens _sNSTopicPolicyPolicyDocument (\s a -> s { _sNSTopicPolicyPolicyDocument = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-policy.html#cfn-sns-topicpolicy-topics
-snstpTopics :: Lens' SNSTopicPolicy [Val Text]
+snstpTopics :: Lens' SNSTopicPolicy (ValList Text)
 snstpTopics = lens _sNSTopicPolicyTopics (\s a -> s { _sNSTopicPolicyTopics = a })

--- a/library-gen/Stratosphere/Resources/SQSQueuePolicy.hs
+++ b/library-gen/Stratosphere/Resources/SQSQueuePolicy.hs
@@ -19,7 +19,7 @@ import Stratosphere.Values
 data SQSQueuePolicy =
   SQSQueuePolicy
   { _sQSQueuePolicyPolicyDocument :: Object
-  , _sQSQueuePolicyQueues :: [Val Text]
+  , _sQSQueuePolicyQueues :: ValList Text
   } deriving (Show, Eq)
 
 instance ToJSON SQSQueuePolicy where
@@ -40,7 +40,7 @@ instance FromJSON SQSQueuePolicy where
 -- | Constructor for 'SQSQueuePolicy' containing required fields as arguments.
 sqsQueuePolicy
   :: Object -- ^ 'sqsqpPolicyDocument'
-  -> [Val Text] -- ^ 'sqsqpQueues'
+  -> ValList Text -- ^ 'sqsqpQueues'
   -> SQSQueuePolicy
 sqsQueuePolicy policyDocumentarg queuesarg =
   SQSQueuePolicy
@@ -53,5 +53,5 @@ sqsqpPolicyDocument :: Lens' SQSQueuePolicy Object
 sqsqpPolicyDocument = lens _sQSQueuePolicyPolicyDocument (\s a -> s { _sQSQueuePolicyPolicyDocument = a })
 
 -- | http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-policy.html#cfn-sqs-queuepolicy-queues
-sqsqpQueues :: Lens' SQSQueuePolicy [Val Text]
+sqsqpQueues :: Lens' SQSQueuePolicy (ValList Text)
 sqsqpQueues = lens _sQSQueuePolicyQueues (\s a -> s { _sQSQueuePolicyQueues = a })

--- a/library/Stratosphere/Values.hs
+++ b/library/Stratosphere/Values.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Stratosphere.Values
   ( Val (..)
@@ -18,7 +19,7 @@ import qualified Data.HashMap.Strict as HM
 import Data.String (IsString (..))
 import Data.Text (Text)
 import Text.Read (readMaybe)
-import GHC.Exts (fromList)
+import GHC.Exts (IsList(..))
 
 -- GADTs are cool, but I couldn't get this to work with FromJSON
 -- data Val a where
@@ -109,6 +110,15 @@ data ValList a
   = ValList [Val a]
   | RefList Text
   deriving (Show, Eq)
+
+instance IsList (ValList a) where
+  type Item (ValList a) = Val a
+  fromList = ValList
+
+  toList (ValList xs) = xs
+  -- This is obviously not meaningful, but the IsList instance is so useful
+  -- that I decided to allow it.
+  toList (RefList _) = []
 
 instance (ToJSON a) => ToJSON (ValList a) where
   toJSON (ValList vals) = toJSON vals

--- a/library/Stratosphere/Values.hs
+++ b/library/Stratosphere/Values.hs
@@ -5,25 +5,26 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Stratosphere.Values
-       ( Val (..)
-       , Integer' (..)
-       , Bool' (..)
-       , Double' (..)
-       , ToRef (..)
-       ) where
+  ( Val (..)
+  , ValList (..)
+  , Integer' (..)
+  , Bool' (..)
+  , Double' (..)
+  , ToRef (..)
+  ) where
 
 import Data.Aeson
 import qualified Data.HashMap.Strict as HM
 import Data.String (IsString (..))
-import qualified Data.Text as T
+import Data.Text (Text)
 import Text.Read (readMaybe)
 import GHC.Exts (fromList)
 
 -- GADTs are cool, but I couldn't get this to work with FromJSON
 -- data Val a where
 --   Literal :: a -> Val a
---   Ref :: T.Text -> Val a
---   If :: T.Text -> Val a -> Val a -> Val a
+--   Ref :: Text -> Val a
+--   If :: Text -> Val a -> Val a -> Val a
 --   And :: Val Bool -> Val Bool -> Val Bool
 --   Equals :: (Show a, ToJSON a) => Val a -> Val a -> Val Bool
 --   Or :: Val Bool -> Val Bool -> Val Bool
@@ -33,19 +34,19 @@ import GHC.Exts (fromList)
 -- http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
 data Val a
  = Literal a
- | Ref T.Text
- | If T.Text (Val a) (Val a)
+ | Ref Text
+ | If Text (Val a) (Val a)
  | And (Val Bool') (Val Bool')
  | Equals (Val Bool') (Val Bool')
  | Or (Val Bool') (Val Bool')
- | GetAtt T.Text T.Text
+ | GetAtt Text Text
  | Base64 (Val a)
- | Join T.Text [Val a]
- | Split T.Text T.Text
+ | Join Text [Val a]
+ | Split Text Text
  | Select Integer' (Val a)
  | GetAZs (Val a)
  | FindInMap (Val a) (Val a) (Val a) -- ^ Map name, top level key, and second level key
- | ImportValue T.Text -- ^ The account-and-region-unique exported name of the value to import
+ | ImportValue Text -- ^ The account-and-region-unique exported name of the value to import
 
 deriving instance (Show a) => Show (Val a)
 deriving instance (Eq a) => Eq (Val a)
@@ -55,7 +56,7 @@ instance (IsString a) => IsString (Val a) where
 
 instance (ToJSON a) => ToJSON (Val a) where
   toJSON (Literal v) = toJSON v
-  toJSON (Ref r) = object [("Ref", toJSON r)]
+  toJSON (Ref r) = refToJSON r
   toJSON (If i x y) = mkFunc "Fn::If" [toJSON i, toJSON x, toJSON y]
   toJSON (And x y) = mkFunc "Fn::And" [toJSON x, toJSON y]
   toJSON (Equals x y) = mkFunc "Fn::Equals" [toJSON x, toJSON y]
@@ -70,7 +71,10 @@ instance (ToJSON a) => ToJSON (Val a) where
     object [("Fn::FindInMap", toJSON [toJSON mapName, toJSON topKey, toJSON secondKey])]
   toJSON (ImportValue t) = object [("Fn::ImportValue", toJSON t)]
 
-mkFunc :: T.Text -> [Value] -> Value
+refToJSON :: Text -> Value
+refToJSON ref = object [("Ref", toJSON ref)]
+
+mkFunc :: Text -> [Value] -> Value
 mkFunc name args = object [(name, Array $ fromList args)]
 
 instance (FromJSON a) => FromJSON (Val a) where
@@ -96,6 +100,27 @@ instance (FromJSON a) => FromJSON (Val a) where
       os -> Literal <$> parseJSON (object os)
   parseJSON v = Literal <$> parseJSON v
 
+-- | There are two ways to construct a list of 'Val's. One is to use a literal
+-- 'ValList' to construct the list. The other is to reference something that is
+-- already a list. For example, if you have a parameter called @SubnetIds@ of
+-- type @List<AWS::EC2::Subnet::Id>@ then, you can use @RefList "SubnetIds"@ to
+-- reference it.
+data ValList a
+  = ValList [Val a]
+  | RefList Text
+  deriving (Show, Eq)
+
+instance (ToJSON a) => ToJSON (ValList a) where
+  toJSON (ValList vals) = toJSON vals
+  toJSON (RefList ref) = refToJSON ref
+
+instance (FromJSON a) => FromJSON (ValList a) where
+  parseJSON a@(Array _) = ValList <$> parseJSON a
+  parseJSON (Object o) =
+    case HM.toList o of
+      [("Ref", o')] -> RefList <$> parseJSON o'
+      _ -> fail "Could not parse object into RefList"
+  parseJSON _ = fail "Expected Array or Object for ValList in parseJSON"
 
 -- | We need to wrap integers so we can override the Aeson type-classes. This
 -- is necessary because CloudFront made the silly decision to represent numbers

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stratosphere
-version: "0.5.1"
+version: "0.6.0"
 synopsis: EDSL for AWS CloudFormation
 description: EDSL for AWS CloudFormation
 category: AWS, Cloud


### PR DESCRIPTION
From the changelog entry:

> Added `ValList` type. This new type allows you to reference parameters that are already list types. Previously you had to use some kludgy workarounds. For example, you can now `Ref` a parameter of type `List<AWS::EC2::AvailabilityZone::Name>`.

> Every type that used to be `[Val a]` is now `ValList a`. If you use the `OverloadedLists` pragma, you might not have to change any of your code. Otherwise, you must wrap existing lists in the `ValList` constructor.