### PR TITLE
Set second argument of split to val

### DIFF
--- a/library/Stratosphere/Helpers.hs
+++ b/library/Stratosphere/Helpers.hs
@@ -45,7 +45,7 @@ prefixFieldRules prefix = set lensField (prefixNamer prefix) defaultFieldRules
 -- in a separate module.
 modTemplateJSONField :: String -> String
 modTemplateJSONField "templateFormatVersion" = "AWSTemplateFormatVersion"
-modTemplateJSONField s = drop 8 s
+modTemplateJSONField s = drop 9 s
 
 
 -- | This class defines items with names in them. It is used to extract the

--- a/library/Stratosphere/Values.hs
+++ b/library/Stratosphere/Values.hs
@@ -121,7 +121,7 @@ data ValList a
   = ValList [Val a]
   | RefList Text
   | ImportValueList Text
-  | Split Text Text
+  | Split Text (Val a)
   | GetAZs (Val Text)
   deriving (Show, Eq)
 


### PR DESCRIPTION
According to the "Supported Functions" section of the
docs (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-split.html),
the second argument to Split doesn't have to be a string literal and
can instead be a function. The delimiter must be a string literal.

Fun note: this wackiness is needed to be able to prepend/append values
to a List type parameter.