### PR TITLE
Use -O0 by default when compiling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ references:
       - run:
           name: Build
           command: |
-            stack build stratosphere --no-terminal --pedantic --test --fast \
+            stack build stratosphere --no-terminal --pedantic --test \
               --no-run-tests --jobs=1 --flag stratosphere:-library-only
 
       - save_cache:
@@ -46,7 +46,7 @@ references:
       - run:
           name: Test
           command: |
-            stack build stratosphere --no-terminal --pedantic --test --fast \
+            stack build stratosphere --no-terminal --pedantic --test \
               --jobs=1 --flag stratosphere:-library-only
 
   # N.B. Doc generation rebuilds everything from the ground up, so there's
@@ -73,12 +73,11 @@ references:
             - 1-{{ checksum "rdigest" }}-{{ .Branch }}-{{ checksum "sdigest" }}
             - 1-{{ checksum "rdigest" }}-{{ .Branch }}
 
-      # We can safely use --fast since it's just for doc generation.
       - run:
           name: Docs
           command: |
             stack haddock stratosphere --no-terminal --no-haddock-deps \
-              --fast --jobs=1 --flag stratosphere:-library-only
+              --jobs=1 --flag stratosphere:-library-only
           no_output_timeout: 30m
 
       - save_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.33.1
+
+* Use `-O0` when compiling `stratosphere`
+
 ## 0.33.0
 
 * **BREAKING CHANGE**: We nuked the huge `ResourceProperties` sum type, which

--- a/gen/package.yaml
+++ b/gen/package.yaml
@@ -20,7 +20,7 @@ executables:
   stratosphere-gen:
     source-dirs: src
     main: Main.hs
-    ghc-options: -Wall
+    ghc-options: -Wall -O0
     dependencies:
       - base
       - aeson >= 0.11

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stratosphere
-version: "0.33.0"
+version: "0.33.1"
 synopsis: EDSL for AWS CloudFormation
 description: EDSL for AWS CloudFormation
 category: AWS, Cloud
@@ -36,7 +36,7 @@ library:
   source-dirs:
     - library
     - library-gen
-  ghc-options: -Wall
+  ghc-options: -Wall -O0
 
 executables:
   auto-scaling-group:


### PR DESCRIPTION
`stratosphere` takes quite a long time to compile when optimizations are turned on, even with our recent changes to reduce that time. Uses of `stratosphere` almost always involve just generating a template and then doing IO like writing to a file or running the template on AWS. I see no reason to compile with optimizations to spit out a small-ish (relatively speaking) JSON template.