### PR TITLE
Have main lib and generator share a stack.yaml

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 
 set -ex;
 
-(cd gen/ && stack build && stack exec stratosphere-gen)
+(cd gen/ && stack build . && stack exec stratosphere-gen)
 stack build "$@"

--- a/circle.yml
+++ b/circle.yml
@@ -14,15 +14,15 @@ dependencies:
     - "~/stratosphere/.stack-work"
   override:
     - stack setup --resolver $GHC_8_0_RESOLVER
-    - stack build --resolver $GHC_8_0_RESOLVER --test --only-dependencies --no-run-tests --jobs=1
+    - stack build --resolver $GHC_8_0_RESOLVER stratosphere --test --only-dependencies --no-run-tests --jobs=1
 
     - stack setup
-    - stack build --test --only-dependencies --no-run-tests --jobs=1
+    - stack build stratosphere --test --only-dependencies --no-run-tests --jobs=1
 
 test:
   override:
-    - stack --resolver $GHC_8_0_RESOLVER build --test --jobs=1 --flag stratosphere:-library-only
-    - stack --resolver $GHC_8_0_RESOLVER haddock --no-haddock-deps --jobs=1 --flag stratosphere:-library-only
+    - stack build --resolver $GHC_8_0_RESOLVER stratosphere --test --jobs=1 --flag stratosphere:-library-only
+    - stack haddock --resolver $GHC_8_0_RESOLVER stratosphere --no-haddock-deps --jobs=1 --flag stratosphere:-library-only
 
-    - stack build --test --jobs=1 --flag stratosphere:-library-only
-    - stack haddock --no-haddock-deps --jobs=1 --flag stratosphere:-library-only
+    - stack build stratosphere --test --jobs=1 --flag stratosphere:-library-only
+    - stack haddock stratosphere --no-haddock-deps --jobs=1 --flag stratosphere:-library-only

--- a/gen/package.yaml
+++ b/gen/package.yaml
@@ -3,9 +3,6 @@ version: "0.1.0"
 synopsis: stratosphere code generation
 maintainer: David Reaver
 
-extra-source-files:
-  - stack.yaml
-
 default-extensions:
   - DeriveGeneric
   - ExistentialQuantification

--- a/gen/src/Main.hs
+++ b/gen/src/Main.hs
@@ -1,11 +1,11 @@
 module Main where
 
+import Control.Monad (when)
 import Data.Aeson
 import Data.List (nub)
 import Data.Monoid ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import Extra (whenM)
 import qualified Filesystem as FS
 import Filesystem.Path.CurrentOS ((</>))
 import qualified Filesystem.Path.CurrentOS as FP
@@ -22,7 +22,8 @@ main = do
     rawSpec = either error id specEither
     spec = specFromRaw rawSpec
 
-  whenM (FS.isDirectory (".." FP.</> "library-gen")) $
+  genExists <- FS.isDirectory (".." FP.</> "library-gen")
+  when genExists $
     FS.removeTree (".." FP.</> "library-gen")
   FS.createDirectory True (".." FP.</> "library-gen")
   FS.createDirectory True (".." FP.</> "library-gen" FP.</> "Stratosphere")

--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -1,4 +1,0 @@
-resolver: nightly-2017-10-11
-packages:
-  - '.'
-extra-deps: []

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,6 @@ github: frontrowed/stratosphere
 extra-source-files:
   - CHANGELOG.md
   - README.md
-  - stack.yaml
 
 dependencies:
   - base >= 4.8 && < 5

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,4 @@
 resolver: nightly-2017-12-16
 packages:
   - '.'
+  - 'gen'


### PR DESCRIPTION
I don't know why they ever didn't share a `stack.yaml`. Maybe I was just being silly when I first made this library.