### PR TITLE
Use more consistent non-generated lens names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
-## 0.15.3
+## 0.16.0
 
+* **BREAKING CHANGE**: Renamed lenses for non-generated code to match naming
+  conventions of generated code.
 * Update resource specification document to 1.14.0
 
 ## 0.15.2

--- a/examples/apigw-lambda-dynamodb.hs
+++ b/examples/apigw-lambda-dynamodb.hs
@@ -32,8 +32,8 @@ myTemplate = template
   , postMethod
   , apiGWDeployment
   ]
-  & description ?~ "Simple restful API gateway attached to a Lambda that reads from and writes the request body to a DynamoDB table"
-  & formatVersion ?~ "2010-09-09"
+  & templateDescription ?~ "Simple restful API gateway attached to a Lambda that reads from and writes the request body to a DynamoDB table"
+  & templateFormatVersion ?~ "2010-09-09"
 
 apiGWRestApi :: Resource
 apiGWRestApi =
@@ -65,7 +65,7 @@ getMethod = (
     & agmeIntegration ?~ integration
     & agmeMethodResponses ?~ [ methodResponse ]
   )
-  & dependsOn ?~ deps [readLambdaPermission]
+  & resourceDependsOn ?~ deps [readLambdaPermission]
 
   where
     integration =
@@ -104,7 +104,7 @@ postMethod = (
     & agmeIntegration ?~ integration
     & agmeMethodResponses ?~ [ methodResponse ]
   )
-  & dependsOn ?~ deps [writeLambdaPermission]
+  & resourceDependsOn ?~ deps [writeLambdaPermission]
 
   where
     integration =
@@ -137,7 +137,7 @@ apiGWDeployment = (resource "ApiGWDeployment" $
     (toRef apiGWRestApi)
     & agdStageName ?~ "v1"
   )
-  & dependsOn ?~ deps [
+  & resourceDependsOn ?~ deps [
       apiGWResource
     , getMethod
     , postMethod
@@ -351,4 +351,4 @@ dynamoDbTable = resource "Table" $
       (Literal 1)
 
 deps :: [Resource] -> [Text]
-deps = map (^. resName)
+deps = map (^. resourceName)

--- a/examples/auto-scaling-group.hs
+++ b/examples/auto-scaling-group.hs
@@ -18,15 +18,15 @@ myTemplate :: Template
 myTemplate =
   template
   [ asgResource
-    & resCreationPolicy ?~ asgCreationPolicy
-    & resUpdatePolicy ?~ asgUpdatePolicy
+    & resourceCreationPolicy ?~ asgCreationPolicy
+    & resourceUpdatePolicy ?~ asgUpdatePolicy
   , launchConfigResource
   ]
-  & parameters ?~
+  & templateParameters ?~
   [ parameter "AvailabilityZones" "List<AWS::EC2::AvailabilityZone::Name>"
   ]
-  & description ?~ "Auto scaling group example"
-  & formatVersion ?~ "2010-09-09"
+  & templateDescription ?~ "Auto scaling group example"
+  & templateFormatVersion ?~ "2010-09-09"
 
 asgResource :: Resource
 asgResource =

--- a/examples/ec2-with-eip.hs
+++ b/examples/ec2-with-eip.hs
@@ -28,7 +28,7 @@ myTemplate =
       & eciUserData ?~ Base64 (Join "" ["IPAddress=", toRef sshParam])
       & eciSecurityGroups ?~ [Ref "InstanceSecuritygroup"]
       )
-    & deletionPolicy ?~ Retain
+    & resourceDeletionPolicy ?~ Retain
   , resource "InstanceSecurityGroup" $
     EC2SecurityGroupProperties $
     ec2SecurityGroup
@@ -47,43 +47,43 @@ myTemplate =
     & eceipaInstanceId ?~ Ref "EC2Instance"
     & eceipaEIP ?~ Ref "IPAddress"
   ]
-  & description ?~ "See https://s3.amazonaws.com/cloudformation-templates-us-east-1/EIP_With_Association.template"
-  & formatVersion ?~ "2010-09-09"
-  & parameters ?~
+  & templateDescription ?~ "See https://s3.amazonaws.com/cloudformation-templates-us-east-1/EIP_With_Association.template"
+  & templateFormatVersion ?~ "2010-09-09"
+  & templateParameters ?~
   [ instanceTypeParam
   , keyParam
   , sshParam
   ]
-  & outputs ?~
+  & templateOutputs ?~
   [ output "InstanceId"
     (Ref "EC2Instance")
-    & description ?~ "InstanceId of the newly created EC2 instance"
+    & outputDescription ?~ "InstanceId of the newly created EC2 instance"
   , output "InstanceIPAddress"
     (Ref "IPAddress")
-    & description ?~ "IP address of the newly created EC2 instance"
+    & outputDescription ?~ "IP address of the newly created EC2 instance"
   ]
 
 instanceTypeParam :: Parameter
 instanceTypeParam =
   parameter "InstanceType" "String"
-  & description ?~ "WebServer EC2 instance type"
-  & default' ?~ "t2.small"
-  & allowedValues ?~ [ "t1.micro", "t2.small" ]
-  & constraintDescription ?~ "must be a valid EC2 instance type."
+  & parameterDescription ?~ "WebServer EC2 instance type"
+  & parameterDefault' ?~ "t2.small"
+  & parameterAllowedValues ?~ [ "t1.micro", "t2.small" ]
+  & parameterConstraintDescription ?~ "must be a valid EC2 instance type."
 
 keyParam :: Parameter
 keyParam =
   parameter "KeyName" "AWS::EC2::KeyPair::KeyName"
-  & description ?~ "Name of an existing EC2 KeyPair to enable SSH access to the instances"
-  & constraintDescription ?~ "must be the name of an existing EC2 KeyPair."
+  & parameterDescription ?~ "Name of an existing EC2 KeyPair to enable SSH access to the instances"
+  & parameterConstraintDescription ?~ "must be the name of an existing EC2 KeyPair."
 
 sshParam :: Parameter
 sshParam =
   parameter "SSHLocation" "String"
-  & description ?~ "The IP address range that can be used to SSH to the EC2 instances"
-  & minLength ?~ 9
-  & maxLength ?~ 18
-  & default' ?~ "0.0.0.0/0"
-  & allowedValues ?~ [ "t1.micro", "t2.small" ]
-  & allowedPattern ?~ "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
-  & constraintDescription ?~ "must be a valid IP CIDR range of the form x.x.x.x/x."
+  & parameterDescription ?~ "The IP address range that can be used to SSH to the EC2 instances"
+  & parameterMinLength ?~ 9
+  & parameterMaxLength ?~ 18
+  & parameterDefault' ?~ "0.0.0.0/0"
+  & parameterAllowedValues ?~ [ "t1.micro", "t2.small" ]
+  & parameterAllowedPattern ?~ "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
+  & parameterConstraintDescription ?~ "must be a valid IP CIDR range of the form x.x.x.x/x."

--- a/examples/rds-master-replica.hs
+++ b/examples/rds-master-replica.hs
@@ -18,12 +18,12 @@ main = B.putStrLn $ encodeTemplate dbTemplate
 dbTemplate :: Template
 dbTemplate =
   template
-  [ rdsParamGroup & deletionPolicy ?~ Retain
-  , rdsMaster & deletionPolicy ?~ Retain
-  , rdsReplica & deletionPolicy ?~ Retain
+  [ rdsParamGroup & resourceDeletionPolicy ?~ Retain
+  , rdsMaster & resourceDeletionPolicy ?~ Retain
+  , rdsReplica & resourceDeletionPolicy ?~ Retain
   ]
-  & description ?~ "Stack for and RDS master and replica"
-  & parameters ?~
+  & templateDescription ?~ "Stack for and RDS master and replica"
+  & templateParameters ?~
   [ parameter "RdsMasterPassword" "String"
   , parameter "RdsSubnetGroup" "String"
   , parameter "VpcId" "String"

--- a/examples/s3-copy.hs
+++ b/examples/s3-copy.hs
@@ -21,8 +21,8 @@ myTemplate =
   , incomingS3Bucket
   , outgoingS3Bucket
   ]
-  & description ?~ "Simple event triggered S3 bucket to bucket copy example"
-  & formatVersion ?~ "2010-09-09"
+  & templateDescription ?~ "Simple event triggered S3 bucket to bucket copy example"
+  & templateFormatVersion ?~ "2010-09-09"
 
 lambda :: Resource
 lambda = (
@@ -35,7 +35,7 @@ lambda = (
     (Literal NodeJS43)
     & lfFunctionName ?~ "copyS3Object"
   )
-  & dependsOn ?~ [ role' ^. resName ]
+  & resourceDependsOn ?~ [ role' ^. resourceName ]
 
   where
     lambdaCode :: LambdaFunctionCode
@@ -114,7 +114,7 @@ incomingS3Bucket = (
   & sbBucketName ?~ "stratosphere-s3-copy-incoming"
   & sbNotificationConfiguration ?~ config
   )
-  & dependsOn ?~ [ lambda ^. resName ]
+  & resourceDependsOn ?~ [ lambda ^. resourceName ]
 
   where
     config =

--- a/examples/simple-lambda.hs
+++ b/examples/simple-lambda.hs
@@ -16,8 +16,8 @@ myTemplate :: Template
 myTemplate =
   template
   [ role', lambda ]
-  & description ?~ "Lambda example"
-  & formatVersion ?~ "2010-09-09"
+  & templateDescription ?~ "Lambda example"
+  & templateFormatVersion ?~ "2010-09-09"
 
 lambda :: Resource
 lambda = (
@@ -29,7 +29,7 @@ lambda = (
     (GetAtt "IAMRole" "Arn")
     (Literal NodeJS43)
   )
-  & dependsOn ?~ [ role' ^. resName ]
+  & resourceDependsOn ?~ [ role' ^. resourceName ]
 
 lambdaCode :: LambdaFunctionCode
 lambdaCode = lambdaFunctionCode

--- a/gen/templates/Resources.hs.ede
+++ b/gen/templates/Resources.hs.ede
@@ -23,19 +23,19 @@
 -- with commas.
 
 module Stratosphere.Resources
-     ( module X
-     , Resource (..)
-     , resource
-     , resName
-     , properties
-     , deletionPolicy
-     , resCreationPolicy
-     , resUpdatePolicy
-     , dependsOn
-     , ResourceProperties (..)
-     , DeletionPolicy (..)
-     , Resources (..)
-     ) where
+  ( module X
+  , Resource (..)
+  , resource
+  , resourceName
+  , resourceProperties
+  , resourceDeletionPolicy
+  , resourceCreationPolicy
+  , resourceUpdatePolicy
+  , resourceDependsOn
+  , ResourceProperties (..)
+  , DeletionPolicy (..)
+  , Resources (..)
+  ) where
 
 import Control.Lens hiding ((.=))
 import Data.Aeson
@@ -70,16 +70,16 @@ instance FromJSON DeletionPolicy where
 
 data Resource =
   Resource
-  { resourceResName :: T.Text
-  , resourceProperties :: ResourceProperties
-  , resourceDeletionPolicy :: Maybe DeletionPolicy
-  , resourceResCreationPolicy :: Maybe CreationPolicy
-  , resourceResUpdatePolicy :: Maybe UpdatePolicy
-  , resourceDependsOn :: Maybe [T.Text]
+  { _resourceName :: T.Text
+  , _resourceProperties :: ResourceProperties
+  , _resourceDeletionPolicy :: Maybe DeletionPolicy
+  , _resourceCreationPolicy :: Maybe CreationPolicy
+  , _resourceUpdatePolicy :: Maybe UpdatePolicy
+  , _resourceDependsOn :: Maybe [T.Text]
   } deriving (Show, Eq)
 
 instance ToRef Resource b where
-  toRef r = Ref (resourceResName r)
+  toRef r = Ref (_resourceName r)
 
 -- | Convenient constructor for 'Resource' with required arguments.
 resource
@@ -88,15 +88,15 @@ resource
   -> Resource
 resource rn rp =
   Resource
-  { resourceResName = rn
-  , resourceProperties = rp
-  , resourceDeletionPolicy = Nothing
-  , resourceResCreationPolicy = Nothing
-  , resourceResUpdatePolicy = Nothing
-  , resourceDependsOn = Nothing
+  { _resourceName = rn
+  , _resourceProperties = rp
+  , _resourceDeletionPolicy = Nothing
+  , _resourceCreationPolicy = Nothing
+  , _resourceUpdatePolicy = Nothing
+  , _resourceDependsOn = Nothing
   }
 
-$(makeFields ''Resource)
+$(makeLenses ''Resource)
 
 resourceToJSON :: Resource -> Value
 resourceToJSON (Resource _ props dp cp up deps) =
@@ -133,7 +133,7 @@ instance IsList Resources where
   toList = unResources
 
 instance NamedItem Resource where
-  itemName = resourceResName
+  itemName = _resourceName
   nameToJSON = resourceToJSON
   nameParseJSON = resourceFromJSON
 

--- a/library-gen/Stratosphere/Resources.hs
+++ b/library-gen/Stratosphere/Resources.hs
@@ -23,19 +23,19 @@
 -- with commas.
 
 module Stratosphere.Resources
-     ( module X
-     , Resource (..)
-     , resource
-     , resName
-     , properties
-     , deletionPolicy
-     , resCreationPolicy
-     , resUpdatePolicy
-     , dependsOn
-     , ResourceProperties (..)
-     , DeletionPolicy (..)
-     , Resources (..)
-     ) where
+  ( module X
+  , Resource (..)
+  , resource
+  , resourceName
+  , resourceProperties
+  , resourceDeletionPolicy
+  , resourceCreationPolicy
+  , resourceUpdatePolicy
+  , resourceDependsOn
+  , ResourceProperties (..)
+  , DeletionPolicy (..)
+  , Resources (..)
+  ) where
 
 import Control.Lens hiding ((.=))
 import Data.Aeson
@@ -1058,16 +1058,16 @@ instance FromJSON DeletionPolicy where
 
 data Resource =
   Resource
-  { resourceResName :: T.Text
-  , resourceProperties :: ResourceProperties
-  , resourceDeletionPolicy :: Maybe DeletionPolicy
-  , resourceResCreationPolicy :: Maybe CreationPolicy
-  , resourceResUpdatePolicy :: Maybe UpdatePolicy
-  , resourceDependsOn :: Maybe [T.Text]
+  { _resourceName :: T.Text
+  , _resourceProperties :: ResourceProperties
+  , _resourceDeletionPolicy :: Maybe DeletionPolicy
+  , _resourceCreationPolicy :: Maybe CreationPolicy
+  , _resourceUpdatePolicy :: Maybe UpdatePolicy
+  , _resourceDependsOn :: Maybe [T.Text]
   } deriving (Show, Eq)
 
 instance ToRef Resource b where
-  toRef r = Ref (resourceResName r)
+  toRef r = Ref (_resourceName r)
 
 -- | Convenient constructor for 'Resource' with required arguments.
 resource
@@ -1076,15 +1076,15 @@ resource
   -> Resource
 resource rn rp =
   Resource
-  { resourceResName = rn
-  , resourceProperties = rp
-  , resourceDeletionPolicy = Nothing
-  , resourceResCreationPolicy = Nothing
-  , resourceResUpdatePolicy = Nothing
-  , resourceDependsOn = Nothing
+  { _resourceName = rn
+  , _resourceProperties = rp
+  , _resourceDeletionPolicy = Nothing
+  , _resourceCreationPolicy = Nothing
+  , _resourceUpdatePolicy = Nothing
+  , _resourceDependsOn = Nothing
   }
 
-$(makeFields ''Resource)
+$(makeLenses ''Resource)
 
 resourceToJSON :: Resource -> Value
 resourceToJSON (Resource _ props dp cp up deps) =
@@ -1862,7 +1862,7 @@ instance IsList Resources where
   toList = unResources
 
 instance NamedItem Resource where
-  itemName = resourceResName
+  itemName = _resourceName
   nameToJSON = resourceToJSON
   nameParseJSON = resourceFromJSON
 

--- a/library/Stratosphere/Check.hs
+++ b/library/Stratosphere/Check.hs
@@ -11,8 +11,8 @@ import Data.Hashable (Hashable)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 
-import Stratosphere.Resources (resourceResName, unResources)
-import Stratosphere.Template (Template, templateResources)
+import Stratosphere.Resources (_resourceName, unResources)
+import Stratosphere.Template (Template, _templateResources)
 
 newtype DuplicateProperty = DuplicateProperty T.Text
   deriving (Show, Eq)
@@ -21,9 +21,9 @@ duplicateProperties :: Template -> [DuplicateProperty]
 duplicateProperties =
     map DuplicateProperty
   . duplicates
-  . map resourceResName
+  . map _resourceName
   . unResources
-  . templateResources
+  . _templateResources
 
 duplicates :: (Foldable f, Eq a, Hashable a) => f a -> [a]
 duplicates =

--- a/library/Stratosphere/Outputs.hs
+++ b/library/Stratosphere/Outputs.hs
@@ -18,15 +18,15 @@
 -- name for a stack so that you can easily find it.
 
 module Stratosphere.Outputs
-       ( Output (..)
-       , output
-       , OutputExport (..)
-       , Outputs (..)
-       , name
-       , description
-       , value
-       , export
-       ) where
+  ( Output (..)
+  , output
+  , OutputExport (..)
+  , Outputs (..)
+  , outputName
+  , outputDescription
+  , outputValue
+  , outputExport
+  ) where
 
 import Control.Lens hiding ((.=))
 import Data.Aeson
@@ -36,7 +36,6 @@ import Data.Text (Text)
 import GHC.Exts (IsList(..))
 
 import Stratosphere.Helpers
-import Stratosphere.Parameters
 import Stratosphere.Values
 
 data OutputExport
@@ -59,23 +58,23 @@ instance FromJSON OutputExport where
 -- | See 'output' for a convenient constructor.
 data Output =
   Output
-  { outputName :: Text
+  { _outputName :: Text
     -- ^ An identifier for this output. The logical ID must be alphanumeric
     -- (A-Za-z0-9) and unique within the template.
-  , outputDescription :: Maybe Text
+  , _outputDescription :: Maybe Text
     -- ^ A String type up to 4K in length describing the output value.
-  , outputValue :: Val Text
+  , _outputValue :: Val Text
     -- ^ The value of the property that is returned by the aws cloudformation
     -- describe-stacks command. The value of an output can be literals,
     -- parameter references, pseudo parameters, a mapping value, and intrinsic
     -- functions.
-  , outputExport :: Maybe OutputExport
+  , _outputExport :: Maybe OutputExport
   } deriving (Show, Eq)
 
-$(makeFields ''Output)
+$(makeLenses ''Output)
 
 instance ToRef Output b where
-  toRef o = Ref (outputName o)
+  toRef o = Ref (_outputName o)
 
 -- | Constructor for 'Output'
 output
@@ -84,18 +83,18 @@ output
   -> Output
 output oname oval =
   Output
-  { outputName = oname
-  , outputDescription = Nothing
-  , outputValue = oval
-  , outputExport = Nothing
+  { _outputName = oname
+  , _outputDescription = Nothing
+  , _outputValue = oval
+  , _outputExport = Nothing
   }
 
 outputToJSON :: Output -> Value
 outputToJSON Output {..} =
   object $ catMaybes
-  [ Just ("Value" .= outputValue)
-  , maybeField "Description" outputDescription
-  , maybeField "Export" outputExport
+  [ Just ("Value" .= _outputValue)
+  , maybeField "Description" _outputDescription
+  , maybeField "Export" _outputExport
   ]
 
 outputFromJSON :: Text -> Object -> Parser Output
@@ -115,7 +114,7 @@ instance IsList Outputs where
   toList = unOutputs
 
 instance NamedItem Output where
-  itemName = outputName
+  itemName = _outputName
   nameToJSON = outputToJSON
   nameParseJSON = outputFromJSON
 

--- a/library/Stratosphere/Parameters.hs
+++ b/library/Stratosphere/Parameters.hs
@@ -33,59 +33,59 @@ import Stratosphere.Values
 
 data Parameter =
   Parameter
-  { parameterName :: T.Text
-  , parameterType' :: T.Text
+  { _parameterName :: T.Text
+  , _parameterType' :: T.Text
     -- ^ The data type for the parameter.
-  , parameterDefault' :: Maybe Value
+  , _parameterDefault' :: Maybe Value
     -- ^ A value of the appropriate type for the template to use if no value is
     -- specified when a stack is created. If you define constraints for the
     -- parameter, you must specify a value that adheres to those constraints.
-  , parameterNoEcho :: Maybe Bool'
+  , _parameterNoEcho :: Maybe Bool'
     -- ^ Whether to mask the parameter value whenever anyone makes a call that
     -- describes the stack. If you set the value to true, the parameter value
     -- is masked with asterisks (*****).
-  , parameterAllowedValues :: Maybe Array
+  , _parameterAllowedValues :: Maybe Array
     -- ^ An array containing the list of values allowed for the parameter.
-  , parameterAllowedPattern :: Maybe T.Text
+  , _parameterAllowedPattern :: Maybe T.Text
     -- ^ A regular expression that represents the patterns you want to allow
     -- for String types.
-  , parameterMaxLength :: Maybe Integer
+  , _parameterMaxLength :: Maybe Integer
     -- ^ An integer value that determines the largest number of characters you
     -- want to allow for String types.
-  , parameterMinLength :: Maybe Integer
+  , _parameterMinLength :: Maybe Integer
     -- ^ An integer value that determines the smallest number of characters you
     -- want to allow for String types.
-  , parameterMaxValue :: Maybe Integer
+  , _parameterMaxValue :: Maybe Integer
     -- ^ A numeric value that determines the largest numeric value you want to
     -- allow for Number types.
-  , parameterMinValue :: Maybe Integer
+  , _parameterMinValue :: Maybe Integer
     -- ^ A numeric value that determines the smallest numeric value you want to
     -- allow for Number types.
-  , parameterDescription :: Maybe T.Text
+  , _parameterDescription :: Maybe T.Text
     -- ^ A string of up to 4000 characters that describes the parameter.
-  , parameterConstraintDescription :: Maybe T.Text
+  , _parameterConstraintDescription :: Maybe T.Text
     -- ^ A string that explains the constraint when the constraint is violated.
   } deriving (Show, Eq)
 
-$(makeFields ''Parameter)
+$(makeLenses ''Parameter)
 
 instance ToRef Parameter b where
-  toRef p = Ref (parameterName p)
+  toRef p = Ref (_parameterName p)
 
 parameterToJSON :: Parameter -> Value
 parameterToJSON Parameter {..} =
   object $ catMaybes
-  [ Just ("Type" .= parameterType')
-  , maybeField "Default" parameterDefault'
-  , maybeField "NoEcho" parameterNoEcho
-  , maybeField "AllowedValues" parameterAllowedValues
-  , maybeField "AllowedPattern" parameterAllowedPattern
-  , maybeField "MaxLength" (Integer' <$> parameterMaxLength)
-  , maybeField "MinLength" (Integer' <$> parameterMinLength)
-  , maybeField "MaxValue" (Integer' <$> parameterMaxValue)
-  , maybeField "MinValue" (Integer' <$> parameterMinValue)
-  , maybeField "Description" parameterDescription
-  , maybeField "ConstraintDescription" parameterConstraintDescription
+  [ Just ("Type" .= _parameterType')
+  , maybeField "Default" _parameterDefault'
+  , maybeField "NoEcho" _parameterNoEcho
+  , maybeField "AllowedValues" _parameterAllowedValues
+  , maybeField "AllowedPattern" _parameterAllowedPattern
+  , maybeField "MaxLength" (Integer' <$> _parameterMaxLength)
+  , maybeField "MinLength" (Integer' <$> _parameterMinLength)
+  , maybeField "MaxValue" (Integer' <$> _parameterMaxValue)
+  , maybeField "MinValue" (Integer' <$> _parameterMinValue)
+  , maybeField "Description" _parameterDescription
+  , maybeField "ConstraintDescription" _parameterConstraintDescription
   ]
 
 parameterFromJSON :: T.Text -> Object -> Parser Parameter
@@ -110,18 +110,18 @@ parameter
   -> Parameter
 parameter pname ptype =
   Parameter
-  { parameterName = pname
-  , parameterType' = ptype
-  , parameterDefault' = Nothing
-  , parameterNoEcho = Nothing
-  , parameterAllowedValues = Nothing
-  , parameterAllowedPattern = Nothing
-  , parameterMaxLength = Nothing
-  , parameterMinLength = Nothing
-  , parameterMaxValue = Nothing
-  , parameterMinValue = Nothing
-  , parameterDescription = Nothing
-  , parameterConstraintDescription = Nothing
+  { _parameterName = pname
+  , _parameterType' = ptype
+  , _parameterDefault' = Nothing
+  , _parameterNoEcho = Nothing
+  , _parameterAllowedValues = Nothing
+  , _parameterAllowedPattern = Nothing
+  , _parameterMaxLength = Nothing
+  , _parameterMinLength = Nothing
+  , _parameterMaxValue = Nothing
+  , _parameterMinValue = Nothing
+  , _parameterDescription = Nothing
+  , _parameterConstraintDescription = Nothing
   }
 
 -- | Wrapper around a list of 'Parameters's to we can modify the aeson
@@ -135,7 +135,7 @@ instance IsList Parameters where
   toList = unParameters
 
 instance NamedItem Parameter where
-  itemName = parameterName
+  itemName = _parameterName
   nameToJSON = parameterToJSON
   nameParseJSON = parameterFromJSON
 

--- a/library/Stratosphere/Template.hs
+++ b/library/Stratosphere/Template.hs
@@ -11,21 +11,21 @@
 -- http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html
 
 module Stratosphere.Template
-       ( Template (..)
-       , template
-       , encodeTemplate
-       , Mapping
+  ( Template (..)
+  , template
+  , encodeTemplate
+  , Mapping
 
-       -- Template lenses
-       , formatVersion
-       , description
-       , metadata
-       , parameters
-       , mappings
-       , conditions
-       , resources
-       , outputs
-       ) where
+    -- Template lenses
+  , templateFormatVersion
+  , templateDescription
+  , templateMetadata
+  , templateParameters
+  , templateMappings
+  , templateConditions
+  , templateResources
+  , templateOutputs
+  ) where
 
 import Control.Lens
 import Data.Aeson
@@ -44,37 +44,37 @@ type Mapping = HM.HashMap T.Text Object
 
 data Template =
   Template
-  { templateFormatVersion :: Maybe T.Text
+  { _templateFormatVersion :: Maybe T.Text
     -- ^ Specifies the AWS CloudFormation template version that the template
     -- conforms to. The template format version is not the same as the API or
     -- WSDL version. The template format version can change independently of
     -- the API and WSDL versions.
-  , templateDescription :: Maybe T.Text
+  , _templateDescription :: Maybe T.Text
     -- ^ A text string that describes the template. This section must always
     -- follow the template format version section.
-  , templateMetadata :: Maybe Object
+  , _templateMetadata :: Maybe Object
     -- ^ JSON objects that provide additional information about the template.
-  , templateParameters :: Maybe Parameters
+  , _templateParameters :: Maybe Parameters
     -- ^ Specifies values that you can pass in to your template at runtime
     -- (when you create or update a stack). You can refer to parameters in the
     -- Resources and Outputs sections of the template.
-  , templateMappings :: Maybe (HM.HashMap T.Text Mapping)
+  , _templateMappings :: Maybe (HM.HashMap T.Text Mapping)
     -- ^ A mapping of keys and associated values that you can use to specify
     -- conditional parameter values, similar to a lookup table. You can match a
     -- key to a corresponding value by using the Fn::FindInMap intrinsic
     -- function in the Resources and Outputs section.
-  , templateConditions :: Maybe Object
+  , _templateConditions :: Maybe Object
     -- ^ Defines conditions that control whether certain resources are created
     -- or whether certain resource properties are assigned a value during stack
     -- creation or update. For example, you could conditionally create a
     -- resource that depends on whether the stack is for a production or test
     -- environment.
-  , templateResources :: Resources
+  , _templateResources :: Resources
     -- ^ Specifies the stack resources and their properties, such as an Amazon
     -- Elastic Compute Cloud instance or an Amazon Simple Storage Service
     -- bucket. You can refer to resources in the Resources and Outputs sections
     -- of the template.
-  , templateOutputs :: Maybe Outputs
+  , _templateOutputs :: Maybe Outputs
     -- ^ Describes the values that are returned whenever you view your stack's
     -- properties. For example, you can declare an output for an Amazon S3
     -- bucket name and then call the aws cloudformation describe-stacks AWS CLI
@@ -84,20 +84,20 @@ data Template =
 
 $(deriveJSON defaultOptions { fieldLabelModifier = modTemplateJSONField
                             , omitNothingFields = True } ''Template)
-$(makeFields ''Template)
+$(makeLenses ''Template)
 
 -- | Convenient constructor for 'Template' with required arguments.
 template :: Resources -> Template
 template res =
   Template
-  { templateFormatVersion = Nothing
-  , templateDescription = Nothing
-  , templateMetadata = Nothing
-  , templateParameters = Nothing
-  , templateMappings = Nothing
-  , templateConditions = Nothing
-  , templateResources = res
-  , templateOutputs = Nothing
+  { _templateFormatVersion = Nothing
+  , _templateDescription = Nothing
+  , _templateMetadata = Nothing
+  , _templateParameters = Nothing
+  , _templateMappings = Nothing
+  , _templateConditions = Nothing
+  , _templateResources = res
+  , _templateOutputs = Nothing
   }
 
 -- | Pretty print a template using aeson-pretty.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stratosphere
-version: "0.15.3"
+version: "0.16.0"
 synopsis: EDSL for AWS CloudFormation
 description: EDSL for AWS CloudFormation
 category: AWS, Cloud


### PR DESCRIPTION
I want to non-generated code to match the conventions in the generated code.