### PR TITLE
Don't encode Bool, Int, or Double as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-## 0.33.1
+## 0.34.0
 
+* Don't encode `Bool`, `Int`, and `Double` values as strings in JSON. See:
+  - https://github.com/frontrowed/stratosphere/pull/123 and
+  - https://github.com/frontrowed/stratosphere/issues/86
 * Use `-O0` when compiling `stratosphere`
 
 ## 0.33.0

--- a/gen/src/Gen/Render/RenderJsonInstances.hs
+++ b/gen/src/Gen/Render/RenderJsonInstances.hs
@@ -57,19 +57,5 @@ renderToJSONFields spaces Module{..} =
     leader = "\n" <> T.pack (replicate spaces ' ') <> ", "
     renderField Property{..} =
       if propertyRequired
-      then [st|(Just . ("#{propertyName}",) . toJSON#{toJSONWrapper propertySpecType}) #{moduleFieldPrefix}#{propertyName}|]
-      else [st|fmap (("#{propertyName}",) . toJSON#{toJSONWrapper propertySpecType}) #{moduleFieldPrefix}#{propertyName}|]
-
-toJSONWrapper :: SpecType -> Text
-toJSONWrapper (AtomicType type') = maybe "" (" . fmap " <>) (atomicType' type')
--- AFAIK we never have a list of numbers or bools, so I don't think this case
--- occurs. Grep for "fmap (fmap" to check.
-toJSONWrapper (ListType type') = maybe "" (\t -> ". fmap (fmap " <> t <> ")") (atomicType' type')
-toJSONWrapper (MapType _) = ""
-
--- | Get the newtype version of the AtomicType, if applicable.
-atomicType' :: AtomicType -> Maybe Text
-atomicType' IntegerPrimitive = Just "Integer'"
-atomicType' DoublePrimitive = Just "Double'"
-atomicType' BoolPrimitive = Just "Bool'"
-atomicType' _ = Nothing
+      then [st|(Just . ("#{propertyName}",) . toJSON) #{moduleFieldPrefix}#{propertyName}|]
+      else [st|fmap (("#{propertyName}",) . toJSON) #{moduleFieldPrefix}#{propertyName}|]

--- a/library-gen/Stratosphere/ResourceProperties/AmazonMQBrokerConfigurationId.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AmazonMQBrokerConfigurationId.hs
@@ -23,7 +23,7 @@ instance ToJSON AmazonMQBrokerConfigurationId where
     object $
     catMaybes
     [ (Just . ("Id",) . toJSON) _amazonMQBrokerConfigurationIdId
-    , (Just . ("Revision",) . toJSON . fmap Integer') _amazonMQBrokerConfigurationIdRevision
+    , (Just . ("Revision",) . toJSON) _amazonMQBrokerConfigurationIdRevision
     ]
 
 -- | Constructor for 'AmazonMQBrokerConfigurationId' containing required

--- a/library-gen/Stratosphere/ResourceProperties/AmazonMQBrokerLogList.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AmazonMQBrokerLogList.hs
@@ -22,8 +22,8 @@ instance ToJSON AmazonMQBrokerLogList where
   toJSON AmazonMQBrokerLogList{..} =
     object $
     catMaybes
-    [ fmap (("Audit",) . toJSON . fmap Bool') _amazonMQBrokerLogListAudit
-    , fmap (("General",) . toJSON . fmap Bool') _amazonMQBrokerLogListGeneral
+    [ fmap (("Audit",) . toJSON) _amazonMQBrokerLogListAudit
+    , fmap (("General",) . toJSON) _amazonMQBrokerLogListGeneral
     ]
 
 -- | Constructor for 'AmazonMQBrokerLogList' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/AmazonMQBrokerUser.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AmazonMQBrokerUser.hs
@@ -24,7 +24,7 @@ instance ToJSON AmazonMQBrokerUser where
   toJSON AmazonMQBrokerUser{..} =
     object $
     catMaybes
-    [ fmap (("ConsoleAccess",) . toJSON . fmap Bool') _amazonMQBrokerUserConsoleAccess
+    [ fmap (("ConsoleAccess",) . toJSON) _amazonMQBrokerUserConsoleAccess
     , fmap (("Groups",) . toJSON) _amazonMQBrokerUserGroups
     , (Just . ("Password",) . toJSON) _amazonMQBrokerUserPassword
     , (Just . ("Username",) . toJSON) _amazonMQBrokerUserUsername

--- a/library-gen/Stratosphere/ResourceProperties/AmazonMQConfigurationAssociationConfigurationId.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AmazonMQConfigurationAssociationConfigurationId.hs
@@ -25,7 +25,7 @@ instance ToJSON AmazonMQConfigurationAssociationConfigurationId where
     object $
     catMaybes
     [ (Just . ("Id",) . toJSON) _amazonMQConfigurationAssociationConfigurationIdId
-    , (Just . ("Revision",) . toJSON . fmap Integer') _amazonMQConfigurationAssociationConfigurationIdRevision
+    , (Just . ("Revision",) . toJSON) _amazonMQConfigurationAssociationConfigurationIdRevision
     ]
 
 -- | Constructor for 'AmazonMQConfigurationAssociationConfigurationId'

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentCanarySetting.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentCanarySetting.hs
@@ -23,9 +23,9 @@ instance ToJSON ApiGatewayDeploymentCanarySetting where
   toJSON ApiGatewayDeploymentCanarySetting{..} =
     object $
     catMaybes
-    [ fmap (("PercentTraffic",) . toJSON . fmap Double') _apiGatewayDeploymentCanarySettingPercentTraffic
+    [ fmap (("PercentTraffic",) . toJSON) _apiGatewayDeploymentCanarySettingPercentTraffic
     , fmap (("StageVariableOverrides",) . toJSON) _apiGatewayDeploymentCanarySettingStageVariableOverrides
-    , fmap (("UseStageCache",) . toJSON . fmap Bool') _apiGatewayDeploymentCanarySettingUseStageCache
+    , fmap (("UseStageCache",) . toJSON) _apiGatewayDeploymentCanarySettingUseStageCache
     ]
 
 -- | Constructor for 'ApiGatewayDeploymentCanarySetting' containing required

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentDeploymentCanarySettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentDeploymentCanarySettings.hs
@@ -25,9 +25,9 @@ instance ToJSON ApiGatewayDeploymentDeploymentCanarySettings where
   toJSON ApiGatewayDeploymentDeploymentCanarySettings{..} =
     object $
     catMaybes
-    [ fmap (("PercentTraffic",) . toJSON . fmap Double') _apiGatewayDeploymentDeploymentCanarySettingsPercentTraffic
+    [ fmap (("PercentTraffic",) . toJSON) _apiGatewayDeploymentDeploymentCanarySettingsPercentTraffic
     , fmap (("StageVariableOverrides",) . toJSON) _apiGatewayDeploymentDeploymentCanarySettingsStageVariableOverrides
-    , fmap (("UseStageCache",) . toJSON . fmap Bool') _apiGatewayDeploymentDeploymentCanarySettingsUseStageCache
+    , fmap (("UseStageCache",) . toJSON) _apiGatewayDeploymentDeploymentCanarySettingsUseStageCache
     ]
 
 -- | Constructor for 'ApiGatewayDeploymentDeploymentCanarySettings' containing

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentMethodSetting.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentMethodSetting.hs
@@ -30,16 +30,16 @@ instance ToJSON ApiGatewayDeploymentMethodSetting where
   toJSON ApiGatewayDeploymentMethodSetting{..} =
     object $
     catMaybes
-    [ fmap (("CacheDataEncrypted",) . toJSON . fmap Bool') _apiGatewayDeploymentMethodSettingCacheDataEncrypted
-    , fmap (("CacheTtlInSeconds",) . toJSON . fmap Integer') _apiGatewayDeploymentMethodSettingCacheTtlInSeconds
-    , fmap (("CachingEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentMethodSettingCachingEnabled
-    , fmap (("DataTraceEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentMethodSettingDataTraceEnabled
+    [ fmap (("CacheDataEncrypted",) . toJSON) _apiGatewayDeploymentMethodSettingCacheDataEncrypted
+    , fmap (("CacheTtlInSeconds",) . toJSON) _apiGatewayDeploymentMethodSettingCacheTtlInSeconds
+    , fmap (("CachingEnabled",) . toJSON) _apiGatewayDeploymentMethodSettingCachingEnabled
+    , fmap (("DataTraceEnabled",) . toJSON) _apiGatewayDeploymentMethodSettingDataTraceEnabled
     , fmap (("HttpMethod",) . toJSON) _apiGatewayDeploymentMethodSettingHttpMethod
     , fmap (("LoggingLevel",) . toJSON) _apiGatewayDeploymentMethodSettingLoggingLevel
-    , fmap (("MetricsEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentMethodSettingMetricsEnabled
+    , fmap (("MetricsEnabled",) . toJSON) _apiGatewayDeploymentMethodSettingMetricsEnabled
     , fmap (("ResourcePath",) . toJSON) _apiGatewayDeploymentMethodSettingResourcePath
-    , fmap (("ThrottlingBurstLimit",) . toJSON . fmap Integer') _apiGatewayDeploymentMethodSettingThrottlingBurstLimit
-    , fmap (("ThrottlingRateLimit",) . toJSON . fmap Double') _apiGatewayDeploymentMethodSettingThrottlingRateLimit
+    , fmap (("ThrottlingBurstLimit",) . toJSON) _apiGatewayDeploymentMethodSettingThrottlingBurstLimit
+    , fmap (("ThrottlingRateLimit",) . toJSON) _apiGatewayDeploymentMethodSettingThrottlingRateLimit
     ]
 
 -- | Constructor for 'ApiGatewayDeploymentMethodSetting' containing required

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentStageDescription.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayDeploymentStageDescription.hs
@@ -44,23 +44,23 @@ instance ToJSON ApiGatewayDeploymentStageDescription where
     object $
     catMaybes
     [ fmap (("AccessLogSetting",) . toJSON) _apiGatewayDeploymentStageDescriptionAccessLogSetting
-    , fmap (("CacheClusterEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentStageDescriptionCacheClusterEnabled
+    , fmap (("CacheClusterEnabled",) . toJSON) _apiGatewayDeploymentStageDescriptionCacheClusterEnabled
     , fmap (("CacheClusterSize",) . toJSON) _apiGatewayDeploymentStageDescriptionCacheClusterSize
-    , fmap (("CacheDataEncrypted",) . toJSON . fmap Bool') _apiGatewayDeploymentStageDescriptionCacheDataEncrypted
-    , fmap (("CacheTtlInSeconds",) . toJSON . fmap Integer') _apiGatewayDeploymentStageDescriptionCacheTtlInSeconds
-    , fmap (("CachingEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentStageDescriptionCachingEnabled
+    , fmap (("CacheDataEncrypted",) . toJSON) _apiGatewayDeploymentStageDescriptionCacheDataEncrypted
+    , fmap (("CacheTtlInSeconds",) . toJSON) _apiGatewayDeploymentStageDescriptionCacheTtlInSeconds
+    , fmap (("CachingEnabled",) . toJSON) _apiGatewayDeploymentStageDescriptionCachingEnabled
     , fmap (("CanarySetting",) . toJSON) _apiGatewayDeploymentStageDescriptionCanarySetting
     , fmap (("ClientCertificateId",) . toJSON) _apiGatewayDeploymentStageDescriptionClientCertificateId
-    , fmap (("DataTraceEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentStageDescriptionDataTraceEnabled
+    , fmap (("DataTraceEnabled",) . toJSON) _apiGatewayDeploymentStageDescriptionDataTraceEnabled
     , fmap (("Description",) . toJSON) _apiGatewayDeploymentStageDescriptionDescription
     , fmap (("DocumentationVersion",) . toJSON) _apiGatewayDeploymentStageDescriptionDocumentationVersion
     , fmap (("LoggingLevel",) . toJSON) _apiGatewayDeploymentStageDescriptionLoggingLevel
     , fmap (("MethodSettings",) . toJSON) _apiGatewayDeploymentStageDescriptionMethodSettings
-    , fmap (("MetricsEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentStageDescriptionMetricsEnabled
+    , fmap (("MetricsEnabled",) . toJSON) _apiGatewayDeploymentStageDescriptionMetricsEnabled
     , fmap (("Tags",) . toJSON) _apiGatewayDeploymentStageDescriptionTags
-    , fmap (("ThrottlingBurstLimit",) . toJSON . fmap Integer') _apiGatewayDeploymentStageDescriptionThrottlingBurstLimit
-    , fmap (("ThrottlingRateLimit",) . toJSON . fmap Double') _apiGatewayDeploymentStageDescriptionThrottlingRateLimit
-    , fmap (("TracingEnabled",) . toJSON . fmap Bool') _apiGatewayDeploymentStageDescriptionTracingEnabled
+    , fmap (("ThrottlingBurstLimit",) . toJSON) _apiGatewayDeploymentStageDescriptionThrottlingBurstLimit
+    , fmap (("ThrottlingRateLimit",) . toJSON) _apiGatewayDeploymentStageDescriptionThrottlingRateLimit
+    , fmap (("TracingEnabled",) . toJSON) _apiGatewayDeploymentStageDescriptionTracingEnabled
     , fmap (("Variables",) . toJSON) _apiGatewayDeploymentStageDescriptionVariables
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayMethodIntegration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayMethodIntegration.hs
@@ -46,7 +46,7 @@ instance ToJSON ApiGatewayMethodIntegration where
     , fmap (("PassthroughBehavior",) . toJSON) _apiGatewayMethodIntegrationPassthroughBehavior
     , fmap (("RequestParameters",) . toJSON) _apiGatewayMethodIntegrationRequestParameters
     , fmap (("RequestTemplates",) . toJSON) _apiGatewayMethodIntegrationRequestTemplates
-    , fmap (("TimeoutInMillis",) . toJSON . fmap Integer') _apiGatewayMethodIntegrationTimeoutInMillis
+    , fmap (("TimeoutInMillis",) . toJSON) _apiGatewayMethodIntegrationTimeoutInMillis
     , fmap (("Type",) . toJSON) _apiGatewayMethodIntegrationType
     , fmap (("Uri",) . toJSON) _apiGatewayMethodIntegrationUri
     ]

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayStageCanarySetting.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayStageCanarySetting.hs
@@ -25,9 +25,9 @@ instance ToJSON ApiGatewayStageCanarySetting where
     object $
     catMaybes
     [ fmap (("DeploymentId",) . toJSON) _apiGatewayStageCanarySettingDeploymentId
-    , fmap (("PercentTraffic",) . toJSON . fmap Double') _apiGatewayStageCanarySettingPercentTraffic
+    , fmap (("PercentTraffic",) . toJSON) _apiGatewayStageCanarySettingPercentTraffic
     , fmap (("StageVariableOverrides",) . toJSON) _apiGatewayStageCanarySettingStageVariableOverrides
-    , fmap (("UseStageCache",) . toJSON . fmap Bool') _apiGatewayStageCanarySettingUseStageCache
+    , fmap (("UseStageCache",) . toJSON) _apiGatewayStageCanarySettingUseStageCache
     ]
 
 -- | Constructor for 'ApiGatewayStageCanarySetting' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayStageMethodSetting.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayStageMethodSetting.hs
@@ -30,16 +30,16 @@ instance ToJSON ApiGatewayStageMethodSetting where
   toJSON ApiGatewayStageMethodSetting{..} =
     object $
     catMaybes
-    [ fmap (("CacheDataEncrypted",) . toJSON . fmap Bool') _apiGatewayStageMethodSettingCacheDataEncrypted
-    , fmap (("CacheTtlInSeconds",) . toJSON . fmap Integer') _apiGatewayStageMethodSettingCacheTtlInSeconds
-    , fmap (("CachingEnabled",) . toJSON . fmap Bool') _apiGatewayStageMethodSettingCachingEnabled
-    , fmap (("DataTraceEnabled",) . toJSON . fmap Bool') _apiGatewayStageMethodSettingDataTraceEnabled
+    [ fmap (("CacheDataEncrypted",) . toJSON) _apiGatewayStageMethodSettingCacheDataEncrypted
+    , fmap (("CacheTtlInSeconds",) . toJSON) _apiGatewayStageMethodSettingCacheTtlInSeconds
+    , fmap (("CachingEnabled",) . toJSON) _apiGatewayStageMethodSettingCachingEnabled
+    , fmap (("DataTraceEnabled",) . toJSON) _apiGatewayStageMethodSettingDataTraceEnabled
     , fmap (("HttpMethod",) . toJSON) _apiGatewayStageMethodSettingHttpMethod
     , fmap (("LoggingLevel",) . toJSON) _apiGatewayStageMethodSettingLoggingLevel
-    , fmap (("MetricsEnabled",) . toJSON . fmap Bool') _apiGatewayStageMethodSettingMetricsEnabled
+    , fmap (("MetricsEnabled",) . toJSON) _apiGatewayStageMethodSettingMetricsEnabled
     , fmap (("ResourcePath",) . toJSON) _apiGatewayStageMethodSettingResourcePath
-    , fmap (("ThrottlingBurstLimit",) . toJSON . fmap Integer') _apiGatewayStageMethodSettingThrottlingBurstLimit
-    , fmap (("ThrottlingRateLimit",) . toJSON . fmap Double') _apiGatewayStageMethodSettingThrottlingRateLimit
+    , fmap (("ThrottlingBurstLimit",) . toJSON) _apiGatewayStageMethodSettingThrottlingBurstLimit
+    , fmap (("ThrottlingRateLimit",) . toJSON) _apiGatewayStageMethodSettingThrottlingRateLimit
     ]
 
 -- | Constructor for 'ApiGatewayStageMethodSetting' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayUsagePlanQuotaSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayUsagePlanQuotaSettings.hs
@@ -23,8 +23,8 @@ instance ToJSON ApiGatewayUsagePlanQuotaSettings where
   toJSON ApiGatewayUsagePlanQuotaSettings{..} =
     object $
     catMaybes
-    [ fmap (("Limit",) . toJSON . fmap Integer') _apiGatewayUsagePlanQuotaSettingsLimit
-    , fmap (("Offset",) . toJSON . fmap Integer') _apiGatewayUsagePlanQuotaSettingsOffset
+    [ fmap (("Limit",) . toJSON) _apiGatewayUsagePlanQuotaSettingsLimit
+    , fmap (("Offset",) . toJSON) _apiGatewayUsagePlanQuotaSettingsOffset
     , fmap (("Period",) . toJSON) _apiGatewayUsagePlanQuotaSettingsPeriod
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayUsagePlanThrottleSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayUsagePlanThrottleSettings.hs
@@ -22,8 +22,8 @@ instance ToJSON ApiGatewayUsagePlanThrottleSettings where
   toJSON ApiGatewayUsagePlanThrottleSettings{..} =
     object $
     catMaybes
-    [ fmap (("BurstLimit",) . toJSON . fmap Integer') _apiGatewayUsagePlanThrottleSettingsBurstLimit
-    , fmap (("RateLimit",) . toJSON . fmap Double') _apiGatewayUsagePlanThrottleSettingsRateLimit
+    [ fmap (("BurstLimit",) . toJSON) _apiGatewayUsagePlanThrottleSettingsBurstLimit
+    , fmap (("RateLimit",) . toJSON) _apiGatewayUsagePlanThrottleSettingsRateLimit
     ]
 
 -- | Constructor for 'ApiGatewayUsagePlanThrottleSettings' containing required

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayV2RouteParameterConstraints.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayV2RouteParameterConstraints.hs
@@ -22,7 +22,7 @@ instance ToJSON ApiGatewayV2RouteParameterConstraints where
   toJSON ApiGatewayV2RouteParameterConstraints{..} =
     object $
     catMaybes
-    [ (Just . ("Required",) . toJSON . fmap Bool') _apiGatewayV2RouteParameterConstraintsRequired
+    [ (Just . ("Required",) . toJSON) _apiGatewayV2RouteParameterConstraintsRequired
     ]
 
 -- | Constructor for 'ApiGatewayV2RouteParameterConstraints' containing

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayV2RouteResponseParameterConstraints.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayV2RouteResponseParameterConstraints.hs
@@ -23,7 +23,7 @@ instance ToJSON ApiGatewayV2RouteResponseParameterConstraints where
   toJSON ApiGatewayV2RouteResponseParameterConstraints{..} =
     object $
     catMaybes
-    [ (Just . ("Required",) . toJSON . fmap Bool') _apiGatewayV2RouteResponseParameterConstraintsRequired
+    [ (Just . ("Required",) . toJSON) _apiGatewayV2RouteResponseParameterConstraintsRequired
     ]
 
 -- | Constructor for 'ApiGatewayV2RouteResponseParameterConstraints'

--- a/library-gen/Stratosphere/ResourceProperties/ApiGatewayV2StageRouteSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApiGatewayV2StageRouteSettings.hs
@@ -25,11 +25,11 @@ instance ToJSON ApiGatewayV2StageRouteSettings where
   toJSON ApiGatewayV2StageRouteSettings{..} =
     object $
     catMaybes
-    [ fmap (("DataTraceEnabled",) . toJSON . fmap Bool') _apiGatewayV2StageRouteSettingsDataTraceEnabled
-    , fmap (("DetailedMetricsEnabled",) . toJSON . fmap Bool') _apiGatewayV2StageRouteSettingsDetailedMetricsEnabled
+    [ fmap (("DataTraceEnabled",) . toJSON) _apiGatewayV2StageRouteSettingsDataTraceEnabled
+    , fmap (("DetailedMetricsEnabled",) . toJSON) _apiGatewayV2StageRouteSettingsDetailedMetricsEnabled
     , fmap (("LoggingLevel",) . toJSON) _apiGatewayV2StageRouteSettingsLoggingLevel
-    , fmap (("ThrottlingBurstLimit",) . toJSON . fmap Integer') _apiGatewayV2StageRouteSettingsThrottlingBurstLimit
-    , fmap (("ThrottlingRateLimit",) . toJSON . fmap Double') _apiGatewayV2StageRouteSettingsThrottlingRateLimit
+    , fmap (("ThrottlingBurstLimit",) . toJSON) _apiGatewayV2StageRouteSettingsThrottlingBurstLimit
+    , fmap (("ThrottlingRateLimit",) . toJSON) _apiGatewayV2StageRouteSettingsThrottlingRateLimit
     ]
 
 -- | Constructor for 'ApiGatewayV2StageRouteSettings' containing required

--- a/library-gen/Stratosphere/ResourceProperties/AppStreamFleetComputeCapacity.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AppStreamFleetComputeCapacity.hs
@@ -21,7 +21,7 @@ instance ToJSON AppStreamFleetComputeCapacity where
   toJSON AppStreamFleetComputeCapacity{..} =
     object $
     catMaybes
-    [ (Just . ("DesiredInstances",) . toJSON . fmap Integer') _appStreamFleetComputeCapacityDesiredInstances
+    [ (Just . ("DesiredInstances",) . toJSON) _appStreamFleetComputeCapacityDesiredInstances
     ]
 
 -- | Constructor for 'AppStreamFleetComputeCapacity' containing required

--- a/library-gen/Stratosphere/ResourceProperties/AppStreamStackApplicationSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AppStreamStackApplicationSettings.hs
@@ -22,7 +22,7 @@ instance ToJSON AppStreamStackApplicationSettings where
   toJSON AppStreamStackApplicationSettings{..} =
     object $
     catMaybes
-    [ (Just . ("Enabled",) . toJSON . fmap Bool') _appStreamStackApplicationSettingsEnabled
+    [ (Just . ("Enabled",) . toJSON) _appStreamStackApplicationSettingsEnabled
     , fmap (("SettingsGroup",) . toJSON) _appStreamStackApplicationSettingsSettingsGroup
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/AppSyncDataSourceDynamoDBConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AppSyncDataSourceDynamoDBConfig.hs
@@ -25,7 +25,7 @@ instance ToJSON AppSyncDataSourceDynamoDBConfig where
     catMaybes
     [ (Just . ("AwsRegion",) . toJSON) _appSyncDataSourceDynamoDBConfigAwsRegion
     , (Just . ("TableName",) . toJSON) _appSyncDataSourceDynamoDBConfigTableName
-    , fmap (("UseCallerCredentials",) . toJSON . fmap Bool') _appSyncDataSourceDynamoDBConfigUseCallerCredentials
+    , fmap (("UseCallerCredentials",) . toJSON) _appSyncDataSourceDynamoDBConfigUseCallerCredentials
     ]
 
 -- | Constructor for 'AppSyncDataSourceDynamoDBConfig' containing required

--- a/library-gen/Stratosphere/ResourceProperties/AppSyncGraphQLApiOpenIDConnectConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AppSyncGraphQLApiOpenIDConnectConfig.hs
@@ -24,9 +24,9 @@ instance ToJSON AppSyncGraphQLApiOpenIDConnectConfig where
   toJSON AppSyncGraphQLApiOpenIDConnectConfig{..} =
     object $
     catMaybes
-    [ fmap (("AuthTTL",) . toJSON . fmap Double') _appSyncGraphQLApiOpenIDConnectConfigAuthTTL
+    [ fmap (("AuthTTL",) . toJSON) _appSyncGraphQLApiOpenIDConnectConfigAuthTTL
     , fmap (("ClientId",) . toJSON) _appSyncGraphQLApiOpenIDConnectConfigClientId
-    , fmap (("IatTTL",) . toJSON . fmap Double') _appSyncGraphQLApiOpenIDConnectConfigIatTTL
+    , fmap (("IatTTL",) . toJSON) _appSyncGraphQLApiOpenIDConnectConfigIatTTL
     , fmap (("Issuer",) . toJSON) _appSyncGraphQLApiOpenIDConnectConfigIssuer
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalableTargetScalableTargetAction.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalableTargetScalableTargetAction.hs
@@ -24,8 +24,8 @@ instance ToJSON ApplicationAutoScalingScalableTargetScalableTargetAction where
   toJSON ApplicationAutoScalingScalableTargetScalableTargetAction{..} =
     object $
     catMaybes
-    [ fmap (("MaxCapacity",) . toJSON . fmap Integer') _applicationAutoScalingScalableTargetScalableTargetActionMaxCapacity
-    , fmap (("MinCapacity",) . toJSON . fmap Integer') _applicationAutoScalingScalableTargetScalableTargetActionMinCapacity
+    [ fmap (("MaxCapacity",) . toJSON) _applicationAutoScalingScalableTargetScalableTargetActionMaxCapacity
+    , fmap (("MinCapacity",) . toJSON) _applicationAutoScalingScalableTargetScalableTargetActionMinCapacity
     ]
 
 -- | Constructor for

--- a/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalingPolicyStepAdjustment.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalingPolicyStepAdjustment.hs
@@ -25,9 +25,9 @@ instance ToJSON ApplicationAutoScalingScalingPolicyStepAdjustment where
   toJSON ApplicationAutoScalingScalingPolicyStepAdjustment{..} =
     object $
     catMaybes
-    [ fmap (("MetricIntervalLowerBound",) . toJSON . fmap Double') _applicationAutoScalingScalingPolicyStepAdjustmentMetricIntervalLowerBound
-    , fmap (("MetricIntervalUpperBound",) . toJSON . fmap Double') _applicationAutoScalingScalingPolicyStepAdjustmentMetricIntervalUpperBound
-    , (Just . ("ScalingAdjustment",) . toJSON . fmap Integer') _applicationAutoScalingScalingPolicyStepAdjustmentScalingAdjustment
+    [ fmap (("MetricIntervalLowerBound",) . toJSON) _applicationAutoScalingScalingPolicyStepAdjustmentMetricIntervalLowerBound
+    , fmap (("MetricIntervalUpperBound",) . toJSON) _applicationAutoScalingScalingPolicyStepAdjustmentMetricIntervalUpperBound
+    , (Just . ("ScalingAdjustment",) . toJSON) _applicationAutoScalingScalingPolicyStepAdjustmentScalingAdjustment
     ]
 
 -- | Constructor for 'ApplicationAutoScalingScalingPolicyStepAdjustment'

--- a/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalingPolicyStepScalingPolicyConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalingPolicyStepScalingPolicyConfiguration.hs
@@ -28,9 +28,9 @@ instance ToJSON ApplicationAutoScalingScalingPolicyStepScalingPolicyConfiguratio
     object $
     catMaybes
     [ fmap (("AdjustmentType",) . toJSON) _applicationAutoScalingScalingPolicyStepScalingPolicyConfigurationAdjustmentType
-    , fmap (("Cooldown",) . toJSON . fmap Integer') _applicationAutoScalingScalingPolicyStepScalingPolicyConfigurationCooldown
+    , fmap (("Cooldown",) . toJSON) _applicationAutoScalingScalingPolicyStepScalingPolicyConfigurationCooldown
     , fmap (("MetricAggregationType",) . toJSON) _applicationAutoScalingScalingPolicyStepScalingPolicyConfigurationMetricAggregationType
-    , fmap (("MinAdjustmentMagnitude",) . toJSON . fmap Integer') _applicationAutoScalingScalingPolicyStepScalingPolicyConfigurationMinAdjustmentMagnitude
+    , fmap (("MinAdjustmentMagnitude",) . toJSON) _applicationAutoScalingScalingPolicyStepScalingPolicyConfigurationMinAdjustmentMagnitude
     , fmap (("StepAdjustments",) . toJSON) _applicationAutoScalingScalingPolicyStepScalingPolicyConfigurationStepAdjustments
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ApplicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfiguration.hs
@@ -31,11 +31,11 @@ instance ToJSON ApplicationAutoScalingScalingPolicyTargetTrackingScalingPolicyCo
     object $
     catMaybes
     [ fmap (("CustomizedMetricSpecification",) . toJSON) _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationCustomizedMetricSpecification
-    , fmap (("DisableScaleIn",) . toJSON . fmap Bool') _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationDisableScaleIn
+    , fmap (("DisableScaleIn",) . toJSON) _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationDisableScaleIn
     , fmap (("PredefinedMetricSpecification",) . toJSON) _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationPredefinedMetricSpecification
-    , fmap (("ScaleInCooldown",) . toJSON . fmap Integer') _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationScaleInCooldown
-    , fmap (("ScaleOutCooldown",) . toJSON . fmap Integer') _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationScaleOutCooldown
-    , (Just . ("TargetValue",) . toJSON . fmap Double') _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationTargetValue
+    , fmap (("ScaleInCooldown",) . toJSON) _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationScaleInCooldown
+    , fmap (("ScaleOutCooldown",) . toJSON) _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationScaleOutCooldown
+    , (Just . ("TargetValue",) . toJSON) _applicationAutoScalingScalingPolicyTargetTrackingScalingPolicyConfigurationTargetValue
     ]
 
 -- | Constructor for

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupInstancesDistribution.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupInstancesDistribution.hs
@@ -29,10 +29,10 @@ instance ToJSON AutoScalingAutoScalingGroupInstancesDistribution where
     object $
     catMaybes
     [ fmap (("OnDemandAllocationStrategy",) . toJSON) _autoScalingAutoScalingGroupInstancesDistributionOnDemandAllocationStrategy
-    , fmap (("OnDemandBaseCapacity",) . toJSON . fmap Integer') _autoScalingAutoScalingGroupInstancesDistributionOnDemandBaseCapacity
-    , fmap (("OnDemandPercentageAboveBaseCapacity",) . toJSON . fmap Integer') _autoScalingAutoScalingGroupInstancesDistributionOnDemandPercentageAboveBaseCapacity
+    , fmap (("OnDemandBaseCapacity",) . toJSON) _autoScalingAutoScalingGroupInstancesDistributionOnDemandBaseCapacity
+    , fmap (("OnDemandPercentageAboveBaseCapacity",) . toJSON) _autoScalingAutoScalingGroupInstancesDistributionOnDemandPercentageAboveBaseCapacity
     , fmap (("SpotAllocationStrategy",) . toJSON) _autoScalingAutoScalingGroupInstancesDistributionSpotAllocationStrategy
-    , fmap (("SpotInstancePools",) . toJSON . fmap Integer') _autoScalingAutoScalingGroupInstancesDistributionSpotInstancePools
+    , fmap (("SpotInstancePools",) . toJSON) _autoScalingAutoScalingGroupInstancesDistributionSpotInstancePools
     , fmap (("SpotMaxPrice",) . toJSON) _autoScalingAutoScalingGroupInstancesDistributionSpotMaxPrice
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupLifecycleHookSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupLifecycleHookSpecification.hs
@@ -30,7 +30,7 @@ instance ToJSON AutoScalingAutoScalingGroupLifecycleHookSpecification where
     object $
     catMaybes
     [ fmap (("DefaultResult",) . toJSON) _autoScalingAutoScalingGroupLifecycleHookSpecificationDefaultResult
-    , fmap (("HeartbeatTimeout",) . toJSON . fmap Integer') _autoScalingAutoScalingGroupLifecycleHookSpecificationHeartbeatTimeout
+    , fmap (("HeartbeatTimeout",) . toJSON) _autoScalingAutoScalingGroupLifecycleHookSpecificationHeartbeatTimeout
     , (Just . ("LifecycleHookName",) . toJSON) _autoScalingAutoScalingGroupLifecycleHookSpecificationLifecycleHookName
     , (Just . ("LifecycleTransition",) . toJSON) _autoScalingAutoScalingGroupLifecycleHookSpecificationLifecycleTransition
     , fmap (("NotificationMetadata",) . toJSON) _autoScalingAutoScalingGroupLifecycleHookSpecificationNotificationMetadata

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupTagProperty.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingAutoScalingGroupTagProperty.hs
@@ -25,7 +25,7 @@ instance ToJSON AutoScalingAutoScalingGroupTagProperty where
     object $
     catMaybes
     [ (Just . ("Key",) . toJSON) _autoScalingAutoScalingGroupTagPropertyKey
-    , (Just . ("PropagateAtLaunch",) . toJSON . fmap Bool') _autoScalingAutoScalingGroupTagPropertyPropagateAtLaunch
+    , (Just . ("PropagateAtLaunch",) . toJSON) _autoScalingAutoScalingGroupTagPropertyPropagateAtLaunch
     , (Just . ("Value",) . toJSON) _autoScalingAutoScalingGroupTagPropertyValue
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingLaunchConfigurationBlockDevice.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingLaunchConfigurationBlockDevice.hs
@@ -27,11 +27,11 @@ instance ToJSON AutoScalingLaunchConfigurationBlockDevice where
   toJSON AutoScalingLaunchConfigurationBlockDevice{..} =
     object $
     catMaybes
-    [ fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _autoScalingLaunchConfigurationBlockDeviceDeleteOnTermination
-    , fmap (("Encrypted",) . toJSON . fmap Bool') _autoScalingLaunchConfigurationBlockDeviceEncrypted
-    , fmap (("Iops",) . toJSON . fmap Integer') _autoScalingLaunchConfigurationBlockDeviceIops
+    [ fmap (("DeleteOnTermination",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceDeleteOnTermination
+    , fmap (("Encrypted",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceEncrypted
+    , fmap (("Iops",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceIops
     , fmap (("SnapshotId",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceSnapshotId
-    , fmap (("VolumeSize",) . toJSON . fmap Integer') _autoScalingLaunchConfigurationBlockDeviceVolumeSize
+    , fmap (("VolumeSize",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceVolumeSize
     , fmap (("VolumeType",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingLaunchConfigurationBlockDeviceMapping.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingLaunchConfigurationBlockDeviceMapping.hs
@@ -28,7 +28,7 @@ instance ToJSON AutoScalingLaunchConfigurationBlockDeviceMapping where
     catMaybes
     [ (Just . ("DeviceName",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceMappingDeviceName
     , fmap (("Ebs",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceMappingEbs
-    , fmap (("NoDevice",) . toJSON . fmap Bool') _autoScalingLaunchConfigurationBlockDeviceMappingNoDevice
+    , fmap (("NoDevice",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceMappingNoDevice
     , fmap (("VirtualName",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceMappingVirtualName
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingPlansScalingPlanScalingInstruction.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingPlansScalingPlanScalingInstruction.hs
@@ -39,17 +39,17 @@ instance ToJSON AutoScalingPlansScalingPlanScalingInstruction where
     object $
     catMaybes
     [ fmap (("CustomizedLoadMetricSpecification",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionCustomizedLoadMetricSpecification
-    , fmap (("DisableDynamicScaling",) . toJSON . fmap Bool') _autoScalingPlansScalingPlanScalingInstructionDisableDynamicScaling
-    , (Just . ("MaxCapacity",) . toJSON . fmap Integer') _autoScalingPlansScalingPlanScalingInstructionMaxCapacity
-    , (Just . ("MinCapacity",) . toJSON . fmap Integer') _autoScalingPlansScalingPlanScalingInstructionMinCapacity
+    , fmap (("DisableDynamicScaling",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionDisableDynamicScaling
+    , (Just . ("MaxCapacity",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionMaxCapacity
+    , (Just . ("MinCapacity",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionMinCapacity
     , fmap (("PredefinedLoadMetricSpecification",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionPredefinedLoadMetricSpecification
     , fmap (("PredictiveScalingMaxCapacityBehavior",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionPredictiveScalingMaxCapacityBehavior
-    , fmap (("PredictiveScalingMaxCapacityBuffer",) . toJSON . fmap Integer') _autoScalingPlansScalingPlanScalingInstructionPredictiveScalingMaxCapacityBuffer
+    , fmap (("PredictiveScalingMaxCapacityBuffer",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionPredictiveScalingMaxCapacityBuffer
     , fmap (("PredictiveScalingMode",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionPredictiveScalingMode
     , (Just . ("ResourceId",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionResourceId
     , (Just . ("ScalableDimension",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionScalableDimension
     , fmap (("ScalingPolicyUpdateBehavior",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionScalingPolicyUpdateBehavior
-    , fmap (("ScheduledActionBufferTime",) . toJSON . fmap Integer') _autoScalingPlansScalingPlanScalingInstructionScheduledActionBufferTime
+    , fmap (("ScheduledActionBufferTime",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionScheduledActionBufferTime
     , (Just . ("ServiceNamespace",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionServiceNamespace
     , (Just . ("TargetTrackingConfigurations",) . toJSON) _autoScalingPlansScalingPlanScalingInstructionTargetTrackingConfigurations
     ]

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingPlansScalingPlanTargetTrackingConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingPlansScalingPlanTargetTrackingConfiguration.hs
@@ -31,12 +31,12 @@ instance ToJSON AutoScalingPlansScalingPlanTargetTrackingConfiguration where
     object $
     catMaybes
     [ fmap (("CustomizedScalingMetricSpecification",) . toJSON) _autoScalingPlansScalingPlanTargetTrackingConfigurationCustomizedScalingMetricSpecification
-    , fmap (("DisableScaleIn",) . toJSON . fmap Bool') _autoScalingPlansScalingPlanTargetTrackingConfigurationDisableScaleIn
-    , fmap (("EstimatedInstanceWarmup",) . toJSON . fmap Integer') _autoScalingPlansScalingPlanTargetTrackingConfigurationEstimatedInstanceWarmup
+    , fmap (("DisableScaleIn",) . toJSON) _autoScalingPlansScalingPlanTargetTrackingConfigurationDisableScaleIn
+    , fmap (("EstimatedInstanceWarmup",) . toJSON) _autoScalingPlansScalingPlanTargetTrackingConfigurationEstimatedInstanceWarmup
     , fmap (("PredefinedScalingMetricSpecification",) . toJSON) _autoScalingPlansScalingPlanTargetTrackingConfigurationPredefinedScalingMetricSpecification
-    , fmap (("ScaleInCooldown",) . toJSON . fmap Integer') _autoScalingPlansScalingPlanTargetTrackingConfigurationScaleInCooldown
-    , fmap (("ScaleOutCooldown",) . toJSON . fmap Integer') _autoScalingPlansScalingPlanTargetTrackingConfigurationScaleOutCooldown
-    , (Just . ("TargetValue",) . toJSON . fmap Double') _autoScalingPlansScalingPlanTargetTrackingConfigurationTargetValue
+    , fmap (("ScaleInCooldown",) . toJSON) _autoScalingPlansScalingPlanTargetTrackingConfigurationScaleInCooldown
+    , fmap (("ScaleOutCooldown",) . toJSON) _autoScalingPlansScalingPlanTargetTrackingConfigurationScaleOutCooldown
+    , (Just . ("TargetValue",) . toJSON) _autoScalingPlansScalingPlanTargetTrackingConfigurationTargetValue
     ]
 
 -- | Constructor for 'AutoScalingPlansScalingPlanTargetTrackingConfiguration'

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingScalingPolicyStepAdjustment.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingScalingPolicyStepAdjustment.hs
@@ -24,9 +24,9 @@ instance ToJSON AutoScalingScalingPolicyStepAdjustment where
   toJSON AutoScalingScalingPolicyStepAdjustment{..} =
     object $
     catMaybes
-    [ fmap (("MetricIntervalLowerBound",) . toJSON . fmap Double') _autoScalingScalingPolicyStepAdjustmentMetricIntervalLowerBound
-    , fmap (("MetricIntervalUpperBound",) . toJSON . fmap Double') _autoScalingScalingPolicyStepAdjustmentMetricIntervalUpperBound
-    , (Just . ("ScalingAdjustment",) . toJSON . fmap Integer') _autoScalingScalingPolicyStepAdjustmentScalingAdjustment
+    [ fmap (("MetricIntervalLowerBound",) . toJSON) _autoScalingScalingPolicyStepAdjustmentMetricIntervalLowerBound
+    , fmap (("MetricIntervalUpperBound",) . toJSON) _autoScalingScalingPolicyStepAdjustmentMetricIntervalUpperBound
+    , (Just . ("ScalingAdjustment",) . toJSON) _autoScalingScalingPolicyStepAdjustmentScalingAdjustment
     ]
 
 -- | Constructor for 'AutoScalingScalingPolicyStepAdjustment' containing

--- a/library-gen/Stratosphere/ResourceProperties/AutoScalingScalingPolicyTargetTrackingConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/AutoScalingScalingPolicyTargetTrackingConfiguration.hs
@@ -28,9 +28,9 @@ instance ToJSON AutoScalingScalingPolicyTargetTrackingConfiguration where
     object $
     catMaybes
     [ fmap (("CustomizedMetricSpecification",) . toJSON) _autoScalingScalingPolicyTargetTrackingConfigurationCustomizedMetricSpecification
-    , fmap (("DisableScaleIn",) . toJSON . fmap Bool') _autoScalingScalingPolicyTargetTrackingConfigurationDisableScaleIn
+    , fmap (("DisableScaleIn",) . toJSON) _autoScalingScalingPolicyTargetTrackingConfigurationDisableScaleIn
     , fmap (("PredefinedMetricSpecification",) . toJSON) _autoScalingScalingPolicyTargetTrackingConfigurationPredefinedMetricSpecification
-    , (Just . ("TargetValue",) . toJSON . fmap Double') _autoScalingScalingPolicyTargetTrackingConfigurationTargetValue
+    , (Just . ("TargetValue",) . toJSON) _autoScalingScalingPolicyTargetTrackingConfigurationTargetValue
     ]
 
 -- | Constructor for 'AutoScalingScalingPolicyTargetTrackingConfiguration'

--- a/library-gen/Stratosphere/ResourceProperties/BatchComputeEnvironmentComputeResources.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchComputeEnvironmentComputeResources.hs
@@ -36,15 +36,15 @@ instance ToJSON BatchComputeEnvironmentComputeResources where
   toJSON BatchComputeEnvironmentComputeResources{..} =
     object $
     catMaybes
-    [ fmap (("BidPercentage",) . toJSON . fmap Integer') _batchComputeEnvironmentComputeResourcesBidPercentage
-    , fmap (("DesiredvCpus",) . toJSON . fmap Integer') _batchComputeEnvironmentComputeResourcesDesiredvCpus
+    [ fmap (("BidPercentage",) . toJSON) _batchComputeEnvironmentComputeResourcesBidPercentage
+    , fmap (("DesiredvCpus",) . toJSON) _batchComputeEnvironmentComputeResourcesDesiredvCpus
     , fmap (("Ec2KeyPair",) . toJSON) _batchComputeEnvironmentComputeResourcesEc2KeyPair
     , fmap (("ImageId",) . toJSON) _batchComputeEnvironmentComputeResourcesImageId
     , (Just . ("InstanceRole",) . toJSON) _batchComputeEnvironmentComputeResourcesInstanceRole
     , (Just . ("InstanceTypes",) . toJSON) _batchComputeEnvironmentComputeResourcesInstanceTypes
     , fmap (("LaunchTemplate",) . toJSON) _batchComputeEnvironmentComputeResourcesLaunchTemplate
-    , (Just . ("MaxvCpus",) . toJSON . fmap Integer') _batchComputeEnvironmentComputeResourcesMaxvCpus
-    , (Just . ("MinvCpus",) . toJSON . fmap Integer') _batchComputeEnvironmentComputeResourcesMinvCpus
+    , (Just . ("MaxvCpus",) . toJSON) _batchComputeEnvironmentComputeResourcesMaxvCpus
+    , (Just . ("MinvCpus",) . toJSON) _batchComputeEnvironmentComputeResourcesMinvCpus
     , fmap (("PlacementGroup",) . toJSON) _batchComputeEnvironmentComputeResourcesPlacementGroup
     , (Just . ("SecurityGroupIds",) . toJSON) _batchComputeEnvironmentComputeResourcesSecurityGroupIds
     , fmap (("SpotIamFleetRole",) . toJSON) _batchComputeEnvironmentComputeResourcesSpotIamFleetRole

--- a/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionContainerProperties.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionContainerProperties.hs
@@ -42,13 +42,13 @@ instance ToJSON BatchJobDefinitionContainerProperties where
     , (Just . ("Image",) . toJSON) _batchJobDefinitionContainerPropertiesImage
     , fmap (("InstanceType",) . toJSON) _batchJobDefinitionContainerPropertiesInstanceType
     , fmap (("JobRoleArn",) . toJSON) _batchJobDefinitionContainerPropertiesJobRoleArn
-    , (Just . ("Memory",) . toJSON . fmap Integer') _batchJobDefinitionContainerPropertiesMemory
+    , (Just . ("Memory",) . toJSON) _batchJobDefinitionContainerPropertiesMemory
     , fmap (("MountPoints",) . toJSON) _batchJobDefinitionContainerPropertiesMountPoints
-    , fmap (("Privileged",) . toJSON . fmap Bool') _batchJobDefinitionContainerPropertiesPrivileged
-    , fmap (("ReadonlyRootFilesystem",) . toJSON . fmap Bool') _batchJobDefinitionContainerPropertiesReadonlyRootFilesystem
+    , fmap (("Privileged",) . toJSON) _batchJobDefinitionContainerPropertiesPrivileged
+    , fmap (("ReadonlyRootFilesystem",) . toJSON) _batchJobDefinitionContainerPropertiesReadonlyRootFilesystem
     , fmap (("Ulimits",) . toJSON) _batchJobDefinitionContainerPropertiesUlimits
     , fmap (("User",) . toJSON) _batchJobDefinitionContainerPropertiesUser
-    , (Just . ("Vcpus",) . toJSON . fmap Integer') _batchJobDefinitionContainerPropertiesVcpus
+    , (Just . ("Vcpus",) . toJSON) _batchJobDefinitionContainerPropertiesVcpus
     , fmap (("Volumes",) . toJSON) _batchJobDefinitionContainerPropertiesVolumes
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionMountPoints.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionMountPoints.hs
@@ -24,7 +24,7 @@ instance ToJSON BatchJobDefinitionMountPoints where
     object $
     catMaybes
     [ fmap (("ContainerPath",) . toJSON) _batchJobDefinitionMountPointsContainerPath
-    , fmap (("ReadOnly",) . toJSON . fmap Bool') _batchJobDefinitionMountPointsReadOnly
+    , fmap (("ReadOnly",) . toJSON) _batchJobDefinitionMountPointsReadOnly
     , fmap (("SourceVolume",) . toJSON) _batchJobDefinitionMountPointsSourceVolume
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionNodeProperties.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionNodeProperties.hs
@@ -23,9 +23,9 @@ instance ToJSON BatchJobDefinitionNodeProperties where
   toJSON BatchJobDefinitionNodeProperties{..} =
     object $
     catMaybes
-    [ (Just . ("MainNode",) . toJSON . fmap Integer') _batchJobDefinitionNodePropertiesMainNode
+    [ (Just . ("MainNode",) . toJSON) _batchJobDefinitionNodePropertiesMainNode
     , (Just . ("NodeRangeProperties",) . toJSON) _batchJobDefinitionNodePropertiesNodeRangeProperties
-    , (Just . ("NumNodes",) . toJSON . fmap Integer') _batchJobDefinitionNodePropertiesNumNodes
+    , (Just . ("NumNodes",) . toJSON) _batchJobDefinitionNodePropertiesNumNodes
     ]
 
 -- | Constructor for 'BatchJobDefinitionNodeProperties' containing required

--- a/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionRetryStrategy.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionRetryStrategy.hs
@@ -21,7 +21,7 @@ instance ToJSON BatchJobDefinitionRetryStrategy where
   toJSON BatchJobDefinitionRetryStrategy{..} =
     object $
     catMaybes
-    [ fmap (("Attempts",) . toJSON . fmap Integer') _batchJobDefinitionRetryStrategyAttempts
+    [ fmap (("Attempts",) . toJSON) _batchJobDefinitionRetryStrategyAttempts
     ]
 
 -- | Constructor for 'BatchJobDefinitionRetryStrategy' containing required

--- a/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionTimeout.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionTimeout.hs
@@ -21,7 +21,7 @@ instance ToJSON BatchJobDefinitionTimeout where
   toJSON BatchJobDefinitionTimeout{..} =
     object $
     catMaybes
-    [ fmap (("AttemptDurationSeconds",) . toJSON . fmap Integer') _batchJobDefinitionTimeoutAttemptDurationSeconds
+    [ fmap (("AttemptDurationSeconds",) . toJSON) _batchJobDefinitionTimeoutAttemptDurationSeconds
     ]
 
 -- | Constructor for 'BatchJobDefinitionTimeout' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionUlimit.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchJobDefinitionUlimit.hs
@@ -23,9 +23,9 @@ instance ToJSON BatchJobDefinitionUlimit where
   toJSON BatchJobDefinitionUlimit{..} =
     object $
     catMaybes
-    [ (Just . ("HardLimit",) . toJSON . fmap Integer') _batchJobDefinitionUlimitHardLimit
+    [ (Just . ("HardLimit",) . toJSON) _batchJobDefinitionUlimitHardLimit
     , (Just . ("Name",) . toJSON) _batchJobDefinitionUlimitName
-    , (Just . ("SoftLimit",) . toJSON . fmap Integer') _batchJobDefinitionUlimitSoftLimit
+    , (Just . ("SoftLimit",) . toJSON) _batchJobDefinitionUlimitSoftLimit
     ]
 
 -- | Constructor for 'BatchJobDefinitionUlimit' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/BatchJobQueueComputeEnvironmentOrder.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BatchJobQueueComputeEnvironmentOrder.hs
@@ -23,7 +23,7 @@ instance ToJSON BatchJobQueueComputeEnvironmentOrder where
     object $
     catMaybes
     [ (Just . ("ComputeEnvironment",) . toJSON) _batchJobQueueComputeEnvironmentOrderComputeEnvironment
-    , (Just . ("Order",) . toJSON . fmap Integer') _batchJobQueueComputeEnvironmentOrderOrder
+    , (Just . ("Order",) . toJSON) _batchJobQueueComputeEnvironmentOrderOrder
     ]
 
 -- | Constructor for 'BatchJobQueueComputeEnvironmentOrder' containing

--- a/library-gen/Stratosphere/ResourceProperties/BudgetsBudgetCostTypes.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BudgetsBudgetCostTypes.hs
@@ -31,17 +31,17 @@ instance ToJSON BudgetsBudgetCostTypes where
   toJSON BudgetsBudgetCostTypes{..} =
     object $
     catMaybes
-    [ fmap (("IncludeCredit",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeCredit
-    , fmap (("IncludeDiscount",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeDiscount
-    , fmap (("IncludeOtherSubscription",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeOtherSubscription
-    , fmap (("IncludeRecurring",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeRecurring
-    , fmap (("IncludeRefund",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeRefund
-    , fmap (("IncludeSubscription",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeSubscription
-    , fmap (("IncludeSupport",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeSupport
-    , fmap (("IncludeTax",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeTax
-    , fmap (("IncludeUpfront",) . toJSON . fmap Bool') _budgetsBudgetCostTypesIncludeUpfront
-    , fmap (("UseAmortized",) . toJSON . fmap Bool') _budgetsBudgetCostTypesUseAmortized
-    , fmap (("UseBlended",) . toJSON . fmap Bool') _budgetsBudgetCostTypesUseBlended
+    [ fmap (("IncludeCredit",) . toJSON) _budgetsBudgetCostTypesIncludeCredit
+    , fmap (("IncludeDiscount",) . toJSON) _budgetsBudgetCostTypesIncludeDiscount
+    , fmap (("IncludeOtherSubscription",) . toJSON) _budgetsBudgetCostTypesIncludeOtherSubscription
+    , fmap (("IncludeRecurring",) . toJSON) _budgetsBudgetCostTypesIncludeRecurring
+    , fmap (("IncludeRefund",) . toJSON) _budgetsBudgetCostTypesIncludeRefund
+    , fmap (("IncludeSubscription",) . toJSON) _budgetsBudgetCostTypesIncludeSubscription
+    , fmap (("IncludeSupport",) . toJSON) _budgetsBudgetCostTypesIncludeSupport
+    , fmap (("IncludeTax",) . toJSON) _budgetsBudgetCostTypesIncludeTax
+    , fmap (("IncludeUpfront",) . toJSON) _budgetsBudgetCostTypesIncludeUpfront
+    , fmap (("UseAmortized",) . toJSON) _budgetsBudgetCostTypesUseAmortized
+    , fmap (("UseBlended",) . toJSON) _budgetsBudgetCostTypesUseBlended
     ]
 
 -- | Constructor for 'BudgetsBudgetCostTypes' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/BudgetsBudgetNotification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BudgetsBudgetNotification.hs
@@ -26,7 +26,7 @@ instance ToJSON BudgetsBudgetNotification where
     catMaybes
     [ (Just . ("ComparisonOperator",) . toJSON) _budgetsBudgetNotificationComparisonOperator
     , (Just . ("NotificationType",) . toJSON) _budgetsBudgetNotificationNotificationType
-    , (Just . ("Threshold",) . toJSON . fmap Double') _budgetsBudgetNotificationThreshold
+    , (Just . ("Threshold",) . toJSON) _budgetsBudgetNotificationThreshold
     , fmap (("ThresholdType",) . toJSON) _budgetsBudgetNotificationThresholdType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/BudgetsBudgetSpend.hs
+++ b/library-gen/Stratosphere/ResourceProperties/BudgetsBudgetSpend.hs
@@ -22,7 +22,7 @@ instance ToJSON BudgetsBudgetSpend where
   toJSON BudgetsBudgetSpend{..} =
     object $
     catMaybes
-    [ (Just . ("Amount",) . toJSON . fmap Double') _budgetsBudgetSpendAmount
+    [ (Just . ("Amount",) . toJSON) _budgetsBudgetSpendAmount
     , (Just . ("Unit",) . toJSON) _budgetsBudgetSpendUnit
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCacheBehavior.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCacheBehavior.hs
@@ -37,15 +37,15 @@ instance ToJSON CloudFrontDistributionCacheBehavior where
     catMaybes
     [ fmap (("AllowedMethods",) . toJSON) _cloudFrontDistributionCacheBehaviorAllowedMethods
     , fmap (("CachedMethods",) . toJSON) _cloudFrontDistributionCacheBehaviorCachedMethods
-    , fmap (("Compress",) . toJSON . fmap Bool') _cloudFrontDistributionCacheBehaviorCompress
-    , fmap (("DefaultTTL",) . toJSON . fmap Double') _cloudFrontDistributionCacheBehaviorDefaultTTL
+    , fmap (("Compress",) . toJSON) _cloudFrontDistributionCacheBehaviorCompress
+    , fmap (("DefaultTTL",) . toJSON) _cloudFrontDistributionCacheBehaviorDefaultTTL
     , fmap (("FieldLevelEncryptionId",) . toJSON) _cloudFrontDistributionCacheBehaviorFieldLevelEncryptionId
     , (Just . ("ForwardedValues",) . toJSON) _cloudFrontDistributionCacheBehaviorForwardedValues
     , fmap (("LambdaFunctionAssociations",) . toJSON) _cloudFrontDistributionCacheBehaviorLambdaFunctionAssociations
-    , fmap (("MaxTTL",) . toJSON . fmap Double') _cloudFrontDistributionCacheBehaviorMaxTTL
-    , fmap (("MinTTL",) . toJSON . fmap Double') _cloudFrontDistributionCacheBehaviorMinTTL
+    , fmap (("MaxTTL",) . toJSON) _cloudFrontDistributionCacheBehaviorMaxTTL
+    , fmap (("MinTTL",) . toJSON) _cloudFrontDistributionCacheBehaviorMinTTL
     , (Just . ("PathPattern",) . toJSON) _cloudFrontDistributionCacheBehaviorPathPattern
-    , fmap (("SmoothStreaming",) . toJSON . fmap Bool') _cloudFrontDistributionCacheBehaviorSmoothStreaming
+    , fmap (("SmoothStreaming",) . toJSON) _cloudFrontDistributionCacheBehaviorSmoothStreaming
     , (Just . ("TargetOriginId",) . toJSON) _cloudFrontDistributionCacheBehaviorTargetOriginId
     , fmap (("TrustedSigners",) . toJSON) _cloudFrontDistributionCacheBehaviorTrustedSigners
     , (Just . ("ViewerProtocolPolicy",) . toJSON) _cloudFrontDistributionCacheBehaviorViewerProtocolPolicy

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCustomErrorResponse.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCustomErrorResponse.hs
@@ -25,9 +25,9 @@ instance ToJSON CloudFrontDistributionCustomErrorResponse where
   toJSON CloudFrontDistributionCustomErrorResponse{..} =
     object $
     catMaybes
-    [ fmap (("ErrorCachingMinTTL",) . toJSON . fmap Double') _cloudFrontDistributionCustomErrorResponseErrorCachingMinTTL
-    , (Just . ("ErrorCode",) . toJSON . fmap Integer') _cloudFrontDistributionCustomErrorResponseErrorCode
-    , fmap (("ResponseCode",) . toJSON . fmap Integer') _cloudFrontDistributionCustomErrorResponseResponseCode
+    [ fmap (("ErrorCachingMinTTL",) . toJSON) _cloudFrontDistributionCustomErrorResponseErrorCachingMinTTL
+    , (Just . ("ErrorCode",) . toJSON) _cloudFrontDistributionCustomErrorResponseErrorCode
+    , fmap (("ResponseCode",) . toJSON) _cloudFrontDistributionCustomErrorResponseResponseCode
     , fmap (("ResponsePagePath",) . toJSON) _cloudFrontDistributionCustomErrorResponseResponsePagePath
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCustomOriginConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionCustomOriginConfig.hs
@@ -27,11 +27,11 @@ instance ToJSON CloudFrontDistributionCustomOriginConfig where
   toJSON CloudFrontDistributionCustomOriginConfig{..} =
     object $
     catMaybes
-    [ fmap (("HTTPPort",) . toJSON . fmap Integer') _cloudFrontDistributionCustomOriginConfigHTTPPort
-    , fmap (("HTTPSPort",) . toJSON . fmap Integer') _cloudFrontDistributionCustomOriginConfigHTTPSPort
-    , fmap (("OriginKeepaliveTimeout",) . toJSON . fmap Integer') _cloudFrontDistributionCustomOriginConfigOriginKeepaliveTimeout
+    [ fmap (("HTTPPort",) . toJSON) _cloudFrontDistributionCustomOriginConfigHTTPPort
+    , fmap (("HTTPSPort",) . toJSON) _cloudFrontDistributionCustomOriginConfigHTTPSPort
+    , fmap (("OriginKeepaliveTimeout",) . toJSON) _cloudFrontDistributionCustomOriginConfigOriginKeepaliveTimeout
     , (Just . ("OriginProtocolPolicy",) . toJSON) _cloudFrontDistributionCustomOriginConfigOriginProtocolPolicy
-    , fmap (("OriginReadTimeout",) . toJSON . fmap Integer') _cloudFrontDistributionCustomOriginConfigOriginReadTimeout
+    , fmap (("OriginReadTimeout",) . toJSON) _cloudFrontDistributionCustomOriginConfigOriginReadTimeout
     , fmap (("OriginSSLProtocols",) . toJSON) _cloudFrontDistributionCustomOriginConfigOriginSSLProtocols
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDefaultCacheBehavior.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDefaultCacheBehavior.hs
@@ -37,14 +37,14 @@ instance ToJSON CloudFrontDistributionDefaultCacheBehavior where
     catMaybes
     [ fmap (("AllowedMethods",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorAllowedMethods
     , fmap (("CachedMethods",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorCachedMethods
-    , fmap (("Compress",) . toJSON . fmap Bool') _cloudFrontDistributionDefaultCacheBehaviorCompress
-    , fmap (("DefaultTTL",) . toJSON . fmap Double') _cloudFrontDistributionDefaultCacheBehaviorDefaultTTL
+    , fmap (("Compress",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorCompress
+    , fmap (("DefaultTTL",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorDefaultTTL
     , fmap (("FieldLevelEncryptionId",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorFieldLevelEncryptionId
     , (Just . ("ForwardedValues",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorForwardedValues
     , fmap (("LambdaFunctionAssociations",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorLambdaFunctionAssociations
-    , fmap (("MaxTTL",) . toJSON . fmap Double') _cloudFrontDistributionDefaultCacheBehaviorMaxTTL
-    , fmap (("MinTTL",) . toJSON . fmap Double') _cloudFrontDistributionDefaultCacheBehaviorMinTTL
-    , fmap (("SmoothStreaming",) . toJSON . fmap Bool') _cloudFrontDistributionDefaultCacheBehaviorSmoothStreaming
+    , fmap (("MaxTTL",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorMaxTTL
+    , fmap (("MinTTL",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorMinTTL
+    , fmap (("SmoothStreaming",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorSmoothStreaming
     , (Just . ("TargetOriginId",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorTargetOriginId
     , fmap (("TrustedSigners",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorTrustedSigners
     , (Just . ("ViewerProtocolPolicy",) . toJSON) _cloudFrontDistributionDefaultCacheBehaviorViewerProtocolPolicy

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDistributionConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionDistributionConfig.hs
@@ -48,9 +48,9 @@ instance ToJSON CloudFrontDistributionDistributionConfig where
     , fmap (("CustomErrorResponses",) . toJSON) _cloudFrontDistributionDistributionConfigCustomErrorResponses
     , fmap (("DefaultCacheBehavior",) . toJSON) _cloudFrontDistributionDistributionConfigDefaultCacheBehavior
     , fmap (("DefaultRootObject",) . toJSON) _cloudFrontDistributionDistributionConfigDefaultRootObject
-    , (Just . ("Enabled",) . toJSON . fmap Bool') _cloudFrontDistributionDistributionConfigEnabled
+    , (Just . ("Enabled",) . toJSON) _cloudFrontDistributionDistributionConfigEnabled
     , fmap (("HttpVersion",) . toJSON) _cloudFrontDistributionDistributionConfigHttpVersion
-    , fmap (("IPV6Enabled",) . toJSON . fmap Bool') _cloudFrontDistributionDistributionConfigIPV6Enabled
+    , fmap (("IPV6Enabled",) . toJSON) _cloudFrontDistributionDistributionConfigIPV6Enabled
     , fmap (("Logging",) . toJSON) _cloudFrontDistributionDistributionConfigLogging
     , fmap (("Origins",) . toJSON) _cloudFrontDistributionDistributionConfigOrigins
     , fmap (("PriceClass",) . toJSON) _cloudFrontDistributionDistributionConfigPriceClass

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionForwardedValues.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionForwardedValues.hs
@@ -27,7 +27,7 @@ instance ToJSON CloudFrontDistributionForwardedValues where
     catMaybes
     [ fmap (("Cookies",) . toJSON) _cloudFrontDistributionForwardedValuesCookies
     , fmap (("Headers",) . toJSON) _cloudFrontDistributionForwardedValuesHeaders
-    , (Just . ("QueryString",) . toJSON . fmap Bool') _cloudFrontDistributionForwardedValuesQueryString
+    , (Just . ("QueryString",) . toJSON) _cloudFrontDistributionForwardedValuesQueryString
     , fmap (("QueryStringCacheKeys",) . toJSON) _cloudFrontDistributionForwardedValuesQueryStringCacheKeys
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionLogging.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionLogging.hs
@@ -24,7 +24,7 @@ instance ToJSON CloudFrontDistributionLogging where
     object $
     catMaybes
     [ (Just . ("Bucket",) . toJSON) _cloudFrontDistributionLoggingBucket
-    , fmap (("IncludeCookies",) . toJSON . fmap Bool') _cloudFrontDistributionLoggingIncludeCookies
+    , fmap (("IncludeCookies",) . toJSON) _cloudFrontDistributionLoggingIncludeCookies
     , fmap (("Prefix",) . toJSON) _cloudFrontDistributionLoggingPrefix
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionViewerCertificate.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontDistributionViewerCertificate.hs
@@ -27,7 +27,7 @@ instance ToJSON CloudFrontDistributionViewerCertificate where
     object $
     catMaybes
     [ fmap (("AcmCertificateArn",) . toJSON) _cloudFrontDistributionViewerCertificateAcmCertificateArn
-    , fmap (("CloudFrontDefaultCertificate",) . toJSON . fmap Bool') _cloudFrontDistributionViewerCertificateCloudFrontDefaultCertificate
+    , fmap (("CloudFrontDefaultCertificate",) . toJSON) _cloudFrontDistributionViewerCertificateCloudFrontDefaultCertificate
     , fmap (("IamCertificateId",) . toJSON) _cloudFrontDistributionViewerCertificateIamCertificateId
     , fmap (("MinimumProtocolVersion",) . toJSON) _cloudFrontDistributionViewerCertificateMinimumProtocolVersion
     , fmap (("SslSupportMethod",) . toJSON) _cloudFrontDistributionViewerCertificateSslSupportMethod

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontStreamingDistributionLogging.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontStreamingDistributionLogging.hs
@@ -25,7 +25,7 @@ instance ToJSON CloudFrontStreamingDistributionLogging where
     object $
     catMaybes
     [ (Just . ("Bucket",) . toJSON) _cloudFrontStreamingDistributionLoggingBucket
-    , (Just . ("Enabled",) . toJSON . fmap Bool') _cloudFrontStreamingDistributionLoggingEnabled
+    , (Just . ("Enabled",) . toJSON) _cloudFrontStreamingDistributionLoggingEnabled
     , (Just . ("Prefix",) . toJSON) _cloudFrontStreamingDistributionLoggingPrefix
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontStreamingDistributionStreamingDistributionConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontStreamingDistributionStreamingDistributionConfig.hs
@@ -33,7 +33,7 @@ instance ToJSON CloudFrontStreamingDistributionStreamingDistributionConfig where
     catMaybes
     [ fmap (("Aliases",) . toJSON) _cloudFrontStreamingDistributionStreamingDistributionConfigAliases
     , (Just . ("Comment",) . toJSON) _cloudFrontStreamingDistributionStreamingDistributionConfigComment
-    , (Just . ("Enabled",) . toJSON . fmap Bool') _cloudFrontStreamingDistributionStreamingDistributionConfigEnabled
+    , (Just . ("Enabled",) . toJSON) _cloudFrontStreamingDistributionStreamingDistributionConfigEnabled
     , fmap (("Logging",) . toJSON) _cloudFrontStreamingDistributionStreamingDistributionConfigLogging
     , fmap (("PriceClass",) . toJSON) _cloudFrontStreamingDistributionStreamingDistributionConfigPriceClass
     , (Just . ("S3Origin",) . toJSON) _cloudFrontStreamingDistributionStreamingDistributionConfigS3Origin

--- a/library-gen/Stratosphere/ResourceProperties/CloudFrontStreamingDistributionTrustedSigners.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudFrontStreamingDistributionTrustedSigners.hs
@@ -25,7 +25,7 @@ instance ToJSON CloudFrontStreamingDistributionTrustedSigners where
     object $
     catMaybes
     [ fmap (("AwsAccountNumbers",) . toJSON) _cloudFrontStreamingDistributionTrustedSignersAwsAccountNumbers
-    , (Just . ("Enabled",) . toJSON . fmap Bool') _cloudFrontStreamingDistributionTrustedSignersEnabled
+    , (Just . ("Enabled",) . toJSON) _cloudFrontStreamingDistributionTrustedSignersEnabled
     ]
 
 -- | Constructor for 'CloudFrontStreamingDistributionTrustedSigners'

--- a/library-gen/Stratosphere/ResourceProperties/CloudTrailTrailEventSelector.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudTrailTrailEventSelector.hs
@@ -24,7 +24,7 @@ instance ToJSON CloudTrailTrailEventSelector where
     object $
     catMaybes
     [ fmap (("DataResources",) . toJSON) _cloudTrailTrailEventSelectorDataResources
-    , fmap (("IncludeManagementEvents",) . toJSON . fmap Bool') _cloudTrailTrailEventSelectorIncludeManagementEvents
+    , fmap (("IncludeManagementEvents",) . toJSON) _cloudTrailTrailEventSelectorIncludeManagementEvents
     , fmap (("ReadWriteType",) . toJSON) _cloudTrailTrailEventSelectorReadWriteType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CloudWatchAlarmMetricDataQuery.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudWatchAlarmMetricDataQuery.hs
@@ -29,7 +29,7 @@ instance ToJSON CloudWatchAlarmMetricDataQuery where
     , (Just . ("Id",) . toJSON) _cloudWatchAlarmMetricDataQueryId
     , fmap (("Label",) . toJSON) _cloudWatchAlarmMetricDataQueryLabel
     , fmap (("MetricStat",) . toJSON) _cloudWatchAlarmMetricDataQueryMetricStat
-    , fmap (("ReturnData",) . toJSON . fmap Bool') _cloudWatchAlarmMetricDataQueryReturnData
+    , fmap (("ReturnData",) . toJSON) _cloudWatchAlarmMetricDataQueryReturnData
     ]
 
 -- | Constructor for 'CloudWatchAlarmMetricDataQuery' containing required

--- a/library-gen/Stratosphere/ResourceProperties/CloudWatchAlarmMetricStat.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CloudWatchAlarmMetricStat.hs
@@ -25,7 +25,7 @@ instance ToJSON CloudWatchAlarmMetricStat where
     object $
     catMaybes
     [ (Just . ("Metric",) . toJSON) _cloudWatchAlarmMetricStatMetric
-    , (Just . ("Period",) . toJSON . fmap Integer') _cloudWatchAlarmMetricStatPeriod
+    , (Just . ("Period",) . toJSON) _cloudWatchAlarmMetricStatPeriod
     , (Just . ("Stat",) . toJSON) _cloudWatchAlarmMetricStatStat
     , fmap (("Unit",) . toJSON) _cloudWatchAlarmMetricStatUnit
     ]

--- a/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectArtifacts.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectArtifacts.hs
@@ -30,11 +30,11 @@ instance ToJSON CodeBuildProjectArtifacts where
     object $
     catMaybes
     [ fmap (("ArtifactIdentifier",) . toJSON) _codeBuildProjectArtifactsArtifactIdentifier
-    , fmap (("EncryptionDisabled",) . toJSON . fmap Bool') _codeBuildProjectArtifactsEncryptionDisabled
+    , fmap (("EncryptionDisabled",) . toJSON) _codeBuildProjectArtifactsEncryptionDisabled
     , fmap (("Location",) . toJSON) _codeBuildProjectArtifactsLocation
     , fmap (("Name",) . toJSON) _codeBuildProjectArtifactsName
     , fmap (("NamespaceType",) . toJSON) _codeBuildProjectArtifactsNamespaceType
-    , fmap (("OverrideArtifactName",) . toJSON . fmap Bool') _codeBuildProjectArtifactsOverrideArtifactName
+    , fmap (("OverrideArtifactName",) . toJSON) _codeBuildProjectArtifactsOverrideArtifactName
     , fmap (("Packaging",) . toJSON) _codeBuildProjectArtifactsPackaging
     , fmap (("Path",) . toJSON) _codeBuildProjectArtifactsPath
     , (Just . ("Type",) . toJSON) _codeBuildProjectArtifactsType

--- a/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectEnvironment.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectEnvironment.hs
@@ -34,7 +34,7 @@ instance ToJSON CodeBuildProjectEnvironment where
     , fmap (("EnvironmentVariables",) . toJSON) _codeBuildProjectEnvironmentEnvironmentVariables
     , (Just . ("Image",) . toJSON) _codeBuildProjectEnvironmentImage
     , fmap (("ImagePullCredentialsType",) . toJSON) _codeBuildProjectEnvironmentImagePullCredentialsType
-    , fmap (("PrivilegedMode",) . toJSON . fmap Bool') _codeBuildProjectEnvironmentPrivilegedMode
+    , fmap (("PrivilegedMode",) . toJSON) _codeBuildProjectEnvironmentPrivilegedMode
     , fmap (("RegistryCredential",) . toJSON) _codeBuildProjectEnvironmentRegistryCredential
     , (Just . ("Type",) . toJSON) _codeBuildProjectEnvironmentType
     ]

--- a/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectProjectTriggers.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectProjectTriggers.hs
@@ -21,7 +21,7 @@ instance ToJSON CodeBuildProjectProjectTriggers where
   toJSON CodeBuildProjectProjectTriggers{..} =
     object $
     catMaybes
-    [ fmap (("Webhook",) . toJSON . fmap Bool') _codeBuildProjectProjectTriggersWebhook
+    [ fmap (("Webhook",) . toJSON) _codeBuildProjectProjectTriggersWebhook
     ]
 
 -- | Constructor for 'CodeBuildProjectProjectTriggers' containing required

--- a/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectSource.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectSource.hs
@@ -30,10 +30,10 @@ instance ToJSON CodeBuildProjectSource where
     catMaybes
     [ fmap (("Auth",) . toJSON) _codeBuildProjectSourceAuth
     , fmap (("BuildSpec",) . toJSON) _codeBuildProjectSourceBuildSpec
-    , fmap (("GitCloneDepth",) . toJSON . fmap Integer') _codeBuildProjectSourceGitCloneDepth
-    , fmap (("InsecureSsl",) . toJSON . fmap Bool') _codeBuildProjectSourceInsecureSsl
+    , fmap (("GitCloneDepth",) . toJSON) _codeBuildProjectSourceGitCloneDepth
+    , fmap (("InsecureSsl",) . toJSON) _codeBuildProjectSourceInsecureSsl
     , fmap (("Location",) . toJSON) _codeBuildProjectSourceLocation
-    , fmap (("ReportBuildStatus",) . toJSON . fmap Bool') _codeBuildProjectSourceReportBuildStatus
+    , fmap (("ReportBuildStatus",) . toJSON) _codeBuildProjectSourceReportBuildStatus
     , fmap (("SourceIdentifier",) . toJSON) _codeBuildProjectSourceSourceIdentifier
     , (Just . ("Type",) . toJSON) _codeBuildProjectSourceType
     ]

--- a/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectWebhookFilter.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeBuildProjectWebhookFilter.hs
@@ -23,7 +23,7 @@ instance ToJSON CodeBuildProjectWebhookFilter where
   toJSON CodeBuildProjectWebhookFilter{..} =
     object $
     catMaybes
-    [ fmap (("ExcludeMatchedPattern",) . toJSON . fmap Bool') _codeBuildProjectWebhookFilterExcludeMatchedPattern
+    [ fmap (("ExcludeMatchedPattern",) . toJSON) _codeBuildProjectWebhookFilterExcludeMatchedPattern
     , (Just . ("Pattern",) . toJSON) _codeBuildProjectWebhookFilterPattern
     , (Just . ("Type",) . toJSON) _codeBuildProjectWebhookFilterType
     ]

--- a/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentConfigMinimumHealthyHosts.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentConfigMinimumHealthyHosts.hs
@@ -25,7 +25,7 @@ instance ToJSON CodeDeployDeploymentConfigMinimumHealthyHosts where
     object $
     catMaybes
     [ (Just . ("Type",) . toJSON) _codeDeployDeploymentConfigMinimumHealthyHostsType
-    , (Just . ("Value",) . toJSON . fmap Integer') _codeDeployDeploymentConfigMinimumHealthyHostsValue
+    , (Just . ("Value",) . toJSON) _codeDeployDeploymentConfigMinimumHealthyHostsValue
     ]
 
 -- | Constructor for 'CodeDeployDeploymentConfigMinimumHealthyHosts'

--- a/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupAlarmConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupAlarmConfiguration.hs
@@ -26,8 +26,8 @@ instance ToJSON CodeDeployDeploymentGroupAlarmConfiguration where
     object $
     catMaybes
     [ fmap (("Alarms",) . toJSON) _codeDeployDeploymentGroupAlarmConfigurationAlarms
-    , fmap (("Enabled",) . toJSON . fmap Bool') _codeDeployDeploymentGroupAlarmConfigurationEnabled
-    , fmap (("IgnorePollAlarmFailure",) . toJSON . fmap Bool') _codeDeployDeploymentGroupAlarmConfigurationIgnorePollAlarmFailure
+    , fmap (("Enabled",) . toJSON) _codeDeployDeploymentGroupAlarmConfigurationEnabled
+    , fmap (("IgnorePollAlarmFailure",) . toJSON) _codeDeployDeploymentGroupAlarmConfigurationIgnorePollAlarmFailure
     ]
 
 -- | Constructor for 'CodeDeployDeploymentGroupAlarmConfiguration' containing

--- a/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupAutoRollbackConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupAutoRollbackConfiguration.hs
@@ -24,7 +24,7 @@ instance ToJSON CodeDeployDeploymentGroupAutoRollbackConfiguration where
   toJSON CodeDeployDeploymentGroupAutoRollbackConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("Enabled",) . toJSON . fmap Bool') _codeDeployDeploymentGroupAutoRollbackConfigurationEnabled
+    [ fmap (("Enabled",) . toJSON) _codeDeployDeploymentGroupAutoRollbackConfigurationEnabled
     , fmap (("Events",) . toJSON) _codeDeployDeploymentGroupAutoRollbackConfigurationEvents
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupDeployment.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodeDeployDeploymentGroupDeployment.hs
@@ -24,7 +24,7 @@ instance ToJSON CodeDeployDeploymentGroupDeployment where
     object $
     catMaybes
     [ fmap (("Description",) . toJSON) _codeDeployDeploymentGroupDeploymentDescription
-    , fmap (("IgnoreApplicationStopFailures",) . toJSON . fmap Bool') _codeDeployDeploymentGroupDeploymentIgnoreApplicationStopFailures
+    , fmap (("IgnoreApplicationStopFailures",) . toJSON) _codeDeployDeploymentGroupDeploymentIgnoreApplicationStopFailures
     , (Just . ("Revision",) . toJSON) _codeDeployDeploymentGroupDeploymentRevision
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CodePipelineCustomActionTypeArtifactDetails.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodePipelineCustomActionTypeArtifactDetails.hs
@@ -24,8 +24,8 @@ instance ToJSON CodePipelineCustomActionTypeArtifactDetails where
   toJSON CodePipelineCustomActionTypeArtifactDetails{..} =
     object $
     catMaybes
-    [ (Just . ("MaximumCount",) . toJSON . fmap Integer') _codePipelineCustomActionTypeArtifactDetailsMaximumCount
-    , (Just . ("MinimumCount",) . toJSON . fmap Integer') _codePipelineCustomActionTypeArtifactDetailsMinimumCount
+    [ (Just . ("MaximumCount",) . toJSON) _codePipelineCustomActionTypeArtifactDetailsMaximumCount
+    , (Just . ("MinimumCount",) . toJSON) _codePipelineCustomActionTypeArtifactDetailsMinimumCount
     ]
 
 -- | Constructor for 'CodePipelineCustomActionTypeArtifactDetails' containing

--- a/library-gen/Stratosphere/ResourceProperties/CodePipelineCustomActionTypeConfigurationProperties.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodePipelineCustomActionTypeConfigurationProperties.hs
@@ -30,11 +30,11 @@ instance ToJSON CodePipelineCustomActionTypeConfigurationProperties where
     object $
     catMaybes
     [ fmap (("Description",) . toJSON) _codePipelineCustomActionTypeConfigurationPropertiesDescription
-    , (Just . ("Key",) . toJSON . fmap Bool') _codePipelineCustomActionTypeConfigurationPropertiesKey
+    , (Just . ("Key",) . toJSON) _codePipelineCustomActionTypeConfigurationPropertiesKey
     , (Just . ("Name",) . toJSON) _codePipelineCustomActionTypeConfigurationPropertiesName
-    , fmap (("Queryable",) . toJSON . fmap Bool') _codePipelineCustomActionTypeConfigurationPropertiesQueryable
-    , (Just . ("Required",) . toJSON . fmap Bool') _codePipelineCustomActionTypeConfigurationPropertiesRequired
-    , (Just . ("Secret",) . toJSON . fmap Bool') _codePipelineCustomActionTypeConfigurationPropertiesSecret
+    , fmap (("Queryable",) . toJSON) _codePipelineCustomActionTypeConfigurationPropertiesQueryable
+    , (Just . ("Required",) . toJSON) _codePipelineCustomActionTypeConfigurationPropertiesRequired
+    , (Just . ("Secret",) . toJSON) _codePipelineCustomActionTypeConfigurationPropertiesSecret
     , fmap (("Type",) . toJSON) _codePipelineCustomActionTypeConfigurationPropertiesType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/CodePipelinePipelineActionDeclaration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CodePipelinePipelineActionDeclaration.hs
@@ -38,7 +38,7 @@ instance ToJSON CodePipelinePipelineActionDeclaration where
     , fmap (("OutputArtifacts",) . toJSON) _codePipelinePipelineActionDeclarationOutputArtifacts
     , fmap (("Region",) . toJSON) _codePipelinePipelineActionDeclarationRegion
     , fmap (("RoleArn",) . toJSON) _codePipelinePipelineActionDeclarationRoleArn
-    , fmap (("RunOrder",) . toJSON . fmap Integer') _codePipelinePipelineActionDeclarationRunOrder
+    , fmap (("RunOrder",) . toJSON) _codePipelinePipelineActionDeclarationRunOrder
     ]
 
 -- | Constructor for 'CodePipelinePipelineActionDeclaration' containing

--- a/library-gen/Stratosphere/ResourceProperties/CognitoIdentityPoolCognitoIdentityProvider.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CognitoIdentityPoolCognitoIdentityProvider.hs
@@ -26,7 +26,7 @@ instance ToJSON CognitoIdentityPoolCognitoIdentityProvider where
     catMaybes
     [ fmap (("ClientId",) . toJSON) _cognitoIdentityPoolCognitoIdentityProviderClientId
     , fmap (("ProviderName",) . toJSON) _cognitoIdentityPoolCognitoIdentityProviderProviderName
-    , fmap (("ServerSideTokenCheck",) . toJSON . fmap Bool') _cognitoIdentityPoolCognitoIdentityProviderServerSideTokenCheck
+    , fmap (("ServerSideTokenCheck",) . toJSON) _cognitoIdentityPoolCognitoIdentityProviderServerSideTokenCheck
     ]
 
 -- | Constructor for 'CognitoIdentityPoolCognitoIdentityProvider' containing

--- a/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolAdminCreateUserConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolAdminCreateUserConfig.hs
@@ -23,9 +23,9 @@ instance ToJSON CognitoUserPoolAdminCreateUserConfig where
   toJSON CognitoUserPoolAdminCreateUserConfig{..} =
     object $
     catMaybes
-    [ fmap (("AllowAdminCreateUserOnly",) . toJSON . fmap Bool') _cognitoUserPoolAdminCreateUserConfigAllowAdminCreateUserOnly
+    [ fmap (("AllowAdminCreateUserOnly",) . toJSON) _cognitoUserPoolAdminCreateUserConfigAllowAdminCreateUserOnly
     , fmap (("InviteMessageTemplate",) . toJSON) _cognitoUserPoolAdminCreateUserConfigInviteMessageTemplate
-    , fmap (("UnusedAccountValidityDays",) . toJSON . fmap Double') _cognitoUserPoolAdminCreateUserConfigUnusedAccountValidityDays
+    , fmap (("UnusedAccountValidityDays",) . toJSON) _cognitoUserPoolAdminCreateUserConfigUnusedAccountValidityDays
     ]
 
 -- | Constructor for 'CognitoUserPoolAdminCreateUserConfig' containing

--- a/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolDeviceConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolDeviceConfiguration.hs
@@ -22,8 +22,8 @@ instance ToJSON CognitoUserPoolDeviceConfiguration where
   toJSON CognitoUserPoolDeviceConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("ChallengeRequiredOnNewDevice",) . toJSON . fmap Bool') _cognitoUserPoolDeviceConfigurationChallengeRequiredOnNewDevice
-    , fmap (("DeviceOnlyRememberedOnUserPrompt",) . toJSON . fmap Bool') _cognitoUserPoolDeviceConfigurationDeviceOnlyRememberedOnUserPrompt
+    [ fmap (("ChallengeRequiredOnNewDevice",) . toJSON) _cognitoUserPoolDeviceConfigurationChallengeRequiredOnNewDevice
+    , fmap (("DeviceOnlyRememberedOnUserPrompt",) . toJSON) _cognitoUserPoolDeviceConfigurationDeviceOnlyRememberedOnUserPrompt
     ]
 
 -- | Constructor for 'CognitoUserPoolDeviceConfiguration' containing required

--- a/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolPasswordPolicy.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolPasswordPolicy.hs
@@ -25,11 +25,11 @@ instance ToJSON CognitoUserPoolPasswordPolicy where
   toJSON CognitoUserPoolPasswordPolicy{..} =
     object $
     catMaybes
-    [ fmap (("MinimumLength",) . toJSON . fmap Integer') _cognitoUserPoolPasswordPolicyMinimumLength
-    , fmap (("RequireLowercase",) . toJSON . fmap Bool') _cognitoUserPoolPasswordPolicyRequireLowercase
-    , fmap (("RequireNumbers",) . toJSON . fmap Bool') _cognitoUserPoolPasswordPolicyRequireNumbers
-    , fmap (("RequireSymbols",) . toJSON . fmap Bool') _cognitoUserPoolPasswordPolicyRequireSymbols
-    , fmap (("RequireUppercase",) . toJSON . fmap Bool') _cognitoUserPoolPasswordPolicyRequireUppercase
+    [ fmap (("MinimumLength",) . toJSON) _cognitoUserPoolPasswordPolicyMinimumLength
+    , fmap (("RequireLowercase",) . toJSON) _cognitoUserPoolPasswordPolicyRequireLowercase
+    , fmap (("RequireNumbers",) . toJSON) _cognitoUserPoolPasswordPolicyRequireNumbers
+    , fmap (("RequireSymbols",) . toJSON) _cognitoUserPoolPasswordPolicyRequireSymbols
+    , fmap (("RequireUppercase",) . toJSON) _cognitoUserPoolPasswordPolicyRequireUppercase
     ]
 
 -- | Constructor for 'CognitoUserPoolPasswordPolicy' containing required

--- a/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolSchemaAttribute.hs
+++ b/library-gen/Stratosphere/ResourceProperties/CognitoUserPoolSchemaAttribute.hs
@@ -29,11 +29,11 @@ instance ToJSON CognitoUserPoolSchemaAttribute where
     object $
     catMaybes
     [ fmap (("AttributeDataType",) . toJSON) _cognitoUserPoolSchemaAttributeAttributeDataType
-    , fmap (("DeveloperOnlyAttribute",) . toJSON . fmap Bool') _cognitoUserPoolSchemaAttributeDeveloperOnlyAttribute
-    , fmap (("Mutable",) . toJSON . fmap Bool') _cognitoUserPoolSchemaAttributeMutable
+    , fmap (("DeveloperOnlyAttribute",) . toJSON) _cognitoUserPoolSchemaAttributeDeveloperOnlyAttribute
+    , fmap (("Mutable",) . toJSON) _cognitoUserPoolSchemaAttributeMutable
     , fmap (("Name",) . toJSON) _cognitoUserPoolSchemaAttributeName
     , fmap (("NumberAttributeConstraints",) . toJSON) _cognitoUserPoolSchemaAttributeNumberAttributeConstraints
-    , fmap (("Required",) . toJSON . fmap Bool') _cognitoUserPoolSchemaAttributeRequired
+    , fmap (("Required",) . toJSON) _cognitoUserPoolSchemaAttributeRequired
     , fmap (("StringAttributeConstraints",) . toJSON) _cognitoUserPoolSchemaAttributeStringAttributeConstraints
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationAggregatorAccountAggregationSource.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationAggregatorAccountAggregationSource.hs
@@ -26,7 +26,7 @@ instance ToJSON ConfigConfigurationAggregatorAccountAggregationSource where
     object $
     catMaybes
     [ (Just . ("AccountIds",) . toJSON) _configConfigurationAggregatorAccountAggregationSourceAccountIds
-    , fmap (("AllAwsRegions",) . toJSON . fmap Bool') _configConfigurationAggregatorAccountAggregationSourceAllAwsRegions
+    , fmap (("AllAwsRegions",) . toJSON) _configConfigurationAggregatorAccountAggregationSourceAllAwsRegions
     , fmap (("AwsRegions",) . toJSON) _configConfigurationAggregatorAccountAggregationSourceAwsRegions
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationAggregatorOrganizationAggregationSource.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationAggregatorOrganizationAggregationSource.hs
@@ -25,7 +25,7 @@ instance ToJSON ConfigConfigurationAggregatorOrganizationAggregationSource where
   toJSON ConfigConfigurationAggregatorOrganizationAggregationSource{..} =
     object $
     catMaybes
-    [ fmap (("AllAwsRegions",) . toJSON . fmap Bool') _configConfigurationAggregatorOrganizationAggregationSourceAllAwsRegions
+    [ fmap (("AllAwsRegions",) . toJSON) _configConfigurationAggregatorOrganizationAggregationSourceAllAwsRegions
     , fmap (("AwsRegions",) . toJSON) _configConfigurationAggregatorOrganizationAggregationSourceAwsRegions
     , (Just . ("RoleArn",) . toJSON) _configConfigurationAggregatorOrganizationAggregationSourceRoleArn
     ]

--- a/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationRecorderRecordingGroup.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ConfigConfigurationRecorderRecordingGroup.hs
@@ -24,8 +24,8 @@ instance ToJSON ConfigConfigurationRecorderRecordingGroup where
   toJSON ConfigConfigurationRecorderRecordingGroup{..} =
     object $
     catMaybes
-    [ fmap (("AllSupported",) . toJSON . fmap Bool') _configConfigurationRecorderRecordingGroupAllSupported
-    , fmap (("IncludeGlobalResourceTypes",) . toJSON . fmap Bool') _configConfigurationRecorderRecordingGroupIncludeGlobalResourceTypes
+    [ fmap (("AllSupported",) . toJSON) _configConfigurationRecorderRecordingGroupAllSupported
+    , fmap (("IncludeGlobalResourceTypes",) . toJSON) _configConfigurationRecorderRecordingGroupIncludeGlobalResourceTypes
     , fmap (("ResourceTypes",) . toJSON) _configConfigurationRecorderRecordingGroupResourceTypes
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/DAXClusterSSESpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DAXClusterSSESpecification.hs
@@ -21,7 +21,7 @@ instance ToJSON DAXClusterSSESpecification where
   toJSON DAXClusterSSESpecification{..} =
     object $
     catMaybes
-    [ fmap (("SSEEnabled",) . toJSON . fmap Bool') _dAXClusterSSESpecificationSSEEnabled
+    [ fmap (("SSEEnabled",) . toJSON) _dAXClusterSSESpecificationSSEEnabled
     ]
 
 -- | Constructor for 'DAXClusterSSESpecification' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/DLMLifecyclePolicyCreateRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DLMLifecyclePolicyCreateRule.hs
@@ -23,7 +23,7 @@ instance ToJSON DLMLifecyclePolicyCreateRule where
   toJSON DLMLifecyclePolicyCreateRule{..} =
     object $
     catMaybes
-    [ (Just . ("Interval",) . toJSON . fmap Integer') _dLMLifecyclePolicyCreateRuleInterval
+    [ (Just . ("Interval",) . toJSON) _dLMLifecyclePolicyCreateRuleInterval
     , (Just . ("IntervalUnit",) . toJSON) _dLMLifecyclePolicyCreateRuleIntervalUnit
     , fmap (("Times",) . toJSON) _dLMLifecyclePolicyCreateRuleTimes
     ]

--- a/library-gen/Stratosphere/ResourceProperties/DLMLifecyclePolicyRetainRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DLMLifecyclePolicyRetainRule.hs
@@ -21,7 +21,7 @@ instance ToJSON DLMLifecyclePolicyRetainRule where
   toJSON DLMLifecyclePolicyRetainRule{..} =
     object $
     catMaybes
-    [ (Just . ("Count",) . toJSON . fmap Integer') _dLMLifecyclePolicyRetainRuleCount
+    [ (Just . ("Count",) . toJSON) _dLMLifecyclePolicyRetainRuleCount
     ]
 
 -- | Constructor for 'DLMLifecyclePolicyRetainRule' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/DLMLifecyclePolicySchedule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DLMLifecyclePolicySchedule.hs
@@ -27,7 +27,7 @@ instance ToJSON DLMLifecyclePolicySchedule where
   toJSON DLMLifecyclePolicySchedule{..} =
     object $
     catMaybes
-    [ fmap (("CopyTags",) . toJSON . fmap Bool') _dLMLifecyclePolicyScheduleCopyTags
+    [ fmap (("CopyTags",) . toJSON) _dLMLifecyclePolicyScheduleCopyTags
     , fmap (("CreateRule",) . toJSON) _dLMLifecyclePolicyScheduleCreateRule
     , fmap (("Name",) . toJSON) _dLMLifecyclePolicyScheduleName
     , fmap (("RetainRule",) . toJSON) _dLMLifecyclePolicyScheduleRetainRule

--- a/library-gen/Stratosphere/ResourceProperties/DMSEndpointElasticsearchSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DMSEndpointElasticsearchSettings.hs
@@ -25,8 +25,8 @@ instance ToJSON DMSEndpointElasticsearchSettings where
     object $
     catMaybes
     [ fmap (("EndpointUri",) . toJSON) _dMSEndpointElasticsearchSettingsEndpointUri
-    , fmap (("ErrorRetryDuration",) . toJSON . fmap Integer') _dMSEndpointElasticsearchSettingsErrorRetryDuration
-    , fmap (("FullLoadErrorPercentage",) . toJSON . fmap Integer') _dMSEndpointElasticsearchSettingsFullLoadErrorPercentage
+    , fmap (("ErrorRetryDuration",) . toJSON) _dMSEndpointElasticsearchSettingsErrorRetryDuration
+    , fmap (("FullLoadErrorPercentage",) . toJSON) _dMSEndpointElasticsearchSettingsFullLoadErrorPercentage
     , fmap (("ServiceAccessRoleArn",) . toJSON) _dMSEndpointElasticsearchSettingsServiceAccessRoleArn
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/DMSEndpointMongoDbSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DMSEndpointMongoDbSettings.hs
@@ -39,7 +39,7 @@ instance ToJSON DMSEndpointMongoDbSettings where
     , fmap (("ExtractDocId",) . toJSON) _dMSEndpointMongoDbSettingsExtractDocId
     , fmap (("NestingLevel",) . toJSON) _dMSEndpointMongoDbSettingsNestingLevel
     , fmap (("Password",) . toJSON) _dMSEndpointMongoDbSettingsPassword
-    , fmap (("Port",) . toJSON . fmap Integer') _dMSEndpointMongoDbSettingsPort
+    , fmap (("Port",) . toJSON) _dMSEndpointMongoDbSettingsPort
     , fmap (("ServerName",) . toJSON) _dMSEndpointMongoDbSettingsServerName
     , fmap (("Username",) . toJSON) _dMSEndpointMongoDbSettingsUsername
     ]

--- a/library-gen/Stratosphere/ResourceProperties/DynamoDBTablePointInTimeRecoverySpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DynamoDBTablePointInTimeRecoverySpecification.hs
@@ -23,7 +23,7 @@ instance ToJSON DynamoDBTablePointInTimeRecoverySpecification where
   toJSON DynamoDBTablePointInTimeRecoverySpecification{..} =
     object $
     catMaybes
-    [ fmap (("PointInTimeRecoveryEnabled",) . toJSON . fmap Bool') _dynamoDBTablePointInTimeRecoverySpecificationPointInTimeRecoveryEnabled
+    [ fmap (("PointInTimeRecoveryEnabled",) . toJSON) _dynamoDBTablePointInTimeRecoverySpecificationPointInTimeRecoveryEnabled
     ]
 
 -- | Constructor for 'DynamoDBTablePointInTimeRecoverySpecification'

--- a/library-gen/Stratosphere/ResourceProperties/DynamoDBTableProvisionedThroughput.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DynamoDBTableProvisionedThroughput.hs
@@ -22,8 +22,8 @@ instance ToJSON DynamoDBTableProvisionedThroughput where
   toJSON DynamoDBTableProvisionedThroughput{..} =
     object $
     catMaybes
-    [ (Just . ("ReadCapacityUnits",) . toJSON . fmap Integer') _dynamoDBTableProvisionedThroughputReadCapacityUnits
-    , (Just . ("WriteCapacityUnits",) . toJSON . fmap Integer') _dynamoDBTableProvisionedThroughputWriteCapacityUnits
+    [ (Just . ("ReadCapacityUnits",) . toJSON) _dynamoDBTableProvisionedThroughputReadCapacityUnits
+    , (Just . ("WriteCapacityUnits",) . toJSON) _dynamoDBTableProvisionedThroughputWriteCapacityUnits
     ]
 
 -- | Constructor for 'DynamoDBTableProvisionedThroughput' containing required

--- a/library-gen/Stratosphere/ResourceProperties/DynamoDBTableSSESpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DynamoDBTableSSESpecification.hs
@@ -21,7 +21,7 @@ instance ToJSON DynamoDBTableSSESpecification where
   toJSON DynamoDBTableSSESpecification{..} =
     object $
     catMaybes
-    [ (Just . ("SSEEnabled",) . toJSON . fmap Bool') _dynamoDBTableSSESpecificationSSEEnabled
+    [ (Just . ("SSEEnabled",) . toJSON) _dynamoDBTableSSESpecificationSSEEnabled
     ]
 
 -- | Constructor for 'DynamoDBTableSSESpecification' containing required

--- a/library-gen/Stratosphere/ResourceProperties/DynamoDBTableTimeToLiveSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/DynamoDBTableTimeToLiveSpecification.hs
@@ -23,7 +23,7 @@ instance ToJSON DynamoDBTableTimeToLiveSpecification where
     object $
     catMaybes
     [ (Just . ("AttributeName",) . toJSON) _dynamoDBTableTimeToLiveSpecificationAttributeName
-    , (Just . ("Enabled",) . toJSON . fmap Bool') _dynamoDBTableTimeToLiveSpecificationEnabled
+    , (Just . ("Enabled",) . toJSON) _dynamoDBTableTimeToLiveSpecificationEnabled
     ]
 
 -- | Constructor for 'DynamoDBTableTimeToLiveSpecification' containing

--- a/library-gen/Stratosphere/ResourceProperties/EC2EC2FleetFleetLaunchTemplateOverridesRequest.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2EC2FleetFleetLaunchTemplateOverridesRequest.hs
@@ -31,9 +31,9 @@ instance ToJSON EC2EC2FleetFleetLaunchTemplateOverridesRequest where
     [ fmap (("AvailabilityZone",) . toJSON) _eC2EC2FleetFleetLaunchTemplateOverridesRequestAvailabilityZone
     , fmap (("InstanceType",) . toJSON) _eC2EC2FleetFleetLaunchTemplateOverridesRequestInstanceType
     , fmap (("MaxPrice",) . toJSON) _eC2EC2FleetFleetLaunchTemplateOverridesRequestMaxPrice
-    , fmap (("Priority",) . toJSON . fmap Double') _eC2EC2FleetFleetLaunchTemplateOverridesRequestPriority
+    , fmap (("Priority",) . toJSON) _eC2EC2FleetFleetLaunchTemplateOverridesRequestPriority
     , fmap (("SubnetId",) . toJSON) _eC2EC2FleetFleetLaunchTemplateOverridesRequestSubnetId
-    , fmap (("WeightedCapacity",) . toJSON . fmap Double') _eC2EC2FleetFleetLaunchTemplateOverridesRequestWeightedCapacity
+    , fmap (("WeightedCapacity",) . toJSON) _eC2EC2FleetFleetLaunchTemplateOverridesRequestWeightedCapacity
     ]
 
 -- | Constructor for 'EC2EC2FleetFleetLaunchTemplateOverridesRequest'

--- a/library-gen/Stratosphere/ResourceProperties/EC2EC2FleetSpotOptionsRequest.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2EC2FleetSpotOptionsRequest.hs
@@ -25,7 +25,7 @@ instance ToJSON EC2EC2FleetSpotOptionsRequest where
     catMaybes
     [ fmap (("AllocationStrategy",) . toJSON) _eC2EC2FleetSpotOptionsRequestAllocationStrategy
     , fmap (("InstanceInterruptionBehavior",) . toJSON) _eC2EC2FleetSpotOptionsRequestInstanceInterruptionBehavior
-    , fmap (("InstancePoolsToUseCount",) . toJSON . fmap Integer') _eC2EC2FleetSpotOptionsRequestInstancePoolsToUseCount
+    , fmap (("InstancePoolsToUseCount",) . toJSON) _eC2EC2FleetSpotOptionsRequestInstancePoolsToUseCount
     ]
 
 -- | Constructor for 'EC2EC2FleetSpotOptionsRequest' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EC2EC2FleetTargetCapacitySpecificationRequest.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2EC2FleetTargetCapacitySpecificationRequest.hs
@@ -27,9 +27,9 @@ instance ToJSON EC2EC2FleetTargetCapacitySpecificationRequest where
     object $
     catMaybes
     [ fmap (("DefaultTargetCapacityType",) . toJSON) _eC2EC2FleetTargetCapacitySpecificationRequestDefaultTargetCapacityType
-    , fmap (("OnDemandTargetCapacity",) . toJSON . fmap Integer') _eC2EC2FleetTargetCapacitySpecificationRequestOnDemandTargetCapacity
-    , fmap (("SpotTargetCapacity",) . toJSON . fmap Integer') _eC2EC2FleetTargetCapacitySpecificationRequestSpotTargetCapacity
-    , (Just . ("TotalTargetCapacity",) . toJSON . fmap Integer') _eC2EC2FleetTargetCapacitySpecificationRequestTotalTargetCapacity
+    , fmap (("OnDemandTargetCapacity",) . toJSON) _eC2EC2FleetTargetCapacitySpecificationRequestOnDemandTargetCapacity
+    , fmap (("SpotTargetCapacity",) . toJSON) _eC2EC2FleetTargetCapacitySpecificationRequestSpotTargetCapacity
+    , (Just . ("TotalTargetCapacity",) . toJSON) _eC2EC2FleetTargetCapacitySpecificationRequestTotalTargetCapacity
     ]
 
 -- | Constructor for 'EC2EC2FleetTargetCapacitySpecificationRequest'

--- a/library-gen/Stratosphere/ResourceProperties/EC2InstanceEbs.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2InstanceEbs.hs
@@ -26,11 +26,11 @@ instance ToJSON EC2InstanceEbs where
   toJSON EC2InstanceEbs{..} =
     object $
     catMaybes
-    [ fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _eC2InstanceEbsDeleteOnTermination
-    , fmap (("Encrypted",) . toJSON . fmap Bool') _eC2InstanceEbsEncrypted
-    , fmap (("Iops",) . toJSON . fmap Integer') _eC2InstanceEbsIops
+    [ fmap (("DeleteOnTermination",) . toJSON) _eC2InstanceEbsDeleteOnTermination
+    , fmap (("Encrypted",) . toJSON) _eC2InstanceEbsEncrypted
+    , fmap (("Iops",) . toJSON) _eC2InstanceEbsIops
     , fmap (("SnapshotId",) . toJSON) _eC2InstanceEbsSnapshotId
-    , fmap (("VolumeSize",) . toJSON . fmap Integer') _eC2InstanceEbsVolumeSize
+    , fmap (("VolumeSize",) . toJSON) _eC2InstanceEbsVolumeSize
     , fmap (("VolumeType",) . toJSON) _eC2InstanceEbsVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2InstanceNetworkInterface.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2InstanceNetworkInterface.hs
@@ -33,17 +33,17 @@ instance ToJSON EC2InstanceNetworkInterface where
   toJSON EC2InstanceNetworkInterface{..} =
     object $
     catMaybes
-    [ fmap (("AssociatePublicIpAddress",) . toJSON . fmap Bool') _eC2InstanceNetworkInterfaceAssociatePublicIpAddress
-    , fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _eC2InstanceNetworkInterfaceDeleteOnTermination
+    [ fmap (("AssociatePublicIpAddress",) . toJSON) _eC2InstanceNetworkInterfaceAssociatePublicIpAddress
+    , fmap (("DeleteOnTermination",) . toJSON) _eC2InstanceNetworkInterfaceDeleteOnTermination
     , fmap (("Description",) . toJSON) _eC2InstanceNetworkInterfaceDescription
     , (Just . ("DeviceIndex",) . toJSON) _eC2InstanceNetworkInterfaceDeviceIndex
     , fmap (("GroupSet",) . toJSON) _eC2InstanceNetworkInterfaceGroupSet
-    , fmap (("Ipv6AddressCount",) . toJSON . fmap Integer') _eC2InstanceNetworkInterfaceIpv6AddressCount
+    , fmap (("Ipv6AddressCount",) . toJSON) _eC2InstanceNetworkInterfaceIpv6AddressCount
     , fmap (("Ipv6Addresses",) . toJSON) _eC2InstanceNetworkInterfaceIpv6Addresses
     , fmap (("NetworkInterfaceId",) . toJSON) _eC2InstanceNetworkInterfaceNetworkInterfaceId
     , fmap (("PrivateIpAddress",) . toJSON) _eC2InstanceNetworkInterfacePrivateIpAddress
     , fmap (("PrivateIpAddresses",) . toJSON) _eC2InstanceNetworkInterfacePrivateIpAddresses
-    , fmap (("SecondaryPrivateIpAddressCount",) . toJSON . fmap Integer') _eC2InstanceNetworkInterfaceSecondaryPrivateIpAddressCount
+    , fmap (("SecondaryPrivateIpAddressCount",) . toJSON) _eC2InstanceNetworkInterfaceSecondaryPrivateIpAddressCount
     , fmap (("SubnetId",) . toJSON) _eC2InstanceNetworkInterfaceSubnetId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2InstancePrivateIpAddressSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2InstancePrivateIpAddressSpecification.hs
@@ -23,7 +23,7 @@ instance ToJSON EC2InstancePrivateIpAddressSpecification where
   toJSON EC2InstancePrivateIpAddressSpecification{..} =
     object $
     catMaybes
-    [ (Just . ("Primary",) . toJSON . fmap Bool') _eC2InstancePrivateIpAddressSpecificationPrimary
+    [ (Just . ("Primary",) . toJSON) _eC2InstancePrivateIpAddressSpecificationPrimary
     , (Just . ("PrivateIpAddress",) . toJSON) _eC2InstancePrivateIpAddressSpecificationPrivateIpAddress
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateCpuOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateCpuOptions.hs
@@ -22,8 +22,8 @@ instance ToJSON EC2LaunchTemplateCpuOptions where
   toJSON EC2LaunchTemplateCpuOptions{..} =
     object $
     catMaybes
-    [ fmap (("CoreCount",) . toJSON . fmap Integer') _eC2LaunchTemplateCpuOptionsCoreCount
-    , fmap (("ThreadsPerCore",) . toJSON . fmap Integer') _eC2LaunchTemplateCpuOptionsThreadsPerCore
+    [ fmap (("CoreCount",) . toJSON) _eC2LaunchTemplateCpuOptionsCoreCount
+    , fmap (("ThreadsPerCore",) . toJSON) _eC2LaunchTemplateCpuOptionsThreadsPerCore
     ]
 
 -- | Constructor for 'EC2LaunchTemplateCpuOptions' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateEbs.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateEbs.hs
@@ -27,12 +27,12 @@ instance ToJSON EC2LaunchTemplateEbs where
   toJSON EC2LaunchTemplateEbs{..} =
     object $
     catMaybes
-    [ fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _eC2LaunchTemplateEbsDeleteOnTermination
-    , fmap (("Encrypted",) . toJSON . fmap Bool') _eC2LaunchTemplateEbsEncrypted
-    , fmap (("Iops",) . toJSON . fmap Integer') _eC2LaunchTemplateEbsIops
+    [ fmap (("DeleteOnTermination",) . toJSON) _eC2LaunchTemplateEbsDeleteOnTermination
+    , fmap (("Encrypted",) . toJSON) _eC2LaunchTemplateEbsEncrypted
+    , fmap (("Iops",) . toJSON) _eC2LaunchTemplateEbsIops
     , fmap (("KmsKeyId",) . toJSON) _eC2LaunchTemplateEbsKmsKeyId
     , fmap (("SnapshotId",) . toJSON) _eC2LaunchTemplateEbsSnapshotId
-    , fmap (("VolumeSize",) . toJSON . fmap Integer') _eC2LaunchTemplateEbsVolumeSize
+    , fmap (("VolumeSize",) . toJSON) _eC2LaunchTemplateEbsVolumeSize
     , fmap (("VolumeType",) . toJSON) _eC2LaunchTemplateEbsVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateHibernationOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateHibernationOptions.hs
@@ -21,7 +21,7 @@ instance ToJSON EC2LaunchTemplateHibernationOptions where
   toJSON EC2LaunchTemplateHibernationOptions{..} =
     object $
     catMaybes
-    [ fmap (("Configured",) . toJSON . fmap Bool') _eC2LaunchTemplateHibernationOptionsConfigured
+    [ fmap (("Configured",) . toJSON) _eC2LaunchTemplateHibernationOptionsConfigured
     ]
 
 -- | Constructor for 'EC2LaunchTemplateHibernationOptions' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateLaunchTemplateData.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateLaunchTemplateData.hs
@@ -62,8 +62,8 @@ instance ToJSON EC2LaunchTemplateLaunchTemplateData where
     , fmap (("CapacityReservationSpecification",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataCapacityReservationSpecification
     , fmap (("CpuOptions",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataCpuOptions
     , fmap (("CreditSpecification",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataCreditSpecification
-    , fmap (("DisableApiTermination",) . toJSON . fmap Bool') _eC2LaunchTemplateLaunchTemplateDataDisableApiTermination
-    , fmap (("EbsOptimized",) . toJSON . fmap Bool') _eC2LaunchTemplateLaunchTemplateDataEbsOptimized
+    , fmap (("DisableApiTermination",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataDisableApiTermination
+    , fmap (("EbsOptimized",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataEbsOptimized
     , fmap (("ElasticGpuSpecifications",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataElasticGpuSpecifications
     , fmap (("ElasticInferenceAccelerators",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataElasticInferenceAccelerators
     , fmap (("HibernationOptions",) . toJSON) _eC2LaunchTemplateLaunchTemplateDataHibernationOptions

--- a/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateMonitoring.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateMonitoring.hs
@@ -21,7 +21,7 @@ instance ToJSON EC2LaunchTemplateMonitoring where
   toJSON EC2LaunchTemplateMonitoring{..} =
     object $
     catMaybes
-    [ fmap (("Enabled",) . toJSON . fmap Bool') _eC2LaunchTemplateMonitoringEnabled
+    [ fmap (("Enabled",) . toJSON) _eC2LaunchTemplateMonitoringEnabled
     ]
 
 -- | Constructor for 'EC2LaunchTemplateMonitoring' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateNetworkInterface.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplateNetworkInterface.hs
@@ -33,17 +33,17 @@ instance ToJSON EC2LaunchTemplateNetworkInterface where
   toJSON EC2LaunchTemplateNetworkInterface{..} =
     object $
     catMaybes
-    [ fmap (("AssociatePublicIpAddress",) . toJSON . fmap Bool') _eC2LaunchTemplateNetworkInterfaceAssociatePublicIpAddress
-    , fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _eC2LaunchTemplateNetworkInterfaceDeleteOnTermination
+    [ fmap (("AssociatePublicIpAddress",) . toJSON) _eC2LaunchTemplateNetworkInterfaceAssociatePublicIpAddress
+    , fmap (("DeleteOnTermination",) . toJSON) _eC2LaunchTemplateNetworkInterfaceDeleteOnTermination
     , fmap (("Description",) . toJSON) _eC2LaunchTemplateNetworkInterfaceDescription
-    , fmap (("DeviceIndex",) . toJSON . fmap Integer') _eC2LaunchTemplateNetworkInterfaceDeviceIndex
+    , fmap (("DeviceIndex",) . toJSON) _eC2LaunchTemplateNetworkInterfaceDeviceIndex
     , fmap (("Groups",) . toJSON) _eC2LaunchTemplateNetworkInterfaceGroups
-    , fmap (("Ipv6AddressCount",) . toJSON . fmap Integer') _eC2LaunchTemplateNetworkInterfaceIpv6AddressCount
+    , fmap (("Ipv6AddressCount",) . toJSON) _eC2LaunchTemplateNetworkInterfaceIpv6AddressCount
     , fmap (("Ipv6Addresses",) . toJSON) _eC2LaunchTemplateNetworkInterfaceIpv6Addresses
     , fmap (("NetworkInterfaceId",) . toJSON) _eC2LaunchTemplateNetworkInterfaceNetworkInterfaceId
     , fmap (("PrivateIpAddress",) . toJSON) _eC2LaunchTemplateNetworkInterfacePrivateIpAddress
     , fmap (("PrivateIpAddresses",) . toJSON) _eC2LaunchTemplateNetworkInterfacePrivateIpAddresses
-    , fmap (("SecondaryPrivateIpAddressCount",) . toJSON . fmap Integer') _eC2LaunchTemplateNetworkInterfaceSecondaryPrivateIpAddressCount
+    , fmap (("SecondaryPrivateIpAddressCount",) . toJSON) _eC2LaunchTemplateNetworkInterfaceSecondaryPrivateIpAddressCount
     , fmap (("SubnetId",) . toJSON) _eC2LaunchTemplateNetworkInterfaceSubnetId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplatePrivateIpAdd.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2LaunchTemplatePrivateIpAdd.hs
@@ -22,7 +22,7 @@ instance ToJSON EC2LaunchTemplatePrivateIpAdd where
   toJSON EC2LaunchTemplatePrivateIpAdd{..} =
     object $
     catMaybes
-    [ fmap (("Primary",) . toJSON . fmap Bool') _eC2LaunchTemplatePrivateIpAddPrimary
+    [ fmap (("Primary",) . toJSON) _eC2LaunchTemplatePrivateIpAddPrimary
     , fmap (("PrivateIpAddress",) . toJSON) _eC2LaunchTemplatePrivateIpAddPrivateIpAddress
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2NetworkAclEntryIcmp.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2NetworkAclEntryIcmp.hs
@@ -22,8 +22,8 @@ instance ToJSON EC2NetworkAclEntryIcmp where
   toJSON EC2NetworkAclEntryIcmp{..} =
     object $
     catMaybes
-    [ fmap (("Code",) . toJSON . fmap Integer') _eC2NetworkAclEntryIcmpCode
-    , fmap (("Type",) . toJSON . fmap Integer') _eC2NetworkAclEntryIcmpType
+    [ fmap (("Code",) . toJSON) _eC2NetworkAclEntryIcmpCode
+    , fmap (("Type",) . toJSON) _eC2NetworkAclEntryIcmpType
     ]
 
 -- | Constructor for 'EC2NetworkAclEntryIcmp' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/EC2NetworkAclEntryPortRange.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2NetworkAclEntryPortRange.hs
@@ -22,8 +22,8 @@ instance ToJSON EC2NetworkAclEntryPortRange where
   toJSON EC2NetworkAclEntryPortRange{..} =
     object $
     catMaybes
-    [ fmap (("From",) . toJSON . fmap Integer') _eC2NetworkAclEntryPortRangeFrom
-    , fmap (("To",) . toJSON . fmap Integer') _eC2NetworkAclEntryPortRangeTo
+    [ fmap (("From",) . toJSON) _eC2NetworkAclEntryPortRangeFrom
+    , fmap (("To",) . toJSON) _eC2NetworkAclEntryPortRangeTo
     ]
 
 -- | Constructor for 'EC2NetworkAclEntryPortRange' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/EC2NetworkInterfacePrivateIpAddressSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2NetworkInterfacePrivateIpAddressSpecification.hs
@@ -24,7 +24,7 @@ instance ToJSON EC2NetworkInterfacePrivateIpAddressSpecification where
   toJSON EC2NetworkInterfacePrivateIpAddressSpecification{..} =
     object $
     catMaybes
-    [ (Just . ("Primary",) . toJSON . fmap Bool') _eC2NetworkInterfacePrivateIpAddressSpecificationPrimary
+    [ (Just . ("Primary",) . toJSON) _eC2NetworkInterfacePrivateIpAddressSpecificationPrimary
     , (Just . ("PrivateIpAddress",) . toJSON) _eC2NetworkInterfacePrivateIpAddressSpecificationPrivateIpAddress
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2SecurityGroupEgressProperty.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SecurityGroupEgressProperty.hs
@@ -33,9 +33,9 @@ instance ToJSON EC2SecurityGroupEgressProperty where
     , fmap (("Description",) . toJSON) _eC2SecurityGroupEgressPropertyDescription
     , fmap (("DestinationPrefixListId",) . toJSON) _eC2SecurityGroupEgressPropertyDestinationPrefixListId
     , fmap (("DestinationSecurityGroupId",) . toJSON) _eC2SecurityGroupEgressPropertyDestinationSecurityGroupId
-    , fmap (("FromPort",) . toJSON . fmap Integer') _eC2SecurityGroupEgressPropertyFromPort
+    , fmap (("FromPort",) . toJSON) _eC2SecurityGroupEgressPropertyFromPort
     , (Just . ("IpProtocol",) . toJSON) _eC2SecurityGroupEgressPropertyIpProtocol
-    , fmap (("ToPort",) . toJSON . fmap Integer') _eC2SecurityGroupEgressPropertyToPort
+    , fmap (("ToPort",) . toJSON) _eC2SecurityGroupEgressPropertyToPort
     ]
 
 -- | Constructor for 'EC2SecurityGroupEgressProperty' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EC2SecurityGroupIngressProperty.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SecurityGroupIngressProperty.hs
@@ -33,13 +33,13 @@ instance ToJSON EC2SecurityGroupIngressProperty where
     [ fmap (("CidrIp",) . toJSON) _eC2SecurityGroupIngressPropertyCidrIp
     , fmap (("CidrIpv6",) . toJSON) _eC2SecurityGroupIngressPropertyCidrIpv6
     , fmap (("Description",) . toJSON) _eC2SecurityGroupIngressPropertyDescription
-    , fmap (("FromPort",) . toJSON . fmap Integer') _eC2SecurityGroupIngressPropertyFromPort
+    , fmap (("FromPort",) . toJSON) _eC2SecurityGroupIngressPropertyFromPort
     , (Just . ("IpProtocol",) . toJSON) _eC2SecurityGroupIngressPropertyIpProtocol
     , fmap (("SourcePrefixListId",) . toJSON) _eC2SecurityGroupIngressPropertySourcePrefixListId
     , fmap (("SourceSecurityGroupId",) . toJSON) _eC2SecurityGroupIngressPropertySourceSecurityGroupId
     , fmap (("SourceSecurityGroupName",) . toJSON) _eC2SecurityGroupIngressPropertySourceSecurityGroupName
     , fmap (("SourceSecurityGroupOwnerId",) . toJSON) _eC2SecurityGroupIngressPropertySourceSecurityGroupOwnerId
-    , fmap (("ToPort",) . toJSON . fmap Integer') _eC2SecurityGroupIngressPropertyToPort
+    , fmap (("ToPort",) . toJSON) _eC2SecurityGroupIngressPropertyToPort
     ]
 
 -- | Constructor for 'EC2SecurityGroupIngressProperty' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetEbsBlockDevice.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetEbsBlockDevice.hs
@@ -26,11 +26,11 @@ instance ToJSON EC2SpotFleetEbsBlockDevice where
   toJSON EC2SpotFleetEbsBlockDevice{..} =
     object $
     catMaybes
-    [ fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _eC2SpotFleetEbsBlockDeviceDeleteOnTermination
-    , fmap (("Encrypted",) . toJSON . fmap Bool') _eC2SpotFleetEbsBlockDeviceEncrypted
-    , fmap (("Iops",) . toJSON . fmap Integer') _eC2SpotFleetEbsBlockDeviceIops
+    [ fmap (("DeleteOnTermination",) . toJSON) _eC2SpotFleetEbsBlockDeviceDeleteOnTermination
+    , fmap (("Encrypted",) . toJSON) _eC2SpotFleetEbsBlockDeviceEncrypted
+    , fmap (("Iops",) . toJSON) _eC2SpotFleetEbsBlockDeviceIops
     , fmap (("SnapshotId",) . toJSON) _eC2SpotFleetEbsBlockDeviceSnapshotId
-    , fmap (("VolumeSize",) . toJSON . fmap Integer') _eC2SpotFleetEbsBlockDeviceVolumeSize
+    , fmap (("VolumeSize",) . toJSON) _eC2SpotFleetEbsBlockDeviceVolumeSize
     , fmap (("VolumeType",) . toJSON) _eC2SpotFleetEbsBlockDeviceVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetInstanceNetworkInterfaceSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetInstanceNetworkInterfaceSpecification.hs
@@ -34,16 +34,16 @@ instance ToJSON EC2SpotFleetInstanceNetworkInterfaceSpecification where
   toJSON EC2SpotFleetInstanceNetworkInterfaceSpecification{..} =
     object $
     catMaybes
-    [ fmap (("AssociatePublicIpAddress",) . toJSON . fmap Bool') _eC2SpotFleetInstanceNetworkInterfaceSpecificationAssociatePublicIpAddress
-    , fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeleteOnTermination
+    [ fmap (("AssociatePublicIpAddress",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationAssociatePublicIpAddress
+    , fmap (("DeleteOnTermination",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeleteOnTermination
     , fmap (("Description",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationDescription
-    , fmap (("DeviceIndex",) . toJSON . fmap Integer') _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeviceIndex
+    , fmap (("DeviceIndex",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationDeviceIndex
     , fmap (("Groups",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationGroups
-    , fmap (("Ipv6AddressCount",) . toJSON . fmap Integer') _eC2SpotFleetInstanceNetworkInterfaceSpecificationIpv6AddressCount
+    , fmap (("Ipv6AddressCount",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationIpv6AddressCount
     , fmap (("Ipv6Addresses",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationIpv6Addresses
     , fmap (("NetworkInterfaceId",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationNetworkInterfaceId
     , fmap (("PrivateIpAddresses",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationPrivateIpAddresses
-    , fmap (("SecondaryPrivateIpAddressCount",) . toJSON . fmap Integer') _eC2SpotFleetInstanceNetworkInterfaceSpecificationSecondaryPrivateIpAddressCount
+    , fmap (("SecondaryPrivateIpAddressCount",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationSecondaryPrivateIpAddressCount
     , fmap (("SubnetId",) . toJSON) _eC2SpotFleetInstanceNetworkInterfaceSpecificationSubnetId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetLaunchTemplateOverrides.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetLaunchTemplateOverrides.hs
@@ -29,7 +29,7 @@ instance ToJSON EC2SpotFleetLaunchTemplateOverrides where
     , fmap (("InstanceType",) . toJSON) _eC2SpotFleetLaunchTemplateOverridesInstanceType
     , fmap (("SpotPrice",) . toJSON) _eC2SpotFleetLaunchTemplateOverridesSpotPrice
     , fmap (("SubnetId",) . toJSON) _eC2SpotFleetLaunchTemplateOverridesSubnetId
-    , fmap (("WeightedCapacity",) . toJSON . fmap Double') _eC2SpotFleetLaunchTemplateOverridesWeightedCapacity
+    , fmap (("WeightedCapacity",) . toJSON) _eC2SpotFleetLaunchTemplateOverridesWeightedCapacity
     ]
 
 -- | Constructor for 'EC2SpotFleetLaunchTemplateOverrides' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetPrivateIpAddressSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetPrivateIpAddressSpecification.hs
@@ -23,7 +23,7 @@ instance ToJSON EC2SpotFleetPrivateIpAddressSpecification where
   toJSON EC2SpotFleetPrivateIpAddressSpecification{..} =
     object $
     catMaybes
-    [ fmap (("Primary",) . toJSON . fmap Bool') _eC2SpotFleetPrivateIpAddressSpecificationPrimary
+    [ fmap (("Primary",) . toJSON) _eC2SpotFleetPrivateIpAddressSpecificationPrimary
     , (Just . ("PrivateIpAddress",) . toJSON) _eC2SpotFleetPrivateIpAddressSpecificationPrivateIpAddress
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetSpotFleetLaunchSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetSpotFleetLaunchSpecification.hs
@@ -45,7 +45,7 @@ instance ToJSON EC2SpotFleetSpotFleetLaunchSpecification where
     object $
     catMaybes
     [ fmap (("BlockDeviceMappings",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationBlockDeviceMappings
-    , fmap (("EbsOptimized",) . toJSON . fmap Bool') _eC2SpotFleetSpotFleetLaunchSpecificationEbsOptimized
+    , fmap (("EbsOptimized",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationEbsOptimized
     , fmap (("IamInstanceProfile",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationIamInstanceProfile
     , (Just . ("ImageId",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationImageId
     , (Just . ("InstanceType",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationInstanceType
@@ -60,7 +60,7 @@ instance ToJSON EC2SpotFleetSpotFleetLaunchSpecification where
     , fmap (("SubnetId",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationSubnetId
     , fmap (("TagSpecifications",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationTagSpecifications
     , fmap (("UserData",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationUserData
-    , fmap (("WeightedCapacity",) . toJSON . fmap Double') _eC2SpotFleetSpotFleetLaunchSpecificationWeightedCapacity
+    , fmap (("WeightedCapacity",) . toJSON) _eC2SpotFleetSpotFleetLaunchSpecificationWeightedCapacity
     ]
 
 -- | Constructor for 'EC2SpotFleetSpotFleetLaunchSpecification' containing

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetSpotFleetMonitoring.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetSpotFleetMonitoring.hs
@@ -21,7 +21,7 @@ instance ToJSON EC2SpotFleetSpotFleetMonitoring where
   toJSON EC2SpotFleetSpotFleetMonitoring{..} =
     object $
     catMaybes
-    [ fmap (("Enabled",) . toJSON . fmap Bool') _eC2SpotFleetSpotFleetMonitoringEnabled
+    [ fmap (("Enabled",) . toJSON) _eC2SpotFleetSpotFleetMonitoringEnabled
     ]
 
 -- | Constructor for 'EC2SpotFleetSpotFleetMonitoring' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetSpotFleetRequestConfigData.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EC2SpotFleetSpotFleetRequestConfigData.hs
@@ -44,10 +44,10 @@ instance ToJSON EC2SpotFleetSpotFleetRequestConfigData where
     , fmap (("LaunchSpecifications",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataLaunchSpecifications
     , fmap (("LaunchTemplateConfigs",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataLaunchTemplateConfigs
     , fmap (("LoadBalancersConfig",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataLoadBalancersConfig
-    , fmap (("ReplaceUnhealthyInstances",) . toJSON . fmap Bool') _eC2SpotFleetSpotFleetRequestConfigDataReplaceUnhealthyInstances
+    , fmap (("ReplaceUnhealthyInstances",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataReplaceUnhealthyInstances
     , fmap (("SpotPrice",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataSpotPrice
-    , (Just . ("TargetCapacity",) . toJSON . fmap Integer') _eC2SpotFleetSpotFleetRequestConfigDataTargetCapacity
-    , fmap (("TerminateInstancesWithExpiration",) . toJSON . fmap Bool') _eC2SpotFleetSpotFleetRequestConfigDataTerminateInstancesWithExpiration
+    , (Just . ("TargetCapacity",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataTargetCapacity
+    , fmap (("TerminateInstancesWithExpiration",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataTerminateInstancesWithExpiration
     , fmap (("Type",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataType
     , fmap (("ValidFrom",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataValidFrom
     , fmap (("ValidUntil",) . toJSON) _eC2SpotFleetSpotFleetRequestConfigDataValidUntil

--- a/library-gen/Stratosphere/ResourceProperties/ECSServiceDeploymentConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSServiceDeploymentConfiguration.hs
@@ -22,8 +22,8 @@ instance ToJSON ECSServiceDeploymentConfiguration where
   toJSON ECSServiceDeploymentConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("MaximumPercent",) . toJSON . fmap Integer') _eCSServiceDeploymentConfigurationMaximumPercent
-    , fmap (("MinimumHealthyPercent",) . toJSON . fmap Integer') _eCSServiceDeploymentConfigurationMinimumHealthyPercent
+    [ fmap (("MaximumPercent",) . toJSON) _eCSServiceDeploymentConfigurationMaximumPercent
+    , fmap (("MinimumHealthyPercent",) . toJSON) _eCSServiceDeploymentConfigurationMinimumHealthyPercent
     ]
 
 -- | Constructor for 'ECSServiceDeploymentConfiguration' containing required

--- a/library-gen/Stratosphere/ResourceProperties/ECSServiceLoadBalancer.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSServiceLoadBalancer.hs
@@ -25,7 +25,7 @@ instance ToJSON ECSServiceLoadBalancer where
     object $
     catMaybes
     [ fmap (("ContainerName",) . toJSON) _eCSServiceLoadBalancerContainerName
-    , (Just . ("ContainerPort",) . toJSON . fmap Integer') _eCSServiceLoadBalancerContainerPort
+    , (Just . ("ContainerPort",) . toJSON) _eCSServiceLoadBalancerContainerPort
     , fmap (("LoadBalancerName",) . toJSON) _eCSServiceLoadBalancerLoadBalancerName
     , fmap (("TargetGroupArn",) . toJSON) _eCSServiceLoadBalancerTargetGroupArn
     ]

--- a/library-gen/Stratosphere/ResourceProperties/ECSServiceServiceRegistry.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSServiceServiceRegistry.hs
@@ -25,8 +25,8 @@ instance ToJSON ECSServiceServiceRegistry where
     object $
     catMaybes
     [ fmap (("ContainerName",) . toJSON) _eCSServiceServiceRegistryContainerName
-    , fmap (("ContainerPort",) . toJSON . fmap Integer') _eCSServiceServiceRegistryContainerPort
-    , fmap (("Port",) . toJSON . fmap Integer') _eCSServiceServiceRegistryPort
+    , fmap (("ContainerPort",) . toJSON) _eCSServiceServiceRegistryContainerPort
+    , fmap (("Port",) . toJSON) _eCSServiceServiceRegistryPort
     , fmap (("RegistryArn",) . toJSON) _eCSServiceServiceRegistryRegistryArn
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionContainerDefinition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionContainerDefinition.hs
@@ -59,15 +59,15 @@ instance ToJSON ECSTaskDefinitionContainerDefinition where
     object $
     catMaybes
     [ fmap (("Command",) . toJSON) _eCSTaskDefinitionContainerDefinitionCommand
-    , fmap (("Cpu",) . toJSON . fmap Integer') _eCSTaskDefinitionContainerDefinitionCpu
-    , fmap (("DisableNetworking",) . toJSON . fmap Bool') _eCSTaskDefinitionContainerDefinitionDisableNetworking
+    , fmap (("Cpu",) . toJSON) _eCSTaskDefinitionContainerDefinitionCpu
+    , fmap (("DisableNetworking",) . toJSON) _eCSTaskDefinitionContainerDefinitionDisableNetworking
     , fmap (("DnsSearchDomains",) . toJSON) _eCSTaskDefinitionContainerDefinitionDnsSearchDomains
     , fmap (("DnsServers",) . toJSON) _eCSTaskDefinitionContainerDefinitionDnsServers
     , fmap (("DockerLabels",) . toJSON) _eCSTaskDefinitionContainerDefinitionDockerLabels
     , fmap (("DockerSecurityOptions",) . toJSON) _eCSTaskDefinitionContainerDefinitionDockerSecurityOptions
     , fmap (("EntryPoint",) . toJSON) _eCSTaskDefinitionContainerDefinitionEntryPoint
     , fmap (("Environment",) . toJSON) _eCSTaskDefinitionContainerDefinitionEnvironment
-    , fmap (("Essential",) . toJSON . fmap Bool') _eCSTaskDefinitionContainerDefinitionEssential
+    , fmap (("Essential",) . toJSON) _eCSTaskDefinitionContainerDefinitionEssential
     , fmap (("ExtraHosts",) . toJSON) _eCSTaskDefinitionContainerDefinitionExtraHosts
     , fmap (("HealthCheck",) . toJSON) _eCSTaskDefinitionContainerDefinitionHealthCheck
     , fmap (("Hostname",) . toJSON) _eCSTaskDefinitionContainerDefinitionHostname
@@ -75,13 +75,13 @@ instance ToJSON ECSTaskDefinitionContainerDefinition where
     , fmap (("Links",) . toJSON) _eCSTaskDefinitionContainerDefinitionLinks
     , fmap (("LinuxParameters",) . toJSON) _eCSTaskDefinitionContainerDefinitionLinuxParameters
     , fmap (("LogConfiguration",) . toJSON) _eCSTaskDefinitionContainerDefinitionLogConfiguration
-    , fmap (("Memory",) . toJSON . fmap Integer') _eCSTaskDefinitionContainerDefinitionMemory
-    , fmap (("MemoryReservation",) . toJSON . fmap Integer') _eCSTaskDefinitionContainerDefinitionMemoryReservation
+    , fmap (("Memory",) . toJSON) _eCSTaskDefinitionContainerDefinitionMemory
+    , fmap (("MemoryReservation",) . toJSON) _eCSTaskDefinitionContainerDefinitionMemoryReservation
     , fmap (("MountPoints",) . toJSON) _eCSTaskDefinitionContainerDefinitionMountPoints
     , (Just . ("Name",) . toJSON) _eCSTaskDefinitionContainerDefinitionName
     , fmap (("PortMappings",) . toJSON) _eCSTaskDefinitionContainerDefinitionPortMappings
-    , fmap (("Privileged",) . toJSON . fmap Bool') _eCSTaskDefinitionContainerDefinitionPrivileged
-    , fmap (("ReadonlyRootFilesystem",) . toJSON . fmap Bool') _eCSTaskDefinitionContainerDefinitionReadonlyRootFilesystem
+    , fmap (("Privileged",) . toJSON) _eCSTaskDefinitionContainerDefinitionPrivileged
+    , fmap (("ReadonlyRootFilesystem",) . toJSON) _eCSTaskDefinitionContainerDefinitionReadonlyRootFilesystem
     , fmap (("RepositoryCredentials",) . toJSON) _eCSTaskDefinitionContainerDefinitionRepositoryCredentials
     , fmap (("Ulimits",) . toJSON) _eCSTaskDefinitionContainerDefinitionUlimits
     , fmap (("User",) . toJSON) _eCSTaskDefinitionContainerDefinitionUser

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionDockerVolumeConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionDockerVolumeConfiguration.hs
@@ -26,7 +26,7 @@ instance ToJSON ECSTaskDefinitionDockerVolumeConfiguration where
   toJSON ECSTaskDefinitionDockerVolumeConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("Autoprovision",) . toJSON . fmap Bool') _eCSTaskDefinitionDockerVolumeConfigurationAutoprovision
+    [ fmap (("Autoprovision",) . toJSON) _eCSTaskDefinitionDockerVolumeConfigurationAutoprovision
     , fmap (("Driver",) . toJSON) _eCSTaskDefinitionDockerVolumeConfigurationDriver
     , fmap (("DriverOpts",) . toJSON) _eCSTaskDefinitionDockerVolumeConfigurationDriverOpts
     , fmap (("Labels",) . toJSON) _eCSTaskDefinitionDockerVolumeConfigurationLabels

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionHealthCheck.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionHealthCheck.hs
@@ -26,10 +26,10 @@ instance ToJSON ECSTaskDefinitionHealthCheck where
     object $
     catMaybes
     [ (Just . ("Command",) . toJSON) _eCSTaskDefinitionHealthCheckCommand
-    , fmap (("Interval",) . toJSON . fmap Integer') _eCSTaskDefinitionHealthCheckInterval
-    , fmap (("Retries",) . toJSON . fmap Integer') _eCSTaskDefinitionHealthCheckRetries
-    , fmap (("StartPeriod",) . toJSON . fmap Integer') _eCSTaskDefinitionHealthCheckStartPeriod
-    , fmap (("Timeout",) . toJSON . fmap Integer') _eCSTaskDefinitionHealthCheckTimeout
+    , fmap (("Interval",) . toJSON) _eCSTaskDefinitionHealthCheckInterval
+    , fmap (("Retries",) . toJSON) _eCSTaskDefinitionHealthCheckRetries
+    , fmap (("StartPeriod",) . toJSON) _eCSTaskDefinitionHealthCheckStartPeriod
+    , fmap (("Timeout",) . toJSON) _eCSTaskDefinitionHealthCheckTimeout
     ]
 
 -- | Constructor for 'ECSTaskDefinitionHealthCheck' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionLinuxParameters.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionLinuxParameters.hs
@@ -29,8 +29,8 @@ instance ToJSON ECSTaskDefinitionLinuxParameters where
     catMaybes
     [ fmap (("Capabilities",) . toJSON) _eCSTaskDefinitionLinuxParametersCapabilities
     , fmap (("Devices",) . toJSON) _eCSTaskDefinitionLinuxParametersDevices
-    , fmap (("InitProcessEnabled",) . toJSON . fmap Bool') _eCSTaskDefinitionLinuxParametersInitProcessEnabled
-    , fmap (("SharedMemorySize",) . toJSON . fmap Integer') _eCSTaskDefinitionLinuxParametersSharedMemorySize
+    , fmap (("InitProcessEnabled",) . toJSON) _eCSTaskDefinitionLinuxParametersInitProcessEnabled
+    , fmap (("SharedMemorySize",) . toJSON) _eCSTaskDefinitionLinuxParametersSharedMemorySize
     , fmap (("Tmpfs",) . toJSON) _eCSTaskDefinitionLinuxParametersTmpfs
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionMountPoint.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionMountPoint.hs
@@ -24,7 +24,7 @@ instance ToJSON ECSTaskDefinitionMountPoint where
     object $
     catMaybes
     [ fmap (("ContainerPath",) . toJSON) _eCSTaskDefinitionMountPointContainerPath
-    , fmap (("ReadOnly",) . toJSON . fmap Bool') _eCSTaskDefinitionMountPointReadOnly
+    , fmap (("ReadOnly",) . toJSON) _eCSTaskDefinitionMountPointReadOnly
     , fmap (("SourceVolume",) . toJSON) _eCSTaskDefinitionMountPointSourceVolume
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionPortMapping.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionPortMapping.hs
@@ -23,8 +23,8 @@ instance ToJSON ECSTaskDefinitionPortMapping where
   toJSON ECSTaskDefinitionPortMapping{..} =
     object $
     catMaybes
-    [ fmap (("ContainerPort",) . toJSON . fmap Integer') _eCSTaskDefinitionPortMappingContainerPort
-    , fmap (("HostPort",) . toJSON . fmap Integer') _eCSTaskDefinitionPortMappingHostPort
+    [ fmap (("ContainerPort",) . toJSON) _eCSTaskDefinitionPortMappingContainerPort
+    , fmap (("HostPort",) . toJSON) _eCSTaskDefinitionPortMappingHostPort
     , fmap (("Protocol",) . toJSON) _eCSTaskDefinitionPortMappingProtocol
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionTmpfs.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionTmpfs.hs
@@ -25,7 +25,7 @@ instance ToJSON ECSTaskDefinitionTmpfs where
     catMaybes
     [ fmap (("ContainerPath",) . toJSON) _eCSTaskDefinitionTmpfsContainerPath
     , fmap (("MountOptions",) . toJSON) _eCSTaskDefinitionTmpfsMountOptions
-    , fmap (("Size",) . toJSON . fmap Integer') _eCSTaskDefinitionTmpfsSize
+    , fmap (("Size",) . toJSON) _eCSTaskDefinitionTmpfsSize
     ]
 
 -- | Constructor for 'ECSTaskDefinitionTmpfs' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionUlimit.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionUlimit.hs
@@ -23,9 +23,9 @@ instance ToJSON ECSTaskDefinitionUlimit where
   toJSON ECSTaskDefinitionUlimit{..} =
     object $
     catMaybes
-    [ (Just . ("HardLimit",) . toJSON . fmap Integer') _eCSTaskDefinitionUlimitHardLimit
+    [ (Just . ("HardLimit",) . toJSON) _eCSTaskDefinitionUlimitHardLimit
     , (Just . ("Name",) . toJSON) _eCSTaskDefinitionUlimitName
-    , (Just . ("SoftLimit",) . toJSON . fmap Integer') _eCSTaskDefinitionUlimitSoftLimit
+    , (Just . ("SoftLimit",) . toJSON) _eCSTaskDefinitionUlimitSoftLimit
     ]
 
 -- | Constructor for 'ECSTaskDefinitionUlimit' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionVolumeFrom.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ECSTaskDefinitionVolumeFrom.hs
@@ -22,7 +22,7 @@ instance ToJSON ECSTaskDefinitionVolumeFrom where
   toJSON ECSTaskDefinitionVolumeFrom{..} =
     object $
     catMaybes
-    [ fmap (("ReadOnly",) . toJSON . fmap Bool') _eCSTaskDefinitionVolumeFromReadOnly
+    [ fmap (("ReadOnly",) . toJSON) _eCSTaskDefinitionVolumeFromReadOnly
     , fmap (("SourceContainer",) . toJSON) _eCSTaskDefinitionVolumeFromSourceContainer
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterCloudWatchAlarmDefinition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterCloudWatchAlarmDefinition.hs
@@ -31,12 +31,12 @@ instance ToJSON EMRClusterCloudWatchAlarmDefinition where
     catMaybes
     [ (Just . ("ComparisonOperator",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionComparisonOperator
     , fmap (("Dimensions",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionDimensions
-    , fmap (("EvaluationPeriods",) . toJSON . fmap Integer') _eMRClusterCloudWatchAlarmDefinitionEvaluationPeriods
+    , fmap (("EvaluationPeriods",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionEvaluationPeriods
     , (Just . ("MetricName",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionMetricName
     , fmap (("Namespace",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionNamespace
-    , (Just . ("Period",) . toJSON . fmap Integer') _eMRClusterCloudWatchAlarmDefinitionPeriod
+    , (Just . ("Period",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionPeriod
     , fmap (("Statistic",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionStatistic
-    , (Just . ("Threshold",) . toJSON . fmap Double') _eMRClusterCloudWatchAlarmDefinitionThreshold
+    , (Just . ("Threshold",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionThreshold
     , fmap (("Unit",) . toJSON) _eMRClusterCloudWatchAlarmDefinitionUnit
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterEbsBlockDeviceConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterEbsBlockDeviceConfig.hs
@@ -23,7 +23,7 @@ instance ToJSON EMRClusterEbsBlockDeviceConfig where
     object $
     catMaybes
     [ (Just . ("VolumeSpecification",) . toJSON) _eMRClusterEbsBlockDeviceConfigVolumeSpecification
-    , fmap (("VolumesPerInstance",) . toJSON . fmap Integer') _eMRClusterEbsBlockDeviceConfigVolumesPerInstance
+    , fmap (("VolumesPerInstance",) . toJSON) _eMRClusterEbsBlockDeviceConfigVolumesPerInstance
     ]
 
 -- | Constructor for 'EMRClusterEbsBlockDeviceConfig' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterEbsConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterEbsConfiguration.hs
@@ -23,7 +23,7 @@ instance ToJSON EMRClusterEbsConfiguration where
     object $
     catMaybes
     [ fmap (("EbsBlockDeviceConfigs",) . toJSON) _eMRClusterEbsConfigurationEbsBlockDeviceConfigs
-    , fmap (("EbsOptimized",) . toJSON . fmap Bool') _eMRClusterEbsConfigurationEbsOptimized
+    , fmap (("EbsOptimized",) . toJSON) _eMRClusterEbsConfigurationEbsOptimized
     ]
 
 -- | Constructor for 'EMRClusterEbsConfiguration' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterInstanceFleetConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterInstanceFleetConfig.hs
@@ -29,8 +29,8 @@ instance ToJSON EMRClusterInstanceFleetConfig where
     [ fmap (("InstanceTypeConfigs",) . toJSON) _eMRClusterInstanceFleetConfigInstanceTypeConfigs
     , fmap (("LaunchSpecifications",) . toJSON) _eMRClusterInstanceFleetConfigLaunchSpecifications
     , fmap (("Name",) . toJSON) _eMRClusterInstanceFleetConfigName
-    , fmap (("TargetOnDemandCapacity",) . toJSON . fmap Integer') _eMRClusterInstanceFleetConfigTargetOnDemandCapacity
-    , fmap (("TargetSpotCapacity",) . toJSON . fmap Integer') _eMRClusterInstanceFleetConfigTargetSpotCapacity
+    , fmap (("TargetOnDemandCapacity",) . toJSON) _eMRClusterInstanceFleetConfigTargetOnDemandCapacity
+    , fmap (("TargetSpotCapacity",) . toJSON) _eMRClusterInstanceFleetConfigTargetSpotCapacity
     ]
 
 -- | Constructor for 'EMRClusterInstanceFleetConfig' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterInstanceGroupConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterInstanceGroupConfig.hs
@@ -34,7 +34,7 @@ instance ToJSON EMRClusterInstanceGroupConfig where
     , fmap (("BidPrice",) . toJSON) _eMRClusterInstanceGroupConfigBidPrice
     , fmap (("Configurations",) . toJSON) _eMRClusterInstanceGroupConfigConfigurations
     , fmap (("EbsConfiguration",) . toJSON) _eMRClusterInstanceGroupConfigEbsConfiguration
-    , (Just . ("InstanceCount",) . toJSON . fmap Integer') _eMRClusterInstanceGroupConfigInstanceCount
+    , (Just . ("InstanceCount",) . toJSON) _eMRClusterInstanceGroupConfigInstanceCount
     , (Just . ("InstanceType",) . toJSON) _eMRClusterInstanceGroupConfigInstanceType
     , fmap (("Market",) . toJSON) _eMRClusterInstanceGroupConfigMarket
     , fmap (("Name",) . toJSON) _eMRClusterInstanceGroupConfigName

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterInstanceTypeConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterInstanceTypeConfig.hs
@@ -28,11 +28,11 @@ instance ToJSON EMRClusterInstanceTypeConfig where
     object $
     catMaybes
     [ fmap (("BidPrice",) . toJSON) _eMRClusterInstanceTypeConfigBidPrice
-    , fmap (("BidPriceAsPercentageOfOnDemandPrice",) . toJSON . fmap Double') _eMRClusterInstanceTypeConfigBidPriceAsPercentageOfOnDemandPrice
+    , fmap (("BidPriceAsPercentageOfOnDemandPrice",) . toJSON) _eMRClusterInstanceTypeConfigBidPriceAsPercentageOfOnDemandPrice
     , fmap (("Configurations",) . toJSON) _eMRClusterInstanceTypeConfigConfigurations
     , fmap (("EbsConfiguration",) . toJSON) _eMRClusterInstanceTypeConfigEbsConfiguration
     , (Just . ("InstanceType",) . toJSON) _eMRClusterInstanceTypeConfigInstanceType
-    , fmap (("WeightedCapacity",) . toJSON . fmap Integer') _eMRClusterInstanceTypeConfigWeightedCapacity
+    , fmap (("WeightedCapacity",) . toJSON) _eMRClusterInstanceTypeConfigWeightedCapacity
     ]
 
 -- | Constructor for 'EMRClusterInstanceTypeConfig' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterJobFlowInstancesConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterJobFlowInstancesConfig.hs
@@ -46,12 +46,12 @@ instance ToJSON EMRClusterJobFlowInstancesConfig where
     , fmap (("EmrManagedMasterSecurityGroup",) . toJSON) _eMRClusterJobFlowInstancesConfigEmrManagedMasterSecurityGroup
     , fmap (("EmrManagedSlaveSecurityGroup",) . toJSON) _eMRClusterJobFlowInstancesConfigEmrManagedSlaveSecurityGroup
     , fmap (("HadoopVersion",) . toJSON) _eMRClusterJobFlowInstancesConfigHadoopVersion
-    , fmap (("KeepJobFlowAliveWhenNoSteps",) . toJSON . fmap Bool') _eMRClusterJobFlowInstancesConfigKeepJobFlowAliveWhenNoSteps
+    , fmap (("KeepJobFlowAliveWhenNoSteps",) . toJSON) _eMRClusterJobFlowInstancesConfigKeepJobFlowAliveWhenNoSteps
     , fmap (("MasterInstanceFleet",) . toJSON) _eMRClusterJobFlowInstancesConfigMasterInstanceFleet
     , fmap (("MasterInstanceGroup",) . toJSON) _eMRClusterJobFlowInstancesConfigMasterInstanceGroup
     , fmap (("Placement",) . toJSON) _eMRClusterJobFlowInstancesConfigPlacement
     , fmap (("ServiceAccessSecurityGroup",) . toJSON) _eMRClusterJobFlowInstancesConfigServiceAccessSecurityGroup
-    , fmap (("TerminationProtected",) . toJSON . fmap Bool') _eMRClusterJobFlowInstancesConfigTerminationProtected
+    , fmap (("TerminationProtected",) . toJSON) _eMRClusterJobFlowInstancesConfigTerminationProtected
     ]
 
 -- | Constructor for 'EMRClusterJobFlowInstancesConfig' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterScalingConstraints.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterScalingConstraints.hs
@@ -22,8 +22,8 @@ instance ToJSON EMRClusterScalingConstraints where
   toJSON EMRClusterScalingConstraints{..} =
     object $
     catMaybes
-    [ (Just . ("MaxCapacity",) . toJSON . fmap Integer') _eMRClusterScalingConstraintsMaxCapacity
-    , (Just . ("MinCapacity",) . toJSON . fmap Integer') _eMRClusterScalingConstraintsMinCapacity
+    [ (Just . ("MaxCapacity",) . toJSON) _eMRClusterScalingConstraintsMaxCapacity
+    , (Just . ("MinCapacity",) . toJSON) _eMRClusterScalingConstraintsMinCapacity
     ]
 
 -- | Constructor for 'EMRClusterScalingConstraints' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterSimpleScalingPolicyConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterSimpleScalingPolicyConfiguration.hs
@@ -25,8 +25,8 @@ instance ToJSON EMRClusterSimpleScalingPolicyConfiguration where
     object $
     catMaybes
     [ fmap (("AdjustmentType",) . toJSON) _eMRClusterSimpleScalingPolicyConfigurationAdjustmentType
-    , fmap (("CoolDown",) . toJSON . fmap Integer') _eMRClusterSimpleScalingPolicyConfigurationCoolDown
-    , (Just . ("ScalingAdjustment",) . toJSON . fmap Integer') _eMRClusterSimpleScalingPolicyConfigurationScalingAdjustment
+    , fmap (("CoolDown",) . toJSON) _eMRClusterSimpleScalingPolicyConfigurationCoolDown
+    , (Just . ("ScalingAdjustment",) . toJSON) _eMRClusterSimpleScalingPolicyConfigurationScalingAdjustment
     ]
 
 -- | Constructor for 'EMRClusterSimpleScalingPolicyConfiguration' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterSpotProvisioningSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterSpotProvisioningSpecification.hs
@@ -24,9 +24,9 @@ instance ToJSON EMRClusterSpotProvisioningSpecification where
   toJSON EMRClusterSpotProvisioningSpecification{..} =
     object $
     catMaybes
-    [ fmap (("BlockDurationMinutes",) . toJSON . fmap Integer') _eMRClusterSpotProvisioningSpecificationBlockDurationMinutes
+    [ fmap (("BlockDurationMinutes",) . toJSON) _eMRClusterSpotProvisioningSpecificationBlockDurationMinutes
     , (Just . ("TimeoutAction",) . toJSON) _eMRClusterSpotProvisioningSpecificationTimeoutAction
-    , (Just . ("TimeoutDurationMinutes",) . toJSON . fmap Integer') _eMRClusterSpotProvisioningSpecificationTimeoutDurationMinutes
+    , (Just . ("TimeoutDurationMinutes",) . toJSON) _eMRClusterSpotProvisioningSpecificationTimeoutDurationMinutes
     ]
 
 -- | Constructor for 'EMRClusterSpotProvisioningSpecification' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRClusterVolumeSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRClusterVolumeSpecification.hs
@@ -23,8 +23,8 @@ instance ToJSON EMRClusterVolumeSpecification where
   toJSON EMRClusterVolumeSpecification{..} =
     object $
     catMaybes
-    [ fmap (("Iops",) . toJSON . fmap Integer') _eMRClusterVolumeSpecificationIops
-    , (Just . ("SizeInGB",) . toJSON . fmap Integer') _eMRClusterVolumeSpecificationSizeInGB
+    [ fmap (("Iops",) . toJSON) _eMRClusterVolumeSpecificationIops
+    , (Just . ("SizeInGB",) . toJSON) _eMRClusterVolumeSpecificationSizeInGB
     , (Just . ("VolumeType",) . toJSON) _eMRClusterVolumeSpecificationVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigEbsBlockDeviceConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigEbsBlockDeviceConfig.hs
@@ -24,7 +24,7 @@ instance ToJSON EMRInstanceFleetConfigEbsBlockDeviceConfig where
     object $
     catMaybes
     [ (Just . ("VolumeSpecification",) . toJSON) _eMRInstanceFleetConfigEbsBlockDeviceConfigVolumeSpecification
-    , fmap (("VolumesPerInstance",) . toJSON . fmap Integer') _eMRInstanceFleetConfigEbsBlockDeviceConfigVolumesPerInstance
+    , fmap (("VolumesPerInstance",) . toJSON) _eMRInstanceFleetConfigEbsBlockDeviceConfigVolumesPerInstance
     ]
 
 -- | Constructor for 'EMRInstanceFleetConfigEbsBlockDeviceConfig' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigEbsConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigEbsConfiguration.hs
@@ -24,7 +24,7 @@ instance ToJSON EMRInstanceFleetConfigEbsConfiguration where
     object $
     catMaybes
     [ fmap (("EbsBlockDeviceConfigs",) . toJSON) _eMRInstanceFleetConfigEbsConfigurationEbsBlockDeviceConfigs
-    , fmap (("EbsOptimized",) . toJSON . fmap Bool') _eMRInstanceFleetConfigEbsConfigurationEbsOptimized
+    , fmap (("EbsOptimized",) . toJSON) _eMRInstanceFleetConfigEbsConfigurationEbsOptimized
     ]
 
 -- | Constructor for 'EMRInstanceFleetConfigEbsConfiguration' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigInstanceTypeConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigInstanceTypeConfig.hs
@@ -29,11 +29,11 @@ instance ToJSON EMRInstanceFleetConfigInstanceTypeConfig where
     object $
     catMaybes
     [ fmap (("BidPrice",) . toJSON) _eMRInstanceFleetConfigInstanceTypeConfigBidPrice
-    , fmap (("BidPriceAsPercentageOfOnDemandPrice",) . toJSON . fmap Double') _eMRInstanceFleetConfigInstanceTypeConfigBidPriceAsPercentageOfOnDemandPrice
+    , fmap (("BidPriceAsPercentageOfOnDemandPrice",) . toJSON) _eMRInstanceFleetConfigInstanceTypeConfigBidPriceAsPercentageOfOnDemandPrice
     , fmap (("Configurations",) . toJSON) _eMRInstanceFleetConfigInstanceTypeConfigConfigurations
     , fmap (("EbsConfiguration",) . toJSON) _eMRInstanceFleetConfigInstanceTypeConfigEbsConfiguration
     , (Just . ("InstanceType",) . toJSON) _eMRInstanceFleetConfigInstanceTypeConfigInstanceType
-    , fmap (("WeightedCapacity",) . toJSON . fmap Integer') _eMRInstanceFleetConfigInstanceTypeConfigWeightedCapacity
+    , fmap (("WeightedCapacity",) . toJSON) _eMRInstanceFleetConfigInstanceTypeConfigWeightedCapacity
     ]
 
 -- | Constructor for 'EMRInstanceFleetConfigInstanceTypeConfig' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigSpotProvisioningSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigSpotProvisioningSpecification.hs
@@ -25,9 +25,9 @@ instance ToJSON EMRInstanceFleetConfigSpotProvisioningSpecification where
   toJSON EMRInstanceFleetConfigSpotProvisioningSpecification{..} =
     object $
     catMaybes
-    [ fmap (("BlockDurationMinutes",) . toJSON . fmap Integer') _eMRInstanceFleetConfigSpotProvisioningSpecificationBlockDurationMinutes
+    [ fmap (("BlockDurationMinutes",) . toJSON) _eMRInstanceFleetConfigSpotProvisioningSpecificationBlockDurationMinutes
     , (Just . ("TimeoutAction",) . toJSON) _eMRInstanceFleetConfigSpotProvisioningSpecificationTimeoutAction
-    , (Just . ("TimeoutDurationMinutes",) . toJSON . fmap Integer') _eMRInstanceFleetConfigSpotProvisioningSpecificationTimeoutDurationMinutes
+    , (Just . ("TimeoutDurationMinutes",) . toJSON) _eMRInstanceFleetConfigSpotProvisioningSpecificationTimeoutDurationMinutes
     ]
 
 -- | Constructor for 'EMRInstanceFleetConfigSpotProvisioningSpecification'

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigVolumeSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceFleetConfigVolumeSpecification.hs
@@ -24,8 +24,8 @@ instance ToJSON EMRInstanceFleetConfigVolumeSpecification where
   toJSON EMRInstanceFleetConfigVolumeSpecification{..} =
     object $
     catMaybes
-    [ fmap (("Iops",) . toJSON . fmap Integer') _eMRInstanceFleetConfigVolumeSpecificationIops
-    , (Just . ("SizeInGB",) . toJSON . fmap Integer') _eMRInstanceFleetConfigVolumeSpecificationSizeInGB
+    [ fmap (("Iops",) . toJSON) _eMRInstanceFleetConfigVolumeSpecificationIops
+    , (Just . ("SizeInGB",) . toJSON) _eMRInstanceFleetConfigVolumeSpecificationSizeInGB
     , (Just . ("VolumeType",) . toJSON) _eMRInstanceFleetConfigVolumeSpecificationVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigCloudWatchAlarmDefinition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigCloudWatchAlarmDefinition.hs
@@ -33,12 +33,12 @@ instance ToJSON EMRInstanceGroupConfigCloudWatchAlarmDefinition where
     catMaybes
     [ (Just . ("ComparisonOperator",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionComparisonOperator
     , fmap (("Dimensions",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionDimensions
-    , fmap (("EvaluationPeriods",) . toJSON . fmap Integer') _eMRInstanceGroupConfigCloudWatchAlarmDefinitionEvaluationPeriods
+    , fmap (("EvaluationPeriods",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionEvaluationPeriods
     , (Just . ("MetricName",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionMetricName
     , fmap (("Namespace",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionNamespace
-    , (Just . ("Period",) . toJSON . fmap Integer') _eMRInstanceGroupConfigCloudWatchAlarmDefinitionPeriod
+    , (Just . ("Period",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionPeriod
     , fmap (("Statistic",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionStatistic
-    , (Just . ("Threshold",) . toJSON . fmap Double') _eMRInstanceGroupConfigCloudWatchAlarmDefinitionThreshold
+    , (Just . ("Threshold",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionThreshold
     , fmap (("Unit",) . toJSON) _eMRInstanceGroupConfigCloudWatchAlarmDefinitionUnit
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigEbsBlockDeviceConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigEbsBlockDeviceConfig.hs
@@ -24,7 +24,7 @@ instance ToJSON EMRInstanceGroupConfigEbsBlockDeviceConfig where
     object $
     catMaybes
     [ (Just . ("VolumeSpecification",) . toJSON) _eMRInstanceGroupConfigEbsBlockDeviceConfigVolumeSpecification
-    , fmap (("VolumesPerInstance",) . toJSON . fmap Integer') _eMRInstanceGroupConfigEbsBlockDeviceConfigVolumesPerInstance
+    , fmap (("VolumesPerInstance",) . toJSON) _eMRInstanceGroupConfigEbsBlockDeviceConfigVolumesPerInstance
     ]
 
 -- | Constructor for 'EMRInstanceGroupConfigEbsBlockDeviceConfig' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigEbsConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigEbsConfiguration.hs
@@ -24,7 +24,7 @@ instance ToJSON EMRInstanceGroupConfigEbsConfiguration where
     object $
     catMaybes
     [ fmap (("EbsBlockDeviceConfigs",) . toJSON) _eMRInstanceGroupConfigEbsConfigurationEbsBlockDeviceConfigs
-    , fmap (("EbsOptimized",) . toJSON . fmap Bool') _eMRInstanceGroupConfigEbsConfigurationEbsOptimized
+    , fmap (("EbsOptimized",) . toJSON) _eMRInstanceGroupConfigEbsConfigurationEbsOptimized
     ]
 
 -- | Constructor for 'EMRInstanceGroupConfigEbsConfiguration' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigScalingConstraints.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigScalingConstraints.hs
@@ -23,8 +23,8 @@ instance ToJSON EMRInstanceGroupConfigScalingConstraints where
   toJSON EMRInstanceGroupConfigScalingConstraints{..} =
     object $
     catMaybes
-    [ (Just . ("MaxCapacity",) . toJSON . fmap Integer') _eMRInstanceGroupConfigScalingConstraintsMaxCapacity
-    , (Just . ("MinCapacity",) . toJSON . fmap Integer') _eMRInstanceGroupConfigScalingConstraintsMinCapacity
+    [ (Just . ("MaxCapacity",) . toJSON) _eMRInstanceGroupConfigScalingConstraintsMaxCapacity
+    , (Just . ("MinCapacity",) . toJSON) _eMRInstanceGroupConfigScalingConstraintsMinCapacity
     ]
 
 -- | Constructor for 'EMRInstanceGroupConfigScalingConstraints' containing

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigSimpleScalingPolicyConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigSimpleScalingPolicyConfiguration.hs
@@ -26,8 +26,8 @@ instance ToJSON EMRInstanceGroupConfigSimpleScalingPolicyConfiguration where
     object $
     catMaybes
     [ fmap (("AdjustmentType",) . toJSON) _eMRInstanceGroupConfigSimpleScalingPolicyConfigurationAdjustmentType
-    , fmap (("CoolDown",) . toJSON . fmap Integer') _eMRInstanceGroupConfigSimpleScalingPolicyConfigurationCoolDown
-    , (Just . ("ScalingAdjustment",) . toJSON . fmap Integer') _eMRInstanceGroupConfigSimpleScalingPolicyConfigurationScalingAdjustment
+    , fmap (("CoolDown",) . toJSON) _eMRInstanceGroupConfigSimpleScalingPolicyConfigurationCoolDown
+    , (Just . ("ScalingAdjustment",) . toJSON) _eMRInstanceGroupConfigSimpleScalingPolicyConfigurationScalingAdjustment
     ]
 
 -- | Constructor for 'EMRInstanceGroupConfigSimpleScalingPolicyConfiguration'

--- a/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigVolumeSpecification.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EMRInstanceGroupConfigVolumeSpecification.hs
@@ -24,8 +24,8 @@ instance ToJSON EMRInstanceGroupConfigVolumeSpecification where
   toJSON EMRInstanceGroupConfigVolumeSpecification{..} =
     object $
     catMaybes
-    [ fmap (("Iops",) . toJSON . fmap Integer') _eMRInstanceGroupConfigVolumeSpecificationIops
-    , (Just . ("SizeInGB",) . toJSON . fmap Integer') _eMRInstanceGroupConfigVolumeSpecificationSizeInGB
+    [ fmap (("Iops",) . toJSON) _eMRInstanceGroupConfigVolumeSpecificationIops
+    , (Just . ("SizeInGB",) . toJSON) _eMRInstanceGroupConfigVolumeSpecificationSizeInGB
     , (Just . ("VolumeType",) . toJSON) _eMRInstanceGroupConfigVolumeSpecificationVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ElastiCacheReplicationGroupNodeGroupConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElastiCacheReplicationGroupNodeGroupConfiguration.hs
@@ -30,7 +30,7 @@ instance ToJSON ElastiCacheReplicationGroupNodeGroupConfiguration where
     [ fmap (("NodeGroupId",) . toJSON) _elastiCacheReplicationGroupNodeGroupConfigurationNodeGroupId
     , fmap (("PrimaryAvailabilityZone",) . toJSON) _elastiCacheReplicationGroupNodeGroupConfigurationPrimaryAvailabilityZone
     , fmap (("ReplicaAvailabilityZones",) . toJSON) _elastiCacheReplicationGroupNodeGroupConfigurationReplicaAvailabilityZones
-    , fmap (("ReplicaCount",) . toJSON . fmap Integer') _elastiCacheReplicationGroupNodeGroupConfigurationReplicaCount
+    , fmap (("ReplicaCount",) . toJSON) _elastiCacheReplicationGroupNodeGroupConfigurationReplicaCount
     , fmap (("Slots",) . toJSON) _elastiCacheReplicationGroupNodeGroupConfigurationSlots
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ElasticBeanstalkApplicationMaxAgeRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticBeanstalkApplicationMaxAgeRule.hs
@@ -24,9 +24,9 @@ instance ToJSON ElasticBeanstalkApplicationMaxAgeRule where
   toJSON ElasticBeanstalkApplicationMaxAgeRule{..} =
     object $
     catMaybes
-    [ fmap (("DeleteSourceFromS3",) . toJSON . fmap Bool') _elasticBeanstalkApplicationMaxAgeRuleDeleteSourceFromS3
-    , fmap (("Enabled",) . toJSON . fmap Bool') _elasticBeanstalkApplicationMaxAgeRuleEnabled
-    , fmap (("MaxAgeInDays",) . toJSON . fmap Integer') _elasticBeanstalkApplicationMaxAgeRuleMaxAgeInDays
+    [ fmap (("DeleteSourceFromS3",) . toJSON) _elasticBeanstalkApplicationMaxAgeRuleDeleteSourceFromS3
+    , fmap (("Enabled",) . toJSON) _elasticBeanstalkApplicationMaxAgeRuleEnabled
+    , fmap (("MaxAgeInDays",) . toJSON) _elasticBeanstalkApplicationMaxAgeRuleMaxAgeInDays
     ]
 
 -- | Constructor for 'ElasticBeanstalkApplicationMaxAgeRule' containing

--- a/library-gen/Stratosphere/ResourceProperties/ElasticBeanstalkApplicationMaxCountRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticBeanstalkApplicationMaxCountRule.hs
@@ -24,9 +24,9 @@ instance ToJSON ElasticBeanstalkApplicationMaxCountRule where
   toJSON ElasticBeanstalkApplicationMaxCountRule{..} =
     object $
     catMaybes
-    [ fmap (("DeleteSourceFromS3",) . toJSON . fmap Bool') _elasticBeanstalkApplicationMaxCountRuleDeleteSourceFromS3
-    , fmap (("Enabled",) . toJSON . fmap Bool') _elasticBeanstalkApplicationMaxCountRuleEnabled
-    , fmap (("MaxCount",) . toJSON . fmap Integer') _elasticBeanstalkApplicationMaxCountRuleMaxCount
+    [ fmap (("DeleteSourceFromS3",) . toJSON) _elasticBeanstalkApplicationMaxCountRuleDeleteSourceFromS3
+    , fmap (("Enabled",) . toJSON) _elasticBeanstalkApplicationMaxCountRuleEnabled
+    , fmap (("MaxCount",) . toJSON) _elasticBeanstalkApplicationMaxCountRuleMaxCount
     ]
 
 -- | Constructor for 'ElasticBeanstalkApplicationMaxCountRule' containing

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerAccessLoggingPolicy.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerAccessLoggingPolicy.hs
@@ -26,8 +26,8 @@ instance ToJSON ElasticLoadBalancingLoadBalancerAccessLoggingPolicy where
   toJSON ElasticLoadBalancingLoadBalancerAccessLoggingPolicy{..} =
     object $
     catMaybes
-    [ fmap (("EmitInterval",) . toJSON . fmap Integer') _elasticLoadBalancingLoadBalancerAccessLoggingPolicyEmitInterval
-    , (Just . ("Enabled",) . toJSON . fmap Bool') _elasticLoadBalancingLoadBalancerAccessLoggingPolicyEnabled
+    [ fmap (("EmitInterval",) . toJSON) _elasticLoadBalancingLoadBalancerAccessLoggingPolicyEmitInterval
+    , (Just . ("Enabled",) . toJSON) _elasticLoadBalancingLoadBalancerAccessLoggingPolicyEnabled
     , (Just . ("S3BucketName",) . toJSON) _elasticLoadBalancingLoadBalancerAccessLoggingPolicyS3BucketName
     , fmap (("S3BucketPrefix",) . toJSON) _elasticLoadBalancingLoadBalancerAccessLoggingPolicyS3BucketPrefix
     ]

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerConnectionDrainingPolicy.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerConnectionDrainingPolicy.hs
@@ -24,8 +24,8 @@ instance ToJSON ElasticLoadBalancingLoadBalancerConnectionDrainingPolicy where
   toJSON ElasticLoadBalancingLoadBalancerConnectionDrainingPolicy{..} =
     object $
     catMaybes
-    [ (Just . ("Enabled",) . toJSON . fmap Bool') _elasticLoadBalancingLoadBalancerConnectionDrainingPolicyEnabled
-    , fmap (("Timeout",) . toJSON . fmap Integer') _elasticLoadBalancingLoadBalancerConnectionDrainingPolicyTimeout
+    [ (Just . ("Enabled",) . toJSON) _elasticLoadBalancingLoadBalancerConnectionDrainingPolicyEnabled
+    , fmap (("Timeout",) . toJSON) _elasticLoadBalancingLoadBalancerConnectionDrainingPolicyTimeout
     ]
 
 -- | Constructor for

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerConnectionSettings.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingLoadBalancerConnectionSettings.hs
@@ -23,7 +23,7 @@ instance ToJSON ElasticLoadBalancingLoadBalancerConnectionSettings where
   toJSON ElasticLoadBalancingLoadBalancerConnectionSettings{..} =
     object $
     catMaybes
-    [ (Just . ("IdleTimeout",) . toJSON . fmap Integer') _elasticLoadBalancingLoadBalancerConnectionSettingsIdleTimeout
+    [ (Just . ("IdleTimeout",) . toJSON) _elasticLoadBalancingLoadBalancerConnectionSettingsIdleTimeout
     ]
 
 -- | Constructor for 'ElasticLoadBalancingLoadBalancerConnectionSettings'

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerAction.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerAction.hs
@@ -33,7 +33,7 @@ instance ToJSON ElasticLoadBalancingV2ListenerAction where
     [ fmap (("AuthenticateCognitoConfig",) . toJSON) _elasticLoadBalancingV2ListenerActionAuthenticateCognitoConfig
     , fmap (("AuthenticateOidcConfig",) . toJSON) _elasticLoadBalancingV2ListenerActionAuthenticateOidcConfig
     , fmap (("FixedResponseConfig",) . toJSON) _elasticLoadBalancingV2ListenerActionFixedResponseConfig
-    , fmap (("Order",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerActionOrder
+    , fmap (("Order",) . toJSON) _elasticLoadBalancingV2ListenerActionOrder
     , fmap (("RedirectConfig",) . toJSON) _elasticLoadBalancingV2ListenerActionRedirectConfig
     , fmap (("TargetGroupArn",) . toJSON) _elasticLoadBalancingV2ListenerActionTargetGroupArn
     , (Just . ("Type",) . toJSON) _elasticLoadBalancingV2ListenerActionType

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerAuthenticateCognitoConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerAuthenticateCognitoConfig.hs
@@ -34,7 +34,7 @@ instance ToJSON ElasticLoadBalancingV2ListenerAuthenticateCognitoConfig where
     , fmap (("OnUnauthenticatedRequest",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigOnUnauthenticatedRequest
     , fmap (("Scope",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigScope
     , fmap (("SessionCookieName",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigSessionCookieName
-    , fmap (("SessionTimeout",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigSessionTimeout
+    , fmap (("SessionTimeout",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigSessionTimeout
     , (Just . ("UserPoolArn",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigUserPoolArn
     , (Just . ("UserPoolClientId",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigUserPoolClientId
     , (Just . ("UserPoolDomain",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateCognitoConfigUserPoolDomain

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerAuthenticateOidcConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerAuthenticateOidcConfig.hs
@@ -41,7 +41,7 @@ instance ToJSON ElasticLoadBalancingV2ListenerAuthenticateOidcConfig where
     , fmap (("OnUnauthenticatedRequest",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateOidcConfigOnUnauthenticatedRequest
     , fmap (("Scope",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateOidcConfigScope
     , fmap (("SessionCookieName",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateOidcConfigSessionCookieName
-    , fmap (("SessionTimeout",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerAuthenticateOidcConfigSessionTimeout
+    , fmap (("SessionTimeout",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateOidcConfigSessionTimeout
     , (Just . ("TokenEndpoint",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateOidcConfigTokenEndpoint
     , (Just . ("UserInfoEndpoint",) . toJSON) _elasticLoadBalancingV2ListenerAuthenticateOidcConfigUserInfoEndpoint
     ]

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleAction.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleAction.hs
@@ -34,7 +34,7 @@ instance ToJSON ElasticLoadBalancingV2ListenerRuleAction where
     [ fmap (("AuthenticateCognitoConfig",) . toJSON) _elasticLoadBalancingV2ListenerRuleActionAuthenticateCognitoConfig
     , fmap (("AuthenticateOidcConfig",) . toJSON) _elasticLoadBalancingV2ListenerRuleActionAuthenticateOidcConfig
     , fmap (("FixedResponseConfig",) . toJSON) _elasticLoadBalancingV2ListenerRuleActionFixedResponseConfig
-    , fmap (("Order",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerRuleActionOrder
+    , fmap (("Order",) . toJSON) _elasticLoadBalancingV2ListenerRuleActionOrder
     , fmap (("RedirectConfig",) . toJSON) _elasticLoadBalancingV2ListenerRuleActionRedirectConfig
     , fmap (("TargetGroupArn",) . toJSON) _elasticLoadBalancingV2ListenerRuleActionTargetGroupArn
     , (Just . ("Type",) . toJSON) _elasticLoadBalancingV2ListenerRuleActionType

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfig.hs
@@ -34,7 +34,7 @@ instance ToJSON ElasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfig wher
     , fmap (("OnUnauthenticatedRequest",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigOnUnauthenticatedRequest
     , fmap (("Scope",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigScope
     , fmap (("SessionCookieName",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigSessionCookieName
-    , fmap (("SessionTimeout",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigSessionTimeout
+    , fmap (("SessionTimeout",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigSessionTimeout
     , (Just . ("UserPoolArn",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigUserPoolArn
     , (Just . ("UserPoolClientId",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigUserPoolClientId
     , (Just . ("UserPoolDomain",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateCognitoConfigUserPoolDomain

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleAuthenticateOidcConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2ListenerRuleAuthenticateOidcConfig.hs
@@ -41,7 +41,7 @@ instance ToJSON ElasticLoadBalancingV2ListenerRuleAuthenticateOidcConfig where
     , fmap (("OnUnauthenticatedRequest",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateOidcConfigOnUnauthenticatedRequest
     , fmap (("Scope",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateOidcConfigScope
     , fmap (("SessionCookieName",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateOidcConfigSessionCookieName
-    , fmap (("SessionTimeout",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerRuleAuthenticateOidcConfigSessionTimeout
+    , fmap (("SessionTimeout",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateOidcConfigSessionTimeout
     , (Just . ("TokenEndpoint",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateOidcConfigTokenEndpoint
     , (Just . ("UserInfoEndpoint",) . toJSON) _elasticLoadBalancingV2ListenerRuleAuthenticateOidcConfigUserInfoEndpoint
     ]

--- a/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2TargetGroupTargetDescription.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticLoadBalancingV2TargetGroupTargetDescription.hs
@@ -27,7 +27,7 @@ instance ToJSON ElasticLoadBalancingV2TargetGroupTargetDescription where
     catMaybes
     [ fmap (("AvailabilityZone",) . toJSON) _elasticLoadBalancingV2TargetGroupTargetDescriptionAvailabilityZone
     , (Just . ("Id",) . toJSON) _elasticLoadBalancingV2TargetGroupTargetDescriptionId
-    , fmap (("Port",) . toJSON . fmap Integer') _elasticLoadBalancingV2TargetGroupTargetDescriptionPort
+    , fmap (("Port",) . toJSON) _elasticLoadBalancingV2TargetGroupTargetDescriptionPort
     ]
 
 -- | Constructor for 'ElasticLoadBalancingV2TargetGroupTargetDescription'

--- a/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainEBSOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainEBSOptions.hs
@@ -24,9 +24,9 @@ instance ToJSON ElasticsearchDomainEBSOptions where
   toJSON ElasticsearchDomainEBSOptions{..} =
     object $
     catMaybes
-    [ fmap (("EBSEnabled",) . toJSON . fmap Bool') _elasticsearchDomainEBSOptionsEBSEnabled
-    , fmap (("Iops",) . toJSON . fmap Integer') _elasticsearchDomainEBSOptionsIops
-    , fmap (("VolumeSize",) . toJSON . fmap Integer') _elasticsearchDomainEBSOptionsVolumeSize
+    [ fmap (("EBSEnabled",) . toJSON) _elasticsearchDomainEBSOptionsEBSEnabled
+    , fmap (("Iops",) . toJSON) _elasticsearchDomainEBSOptionsIops
+    , fmap (("VolumeSize",) . toJSON) _elasticsearchDomainEBSOptionsVolumeSize
     , fmap (("VolumeType",) . toJSON) _elasticsearchDomainEBSOptionsVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainElasticsearchClusterConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainElasticsearchClusterConfig.hs
@@ -28,12 +28,12 @@ instance ToJSON ElasticsearchDomainElasticsearchClusterConfig where
   toJSON ElasticsearchDomainElasticsearchClusterConfig{..} =
     object $
     catMaybes
-    [ fmap (("DedicatedMasterCount",) . toJSON . fmap Integer') _elasticsearchDomainElasticsearchClusterConfigDedicatedMasterCount
-    , fmap (("DedicatedMasterEnabled",) . toJSON . fmap Bool') _elasticsearchDomainElasticsearchClusterConfigDedicatedMasterEnabled
+    [ fmap (("DedicatedMasterCount",) . toJSON) _elasticsearchDomainElasticsearchClusterConfigDedicatedMasterCount
+    , fmap (("DedicatedMasterEnabled",) . toJSON) _elasticsearchDomainElasticsearchClusterConfigDedicatedMasterEnabled
     , fmap (("DedicatedMasterType",) . toJSON) _elasticsearchDomainElasticsearchClusterConfigDedicatedMasterType
-    , fmap (("InstanceCount",) . toJSON . fmap Integer') _elasticsearchDomainElasticsearchClusterConfigInstanceCount
+    , fmap (("InstanceCount",) . toJSON) _elasticsearchDomainElasticsearchClusterConfigInstanceCount
     , fmap (("InstanceType",) . toJSON) _elasticsearchDomainElasticsearchClusterConfigInstanceType
-    , fmap (("ZoneAwarenessEnabled",) . toJSON . fmap Bool') _elasticsearchDomainElasticsearchClusterConfigZoneAwarenessEnabled
+    , fmap (("ZoneAwarenessEnabled",) . toJSON) _elasticsearchDomainElasticsearchClusterConfigZoneAwarenessEnabled
     ]
 
 -- | Constructor for 'ElasticsearchDomainElasticsearchClusterConfig'

--- a/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainEncryptionAtRestOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainEncryptionAtRestOptions.hs
@@ -23,7 +23,7 @@ instance ToJSON ElasticsearchDomainEncryptionAtRestOptions where
   toJSON ElasticsearchDomainEncryptionAtRestOptions{..} =
     object $
     catMaybes
-    [ fmap (("Enabled",) . toJSON . fmap Bool') _elasticsearchDomainEncryptionAtRestOptionsEnabled
+    [ fmap (("Enabled",) . toJSON) _elasticsearchDomainEncryptionAtRestOptionsEnabled
     , fmap (("KmsKeyId",) . toJSON) _elasticsearchDomainEncryptionAtRestOptionsKmsKeyId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainNodeToNodeEncryptionOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainNodeToNodeEncryptionOptions.hs
@@ -23,7 +23,7 @@ instance ToJSON ElasticsearchDomainNodeToNodeEncryptionOptions where
   toJSON ElasticsearchDomainNodeToNodeEncryptionOptions{..} =
     object $
     catMaybes
-    [ fmap (("Enabled",) . toJSON . fmap Bool') _elasticsearchDomainNodeToNodeEncryptionOptionsEnabled
+    [ fmap (("Enabled",) . toJSON) _elasticsearchDomainNodeToNodeEncryptionOptionsEnabled
     ]
 
 -- | Constructor for 'ElasticsearchDomainNodeToNodeEncryptionOptions'

--- a/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainSnapshotOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ElasticsearchDomainSnapshotOptions.hs
@@ -21,7 +21,7 @@ instance ToJSON ElasticsearchDomainSnapshotOptions where
   toJSON ElasticsearchDomainSnapshotOptions{..} =
     object $
     catMaybes
-    [ fmap (("AutomatedSnapshotStartHour",) . toJSON . fmap Integer') _elasticsearchDomainSnapshotOptionsAutomatedSnapshotStartHour
+    [ fmap (("AutomatedSnapshotStartHour",) . toJSON) _elasticsearchDomainSnapshotOptionsAutomatedSnapshotStartHour
     ]
 
 -- | Constructor for 'ElasticsearchDomainSnapshotOptions' containing required

--- a/library-gen/Stratosphere/ResourceProperties/EventsRuleEcsParameters.hs
+++ b/library-gen/Stratosphere/ResourceProperties/EventsRuleEcsParameters.hs
@@ -22,7 +22,7 @@ instance ToJSON EventsRuleEcsParameters where
   toJSON EventsRuleEcsParameters{..} =
     object $
     catMaybes
-    [ fmap (("TaskCount",) . toJSON . fmap Integer') _eventsRuleEcsParametersTaskCount
+    [ fmap (("TaskCount",) . toJSON) _eventsRuleEcsParametersTaskCount
     , (Just . ("TaskDefinitionArn",) . toJSON) _eventsRuleEcsParametersTaskDefinitionArn
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/FSxFileSystemLustreConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/FSxFileSystemLustreConfiguration.hs
@@ -26,7 +26,7 @@ instance ToJSON FSxFileSystemLustreConfiguration where
     catMaybes
     [ fmap (("ExportPath",) . toJSON) _fSxFileSystemLustreConfigurationExportPath
     , fmap (("ImportPath",) . toJSON) _fSxFileSystemLustreConfigurationImportPath
-    , fmap (("ImportedFileChunkSize",) . toJSON . fmap Integer') _fSxFileSystemLustreConfigurationImportedFileChunkSize
+    , fmap (("ImportedFileChunkSize",) . toJSON) _fSxFileSystemLustreConfigurationImportedFileChunkSize
     , fmap (("WeeklyMaintenanceStartTime",) . toJSON) _fSxFileSystemLustreConfigurationWeeklyMaintenanceStartTime
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/FSxFileSystemWindowsConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/FSxFileSystemWindowsConfiguration.hs
@@ -27,10 +27,10 @@ instance ToJSON FSxFileSystemWindowsConfiguration where
     object $
     catMaybes
     [ fmap (("ActiveDirectoryId",) . toJSON) _fSxFileSystemWindowsConfigurationActiveDirectoryId
-    , fmap (("AutomaticBackupRetentionDays",) . toJSON . fmap Integer') _fSxFileSystemWindowsConfigurationAutomaticBackupRetentionDays
-    , fmap (("CopyTagsToBackups",) . toJSON . fmap Bool') _fSxFileSystemWindowsConfigurationCopyTagsToBackups
+    , fmap (("AutomaticBackupRetentionDays",) . toJSON) _fSxFileSystemWindowsConfigurationAutomaticBackupRetentionDays
+    , fmap (("CopyTagsToBackups",) . toJSON) _fSxFileSystemWindowsConfigurationCopyTagsToBackups
     , fmap (("DailyAutomaticBackupStartTime",) . toJSON) _fSxFileSystemWindowsConfigurationDailyAutomaticBackupStartTime
-    , fmap (("ThroughputCapacity",) . toJSON . fmap Integer') _fSxFileSystemWindowsConfigurationThroughputCapacity
+    , fmap (("ThroughputCapacity",) . toJSON) _fSxFileSystemWindowsConfigurationThroughputCapacity
     , fmap (("WeeklyMaintenanceStartTime",) . toJSON) _fSxFileSystemWindowsConfigurationWeeklyMaintenanceStartTime
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/GameLiftFleetIpPermission.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GameLiftFleetIpPermission.hs
@@ -24,10 +24,10 @@ instance ToJSON GameLiftFleetIpPermission where
   toJSON GameLiftFleetIpPermission{..} =
     object $
     catMaybes
-    [ (Just . ("FromPort",) . toJSON . fmap Integer') _gameLiftFleetIpPermissionFromPort
+    [ (Just . ("FromPort",) . toJSON) _gameLiftFleetIpPermissionFromPort
     , (Just . ("IpRange",) . toJSON) _gameLiftFleetIpPermissionIpRange
     , (Just . ("Protocol",) . toJSON) _gameLiftFleetIpPermissionProtocol
-    , (Just . ("ToPort",) . toJSON . fmap Integer') _gameLiftFleetIpPermissionToPort
+    , (Just . ("ToPort",) . toJSON) _gameLiftFleetIpPermissionToPort
     ]
 
 -- | Constructor for 'GameLiftFleetIpPermission' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/GlueJobExecutionProperty.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GlueJobExecutionProperty.hs
@@ -21,7 +21,7 @@ instance ToJSON GlueJobExecutionProperty where
   toJSON GlueJobExecutionProperty{..} =
     object $
     catMaybes
-    [ fmap (("MaxConcurrentRuns",) . toJSON . fmap Double') _glueJobExecutionPropertyMaxConcurrentRuns
+    [ fmap (("MaxConcurrentRuns",) . toJSON) _glueJobExecutionPropertyMaxConcurrentRuns
     ]
 
 -- | Constructor for 'GlueJobExecutionProperty' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/GluePartitionOrder.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GluePartitionOrder.hs
@@ -23,7 +23,7 @@ instance ToJSON GluePartitionOrder where
     object $
     catMaybes
     [ (Just . ("Column",) . toJSON) _gluePartitionOrderColumn
-    , fmap (("SortOrder",) . toJSON . fmap Integer') _gluePartitionOrderSortOrder
+    , fmap (("SortOrder",) . toJSON) _gluePartitionOrderSortOrder
     ]
 
 -- | Constructor for 'GluePartitionOrder' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/GluePartitionStorageDescriptor.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GluePartitionStorageDescriptor.hs
@@ -37,16 +37,16 @@ instance ToJSON GluePartitionStorageDescriptor where
     catMaybes
     [ fmap (("BucketColumns",) . toJSON) _gluePartitionStorageDescriptorBucketColumns
     , fmap (("Columns",) . toJSON) _gluePartitionStorageDescriptorColumns
-    , fmap (("Compressed",) . toJSON . fmap Bool') _gluePartitionStorageDescriptorCompressed
+    , fmap (("Compressed",) . toJSON) _gluePartitionStorageDescriptorCompressed
     , fmap (("InputFormat",) . toJSON) _gluePartitionStorageDescriptorInputFormat
     , fmap (("Location",) . toJSON) _gluePartitionStorageDescriptorLocation
-    , fmap (("NumberOfBuckets",) . toJSON . fmap Integer') _gluePartitionStorageDescriptorNumberOfBuckets
+    , fmap (("NumberOfBuckets",) . toJSON) _gluePartitionStorageDescriptorNumberOfBuckets
     , fmap (("OutputFormat",) . toJSON) _gluePartitionStorageDescriptorOutputFormat
     , fmap (("Parameters",) . toJSON) _gluePartitionStorageDescriptorParameters
     , fmap (("SerdeInfo",) . toJSON) _gluePartitionStorageDescriptorSerdeInfo
     , fmap (("SkewedInfo",) . toJSON) _gluePartitionStorageDescriptorSkewedInfo
     , fmap (("SortColumns",) . toJSON) _gluePartitionStorageDescriptorSortColumns
-    , fmap (("StoredAsSubDirectories",) . toJSON . fmap Bool') _gluePartitionStorageDescriptorStoredAsSubDirectories
+    , fmap (("StoredAsSubDirectories",) . toJSON) _gluePartitionStorageDescriptorStoredAsSubDirectories
     ]
 
 -- | Constructor for 'GluePartitionStorageDescriptor' containing required

--- a/library-gen/Stratosphere/ResourceProperties/GlueTableOrder.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GlueTableOrder.hs
@@ -23,7 +23,7 @@ instance ToJSON GlueTableOrder where
     object $
     catMaybes
     [ (Just . ("Column",) . toJSON) _glueTableOrderColumn
-    , (Just . ("SortOrder",) . toJSON . fmap Integer') _glueTableOrderSortOrder
+    , (Just . ("SortOrder",) . toJSON) _glueTableOrderSortOrder
     ]
 
 -- | Constructor for 'GlueTableOrder' containing required fields as arguments.

--- a/library-gen/Stratosphere/ResourceProperties/GlueTableStorageDescriptor.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GlueTableStorageDescriptor.hs
@@ -37,16 +37,16 @@ instance ToJSON GlueTableStorageDescriptor where
     catMaybes
     [ fmap (("BucketColumns",) . toJSON) _glueTableStorageDescriptorBucketColumns
     , fmap (("Columns",) . toJSON) _glueTableStorageDescriptorColumns
-    , fmap (("Compressed",) . toJSON . fmap Bool') _glueTableStorageDescriptorCompressed
+    , fmap (("Compressed",) . toJSON) _glueTableStorageDescriptorCompressed
     , fmap (("InputFormat",) . toJSON) _glueTableStorageDescriptorInputFormat
     , fmap (("Location",) . toJSON) _glueTableStorageDescriptorLocation
-    , fmap (("NumberOfBuckets",) . toJSON . fmap Integer') _glueTableStorageDescriptorNumberOfBuckets
+    , fmap (("NumberOfBuckets",) . toJSON) _glueTableStorageDescriptorNumberOfBuckets
     , fmap (("OutputFormat",) . toJSON) _glueTableStorageDescriptorOutputFormat
     , fmap (("Parameters",) . toJSON) _glueTableStorageDescriptorParameters
     , fmap (("SerdeInfo",) . toJSON) _glueTableStorageDescriptorSerdeInfo
     , fmap (("SkewedInfo",) . toJSON) _glueTableStorageDescriptorSkewedInfo
     , fmap (("SortColumns",) . toJSON) _glueTableStorageDescriptorSortColumns
-    , fmap (("StoredAsSubDirectories",) . toJSON . fmap Bool') _glueTableStorageDescriptorStoredAsSubDirectories
+    , fmap (("StoredAsSubDirectories",) . toJSON) _glueTableStorageDescriptorStoredAsSubDirectories
     ]
 
 -- | Constructor for 'GlueTableStorageDescriptor' containing required fields

--- a/library-gen/Stratosphere/ResourceProperties/GlueTableTableInput.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GlueTableTableInput.hs
@@ -36,7 +36,7 @@ instance ToJSON GlueTableTableInput where
     , fmap (("Owner",) . toJSON) _glueTableTableInputOwner
     , fmap (("Parameters",) . toJSON) _glueTableTableInputParameters
     , fmap (("PartitionKeys",) . toJSON) _glueTableTableInputPartitionKeys
-    , fmap (("Retention",) . toJSON . fmap Integer') _glueTableTableInputRetention
+    , fmap (("Retention",) . toJSON) _glueTableTableInputRetention
     , fmap (("StorageDescriptor",) . toJSON) _glueTableTableInputStorageDescriptor
     , fmap (("TableType",) . toJSON) _glueTableTableInputTableType
     , fmap (("ViewExpandedText",) . toJSON) _glueTableTableInputViewExpandedText

--- a/library-gen/Stratosphere/ResourceProperties/GuardDutyFilterCondition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/GuardDutyFilterCondition.hs
@@ -26,9 +26,9 @@ instance ToJSON GuardDutyFilterCondition where
     object $
     catMaybes
     [ fmap (("Eq",) . toJSON) _guardDutyFilterConditionEq
-    , fmap (("Gte",) . toJSON . fmap Integer') _guardDutyFilterConditionGte
-    , fmap (("Lt",) . toJSON . fmap Integer') _guardDutyFilterConditionLt
-    , fmap (("Lte",) . toJSON . fmap Integer') _guardDutyFilterConditionLte
+    , fmap (("Gte",) . toJSON) _guardDutyFilterConditionGte
+    , fmap (("Lt",) . toJSON) _guardDutyFilterConditionLt
+    , fmap (("Lte",) . toJSON) _guardDutyFilterConditionLte
     , fmap (("Neq",) . toJSON) _guardDutyFilterConditionNeq
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/IAMUserLoginProfile.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IAMUserLoginProfile.hs
@@ -23,7 +23,7 @@ instance ToJSON IAMUserLoginProfile where
     object $
     catMaybes
     [ (Just . ("Password",) . toJSON) _iAMUserLoginProfilePassword
-    , fmap (("PasswordResetRequired",) . toJSON . fmap Bool') _iAMUserLoginProfilePasswordResetRequired
+    , fmap (("PasswordResetRequired",) . toJSON) _iAMUserLoginProfilePasswordResetRequired
     ]
 
 -- | Constructor for 'IAMUserLoginProfile' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsChannelRetentionPeriod.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsChannelRetentionPeriod.hs
@@ -22,8 +22,8 @@ instance ToJSON IoTAnalyticsChannelRetentionPeriod where
   toJSON IoTAnalyticsChannelRetentionPeriod{..} =
     object $
     catMaybes
-    [ fmap (("NumberOfDays",) . toJSON . fmap Integer') _ioTAnalyticsChannelRetentionPeriodNumberOfDays
-    , fmap (("Unlimited",) . toJSON . fmap Bool') _ioTAnalyticsChannelRetentionPeriodUnlimited
+    [ fmap (("NumberOfDays",) . toJSON) _ioTAnalyticsChannelRetentionPeriodNumberOfDays
+    , fmap (("Unlimited",) . toJSON) _ioTAnalyticsChannelRetentionPeriodUnlimited
     ]
 
 -- | Constructor for 'IoTAnalyticsChannelRetentionPeriod' containing required

--- a/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetDeltaTime.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetDeltaTime.hs
@@ -22,7 +22,7 @@ instance ToJSON IoTAnalyticsDatasetDeltaTime where
   toJSON IoTAnalyticsDatasetDeltaTime{..} =
     object $
     catMaybes
-    [ (Just . ("OffsetSeconds",) . toJSON . fmap Integer') _ioTAnalyticsDatasetDeltaTimeOffsetSeconds
+    [ (Just . ("OffsetSeconds",) . toJSON) _ioTAnalyticsDatasetDeltaTimeOffsetSeconds
     , (Just . ("TimeExpression",) . toJSON) _ioTAnalyticsDatasetDeltaTimeTimeExpression
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetResourceConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetResourceConfiguration.hs
@@ -24,7 +24,7 @@ instance ToJSON IoTAnalyticsDatasetResourceConfiguration where
     object $
     catMaybes
     [ (Just . ("ComputeType",) . toJSON) _ioTAnalyticsDatasetResourceConfigurationComputeType
-    , (Just . ("VolumeSizeInGB",) . toJSON . fmap Integer') _ioTAnalyticsDatasetResourceConfigurationVolumeSizeInGB
+    , (Just . ("VolumeSizeInGB",) . toJSON) _ioTAnalyticsDatasetResourceConfigurationVolumeSizeInGB
     ]
 
 -- | Constructor for 'IoTAnalyticsDatasetResourceConfiguration' containing

--- a/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetRetentionPeriod.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetRetentionPeriod.hs
@@ -22,8 +22,8 @@ instance ToJSON IoTAnalyticsDatasetRetentionPeriod where
   toJSON IoTAnalyticsDatasetRetentionPeriod{..} =
     object $
     catMaybes
-    [ (Just . ("NumberOfDays",) . toJSON . fmap Integer') _ioTAnalyticsDatasetRetentionPeriodNumberOfDays
-    , (Just . ("Unlimited",) . toJSON . fmap Bool') _ioTAnalyticsDatasetRetentionPeriodUnlimited
+    [ (Just . ("NumberOfDays",) . toJSON) _ioTAnalyticsDatasetRetentionPeriodNumberOfDays
+    , (Just . ("Unlimited",) . toJSON) _ioTAnalyticsDatasetRetentionPeriodUnlimited
     ]
 
 -- | Constructor for 'IoTAnalyticsDatasetRetentionPeriod' containing required

--- a/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetVariable.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatasetVariable.hs
@@ -27,7 +27,7 @@ instance ToJSON IoTAnalyticsDatasetVariable where
     object $
     catMaybes
     [ fmap (("DatasetContentVersionValue",) . toJSON) _ioTAnalyticsDatasetVariableDatasetContentVersionValue
-    , fmap (("DoubleValue",) . toJSON . fmap Double') _ioTAnalyticsDatasetVariableDoubleValue
+    , fmap (("DoubleValue",) . toJSON) _ioTAnalyticsDatasetVariableDoubleValue
     , fmap (("OutputFileUriValue",) . toJSON) _ioTAnalyticsDatasetVariableOutputFileUriValue
     , fmap (("StringValue",) . toJSON) _ioTAnalyticsDatasetVariableStringValue
     , (Just . ("VariableName",) . toJSON) _ioTAnalyticsDatasetVariableVariableName

--- a/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatastoreRetentionPeriod.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsDatastoreRetentionPeriod.hs
@@ -22,8 +22,8 @@ instance ToJSON IoTAnalyticsDatastoreRetentionPeriod where
   toJSON IoTAnalyticsDatastoreRetentionPeriod{..} =
     object $
     catMaybes
-    [ fmap (("NumberOfDays",) . toJSON . fmap Integer') _ioTAnalyticsDatastoreRetentionPeriodNumberOfDays
-    , fmap (("Unlimited",) . toJSON . fmap Bool') _ioTAnalyticsDatastoreRetentionPeriodUnlimited
+    [ fmap (("NumberOfDays",) . toJSON) _ioTAnalyticsDatastoreRetentionPeriodNumberOfDays
+    , fmap (("Unlimited",) . toJSON) _ioTAnalyticsDatastoreRetentionPeriodUnlimited
     ]
 
 -- | Constructor for 'IoTAnalyticsDatastoreRetentionPeriod' containing

--- a/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsPipelineLambda.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTAnalyticsPipelineLambda.hs
@@ -24,7 +24,7 @@ instance ToJSON IoTAnalyticsPipelineLambda where
   toJSON IoTAnalyticsPipelineLambda{..} =
     object $
     catMaybes
-    [ fmap (("BatchSize",) . toJSON . fmap Integer') _ioTAnalyticsPipelineLambdaBatchSize
+    [ fmap (("BatchSize",) . toJSON) _ioTAnalyticsPipelineLambdaBatchSize
     , fmap (("LambdaName",) . toJSON) _ioTAnalyticsPipelineLambdaLambdaName
     , fmap (("Name",) . toJSON) _ioTAnalyticsPipelineLambdaName
     , fmap (("Next",) . toJSON) _ioTAnalyticsPipelineLambdaNext

--- a/library-gen/Stratosphere/ResourceProperties/IoTTopicRuleSqsAction.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTTopicRuleSqsAction.hs
@@ -25,7 +25,7 @@ instance ToJSON IoTTopicRuleSqsAction where
     catMaybes
     [ (Just . ("QueueUrl",) . toJSON) _ioTTopicRuleSqsActionQueueUrl
     , (Just . ("RoleArn",) . toJSON) _ioTTopicRuleSqsActionRoleArn
-    , fmap (("UseBase64",) . toJSON . fmap Bool') _ioTTopicRuleSqsActionUseBase64
+    , fmap (("UseBase64",) . toJSON) _ioTTopicRuleSqsActionUseBase64
     ]
 
 -- | Constructor for 'IoTTopicRuleSqsAction' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/IoTTopicRuleTopicRulePayload.hs
+++ b/library-gen/Stratosphere/ResourceProperties/IoTTopicRuleTopicRulePayload.hs
@@ -30,7 +30,7 @@ instance ToJSON IoTTopicRuleTopicRulePayload where
     , fmap (("AwsIotSqlVersion",) . toJSON) _ioTTopicRuleTopicRulePayloadAwsIotSqlVersion
     , fmap (("Description",) . toJSON) _ioTTopicRuleTopicRulePayloadDescription
     , fmap (("ErrorAction",) . toJSON) _ioTTopicRuleTopicRulePayloadErrorAction
-    , (Just . ("RuleDisabled",) . toJSON . fmap Bool') _ioTTopicRuleTopicRulePayloadRuleDisabled
+    , (Just . ("RuleDisabled",) . toJSON) _ioTTopicRuleTopicRulePayloadRuleDisabled
     , (Just . ("Sql",) . toJSON) _ioTTopicRuleTopicRulePayloadSql
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsApplicationInputParallelism.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsApplicationInputParallelism.hs
@@ -23,7 +23,7 @@ instance ToJSON KinesisAnalyticsApplicationInputParallelism where
   toJSON KinesisAnalyticsApplicationInputParallelism{..} =
     object $
     catMaybes
-    [ fmap (("Count",) . toJSON . fmap Integer') _kinesisAnalyticsApplicationInputParallelismCount
+    [ fmap (("Count",) . toJSON) _kinesisAnalyticsApplicationInputParallelismCount
     ]
 
 -- | Constructor for 'KinesisAnalyticsApplicationInputParallelism' containing

--- a/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationApplicationSnapshotConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationApplicationSnapshotConfiguration.hs
@@ -23,7 +23,7 @@ instance ToJSON KinesisAnalyticsV2ApplicationApplicationSnapshotConfiguration wh
   toJSON KinesisAnalyticsV2ApplicationApplicationSnapshotConfiguration{..} =
     object $
     catMaybes
-    [ (Just . ("SnapshotsEnabled",) . toJSON . fmap Bool') _kinesisAnalyticsV2ApplicationApplicationSnapshotConfigurationSnapshotsEnabled
+    [ (Just . ("SnapshotsEnabled",) . toJSON) _kinesisAnalyticsV2ApplicationApplicationSnapshotConfigurationSnapshotsEnabled
     ]
 
 -- | Constructor for

--- a/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationCheckpointConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationCheckpointConfiguration.hs
@@ -26,10 +26,10 @@ instance ToJSON KinesisAnalyticsV2ApplicationCheckpointConfiguration where
   toJSON KinesisAnalyticsV2ApplicationCheckpointConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("CheckpointInterval",) . toJSON . fmap Integer') _kinesisAnalyticsV2ApplicationCheckpointConfigurationCheckpointInterval
-    , fmap (("CheckpointingEnabled",) . toJSON . fmap Bool') _kinesisAnalyticsV2ApplicationCheckpointConfigurationCheckpointingEnabled
+    [ fmap (("CheckpointInterval",) . toJSON) _kinesisAnalyticsV2ApplicationCheckpointConfigurationCheckpointInterval
+    , fmap (("CheckpointingEnabled",) . toJSON) _kinesisAnalyticsV2ApplicationCheckpointConfigurationCheckpointingEnabled
     , (Just . ("ConfigurationType",) . toJSON) _kinesisAnalyticsV2ApplicationCheckpointConfigurationConfigurationType
-    , fmap (("MinPauseBetweenCheckpoints",) . toJSON . fmap Integer') _kinesisAnalyticsV2ApplicationCheckpointConfigurationMinPauseBetweenCheckpoints
+    , fmap (("MinPauseBetweenCheckpoints",) . toJSON) _kinesisAnalyticsV2ApplicationCheckpointConfigurationMinPauseBetweenCheckpoints
     ]
 
 -- | Constructor for 'KinesisAnalyticsV2ApplicationCheckpointConfiguration'

--- a/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationInputParallelism.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationInputParallelism.hs
@@ -23,7 +23,7 @@ instance ToJSON KinesisAnalyticsV2ApplicationInputParallelism where
   toJSON KinesisAnalyticsV2ApplicationInputParallelism{..} =
     object $
     catMaybes
-    [ fmap (("Count",) . toJSON . fmap Integer') _kinesisAnalyticsV2ApplicationInputParallelismCount
+    [ fmap (("Count",) . toJSON) _kinesisAnalyticsV2ApplicationInputParallelismCount
     ]
 
 -- | Constructor for 'KinesisAnalyticsV2ApplicationInputParallelism'

--- a/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationParallelismConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisAnalyticsV2ApplicationParallelismConfiguration.hs
@@ -26,10 +26,10 @@ instance ToJSON KinesisAnalyticsV2ApplicationParallelismConfiguration where
   toJSON KinesisAnalyticsV2ApplicationParallelismConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("AutoScalingEnabled",) . toJSON . fmap Bool') _kinesisAnalyticsV2ApplicationParallelismConfigurationAutoScalingEnabled
+    [ fmap (("AutoScalingEnabled",) . toJSON) _kinesisAnalyticsV2ApplicationParallelismConfigurationAutoScalingEnabled
     , (Just . ("ConfigurationType",) . toJSON) _kinesisAnalyticsV2ApplicationParallelismConfigurationConfigurationType
-    , fmap (("Parallelism",) . toJSON . fmap Integer') _kinesisAnalyticsV2ApplicationParallelismConfigurationParallelism
-    , fmap (("ParallelismPerKPU",) . toJSON . fmap Integer') _kinesisAnalyticsV2ApplicationParallelismConfigurationParallelismPerKPU
+    , fmap (("Parallelism",) . toJSON) _kinesisAnalyticsV2ApplicationParallelismConfigurationParallelism
+    , fmap (("ParallelismPerKPU",) . toJSON) _kinesisAnalyticsV2ApplicationParallelismConfigurationParallelismPerKPU
     ]
 
 -- | Constructor for 'KinesisAnalyticsV2ApplicationParallelismConfiguration'

--- a/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamBufferingHints.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamBufferingHints.hs
@@ -24,8 +24,8 @@ instance ToJSON KinesisFirehoseDeliveryStreamBufferingHints where
   toJSON KinesisFirehoseDeliveryStreamBufferingHints{..} =
     object $
     catMaybes
-    [ (Just . ("IntervalInSeconds",) . toJSON . fmap Integer') _kinesisFirehoseDeliveryStreamBufferingHintsIntervalInSeconds
-    , (Just . ("SizeInMBs",) . toJSON . fmap Integer') _kinesisFirehoseDeliveryStreamBufferingHintsSizeInMBs
+    [ (Just . ("IntervalInSeconds",) . toJSON) _kinesisFirehoseDeliveryStreamBufferingHintsIntervalInSeconds
+    , (Just . ("SizeInMBs",) . toJSON) _kinesisFirehoseDeliveryStreamBufferingHintsSizeInMBs
     ]
 
 -- | Constructor for 'KinesisFirehoseDeliveryStreamBufferingHints' containing

--- a/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamCloudWatchLoggingOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamCloudWatchLoggingOptions.hs
@@ -25,7 +25,7 @@ instance ToJSON KinesisFirehoseDeliveryStreamCloudWatchLoggingOptions where
   toJSON KinesisFirehoseDeliveryStreamCloudWatchLoggingOptions{..} =
     object $
     catMaybes
-    [ fmap (("Enabled",) . toJSON . fmap Bool') _kinesisFirehoseDeliveryStreamCloudWatchLoggingOptionsEnabled
+    [ fmap (("Enabled",) . toJSON) _kinesisFirehoseDeliveryStreamCloudWatchLoggingOptionsEnabled
     , fmap (("LogGroupName",) . toJSON) _kinesisFirehoseDeliveryStreamCloudWatchLoggingOptionsLogGroupName
     , fmap (("LogStreamName",) . toJSON) _kinesisFirehoseDeliveryStreamCloudWatchLoggingOptionsLogStreamName
     ]

--- a/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamElasticsearchBufferingHints.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamElasticsearchBufferingHints.hs
@@ -24,8 +24,8 @@ instance ToJSON KinesisFirehoseDeliveryStreamElasticsearchBufferingHints where
   toJSON KinesisFirehoseDeliveryStreamElasticsearchBufferingHints{..} =
     object $
     catMaybes
-    [ (Just . ("IntervalInSeconds",) . toJSON . fmap Integer') _kinesisFirehoseDeliveryStreamElasticsearchBufferingHintsIntervalInSeconds
-    , (Just . ("SizeInMBs",) . toJSON . fmap Integer') _kinesisFirehoseDeliveryStreamElasticsearchBufferingHintsSizeInMBs
+    [ (Just . ("IntervalInSeconds",) . toJSON) _kinesisFirehoseDeliveryStreamElasticsearchBufferingHintsIntervalInSeconds
+    , (Just . ("SizeInMBs",) . toJSON) _kinesisFirehoseDeliveryStreamElasticsearchBufferingHintsSizeInMBs
     ]
 
 -- | Constructor for

--- a/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamElasticsearchRetryOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamElasticsearchRetryOptions.hs
@@ -23,7 +23,7 @@ instance ToJSON KinesisFirehoseDeliveryStreamElasticsearchRetryOptions where
   toJSON KinesisFirehoseDeliveryStreamElasticsearchRetryOptions{..} =
     object $
     catMaybes
-    [ (Just . ("DurationInSeconds",) . toJSON . fmap Integer') _kinesisFirehoseDeliveryStreamElasticsearchRetryOptionsDurationInSeconds
+    [ (Just . ("DurationInSeconds",) . toJSON) _kinesisFirehoseDeliveryStreamElasticsearchRetryOptionsDurationInSeconds
     ]
 
 -- | Constructor for 'KinesisFirehoseDeliveryStreamElasticsearchRetryOptions'

--- a/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamProcessingConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamProcessingConfiguration.hs
@@ -24,7 +24,7 @@ instance ToJSON KinesisFirehoseDeliveryStreamProcessingConfiguration where
   toJSON KinesisFirehoseDeliveryStreamProcessingConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("Enabled",) . toJSON . fmap Bool') _kinesisFirehoseDeliveryStreamProcessingConfigurationEnabled
+    [ fmap (("Enabled",) . toJSON) _kinesisFirehoseDeliveryStreamProcessingConfigurationEnabled
     , fmap (("Processors",) . toJSON) _kinesisFirehoseDeliveryStreamProcessingConfigurationProcessors
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamSplunkDestinationConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamSplunkDestinationConfiguration.hs
@@ -35,7 +35,7 @@ instance ToJSON KinesisFirehoseDeliveryStreamSplunkDestinationConfiguration wher
     object $
     catMaybes
     [ fmap (("CloudWatchLoggingOptions",) . toJSON) _kinesisFirehoseDeliveryStreamSplunkDestinationConfigurationCloudWatchLoggingOptions
-    , fmap (("HECAcknowledgmentTimeoutInSeconds",) . toJSON . fmap Integer') _kinesisFirehoseDeliveryStreamSplunkDestinationConfigurationHECAcknowledgmentTimeoutInSeconds
+    , fmap (("HECAcknowledgmentTimeoutInSeconds",) . toJSON) _kinesisFirehoseDeliveryStreamSplunkDestinationConfigurationHECAcknowledgmentTimeoutInSeconds
     , (Just . ("HECEndpoint",) . toJSON) _kinesisFirehoseDeliveryStreamSplunkDestinationConfigurationHECEndpoint
     , (Just . ("HECEndpointType",) . toJSON) _kinesisFirehoseDeliveryStreamSplunkDestinationConfigurationHECEndpointType
     , (Just . ("HECToken",) . toJSON) _kinesisFirehoseDeliveryStreamSplunkDestinationConfigurationHECToken

--- a/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamSplunkRetryOptions.hs
+++ b/library-gen/Stratosphere/ResourceProperties/KinesisFirehoseDeliveryStreamSplunkRetryOptions.hs
@@ -23,7 +23,7 @@ instance ToJSON KinesisFirehoseDeliveryStreamSplunkRetryOptions where
   toJSON KinesisFirehoseDeliveryStreamSplunkRetryOptions{..} =
     object $
     catMaybes
-    [ (Just . ("DurationInSeconds",) . toJSON . fmap Integer') _kinesisFirehoseDeliveryStreamSplunkRetryOptionsDurationInSeconds
+    [ (Just . ("DurationInSeconds",) . toJSON) _kinesisFirehoseDeliveryStreamSplunkRetryOptionsDurationInSeconds
     ]
 
 -- | Constructor for 'KinesisFirehoseDeliveryStreamSplunkRetryOptions'

--- a/library-gen/Stratosphere/ResourceProperties/LambdaAliasVersionWeight.hs
+++ b/library-gen/Stratosphere/ResourceProperties/LambdaAliasVersionWeight.hs
@@ -23,7 +23,7 @@ instance ToJSON LambdaAliasVersionWeight where
     object $
     catMaybes
     [ (Just . ("FunctionVersion",) . toJSON) _lambdaAliasVersionWeightFunctionVersion
-    , (Just . ("FunctionWeight",) . toJSON . fmap Double') _lambdaAliasVersionWeightFunctionWeight
+    , (Just . ("FunctionWeight",) . toJSON) _lambdaAliasVersionWeightFunctionWeight
     ]
 
 -- | Constructor for 'LambdaAliasVersionWeight' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/LogsMetricFilterMetricTransformation.hs
+++ b/library-gen/Stratosphere/ResourceProperties/LogsMetricFilterMetricTransformation.hs
@@ -24,7 +24,7 @@ instance ToJSON LogsMetricFilterMetricTransformation where
   toJSON LogsMetricFilterMetricTransformation{..} =
     object $
     catMaybes
-    [ fmap (("DefaultValue",) . toJSON . fmap Double') _logsMetricFilterMetricTransformationDefaultValue
+    [ fmap (("DefaultValue",) . toJSON) _logsMetricFilterMetricTransformationDefaultValue
     , (Just . ("MetricName",) . toJSON) _logsMetricFilterMetricTransformationMetricName
     , (Just . ("MetricNamespace",) . toJSON) _logsMetricFilterMetricTransformationMetricNamespace
     , (Just . ("MetricValue",) . toJSON) _logsMetricFilterMetricTransformationMetricValue

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksAppEnvironmentVariable.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksAppEnvironmentVariable.hs
@@ -24,7 +24,7 @@ instance ToJSON OpsWorksAppEnvironmentVariable where
     object $
     catMaybes
     [ (Just . ("Key",) . toJSON) _opsWorksAppEnvironmentVariableKey
-    , fmap (("Secure",) . toJSON . fmap Bool') _opsWorksAppEnvironmentVariableSecure
+    , fmap (("Secure",) . toJSON) _opsWorksAppEnvironmentVariableSecure
     , (Just . ("Value",) . toJSON) _opsWorksAppEnvironmentVariableValue
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksInstanceEbsBlockDevice.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksInstanceEbsBlockDevice.hs
@@ -25,10 +25,10 @@ instance ToJSON OpsWorksInstanceEbsBlockDevice where
   toJSON OpsWorksInstanceEbsBlockDevice{..} =
     object $
     catMaybes
-    [ fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _opsWorksInstanceEbsBlockDeviceDeleteOnTermination
-    , fmap (("Iops",) . toJSON . fmap Integer') _opsWorksInstanceEbsBlockDeviceIops
+    [ fmap (("DeleteOnTermination",) . toJSON) _opsWorksInstanceEbsBlockDeviceDeleteOnTermination
+    , fmap (("Iops",) . toJSON) _opsWorksInstanceEbsBlockDeviceIops
     , fmap (("SnapshotId",) . toJSON) _opsWorksInstanceEbsBlockDeviceSnapshotId
-    , fmap (("VolumeSize",) . toJSON . fmap Integer') _opsWorksInstanceEbsBlockDeviceVolumeSize
+    , fmap (("VolumeSize",) . toJSON) _opsWorksInstanceEbsBlockDeviceVolumeSize
     , fmap (("VolumeType",) . toJSON) _opsWorksInstanceEbsBlockDeviceVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerAutoScalingThresholds.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerAutoScalingThresholds.hs
@@ -26,12 +26,12 @@ instance ToJSON OpsWorksLayerAutoScalingThresholds where
   toJSON OpsWorksLayerAutoScalingThresholds{..} =
     object $
     catMaybes
-    [ fmap (("CpuThreshold",) . toJSON . fmap Double') _opsWorksLayerAutoScalingThresholdsCpuThreshold
-    , fmap (("IgnoreMetricsTime",) . toJSON . fmap Integer') _opsWorksLayerAutoScalingThresholdsIgnoreMetricsTime
-    , fmap (("InstanceCount",) . toJSON . fmap Integer') _opsWorksLayerAutoScalingThresholdsInstanceCount
-    , fmap (("LoadThreshold",) . toJSON . fmap Double') _opsWorksLayerAutoScalingThresholdsLoadThreshold
-    , fmap (("MemoryThreshold",) . toJSON . fmap Double') _opsWorksLayerAutoScalingThresholdsMemoryThreshold
-    , fmap (("ThresholdsWaitTime",) . toJSON . fmap Integer') _opsWorksLayerAutoScalingThresholdsThresholdsWaitTime
+    [ fmap (("CpuThreshold",) . toJSON) _opsWorksLayerAutoScalingThresholdsCpuThreshold
+    , fmap (("IgnoreMetricsTime",) . toJSON) _opsWorksLayerAutoScalingThresholdsIgnoreMetricsTime
+    , fmap (("InstanceCount",) . toJSON) _opsWorksLayerAutoScalingThresholdsInstanceCount
+    , fmap (("LoadThreshold",) . toJSON) _opsWorksLayerAutoScalingThresholdsLoadThreshold
+    , fmap (("MemoryThreshold",) . toJSON) _opsWorksLayerAutoScalingThresholdsMemoryThreshold
+    , fmap (("ThresholdsWaitTime",) . toJSON) _opsWorksLayerAutoScalingThresholdsThresholdsWaitTime
     ]
 
 -- | Constructor for 'OpsWorksLayerAutoScalingThresholds' containing required

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerLoadBasedAutoScaling.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerLoadBasedAutoScaling.hs
@@ -24,7 +24,7 @@ instance ToJSON OpsWorksLayerLoadBasedAutoScaling where
     object $
     catMaybes
     [ fmap (("DownScaling",) . toJSON) _opsWorksLayerLoadBasedAutoScalingDownScaling
-    , fmap (("Enable",) . toJSON . fmap Bool') _opsWorksLayerLoadBasedAutoScalingEnable
+    , fmap (("Enable",) . toJSON) _opsWorksLayerLoadBasedAutoScalingEnable
     , fmap (("UpScaling",) . toJSON) _opsWorksLayerLoadBasedAutoScalingUpScaling
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerShutdownEventConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerShutdownEventConfiguration.hs
@@ -23,8 +23,8 @@ instance ToJSON OpsWorksLayerShutdownEventConfiguration where
   toJSON OpsWorksLayerShutdownEventConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("DelayUntilElbConnectionsDrained",) . toJSON . fmap Bool') _opsWorksLayerShutdownEventConfigurationDelayUntilElbConnectionsDrained
-    , fmap (("ExecutionTimeout",) . toJSON . fmap Integer') _opsWorksLayerShutdownEventConfigurationExecutionTimeout
+    [ fmap (("DelayUntilElbConnectionsDrained",) . toJSON) _opsWorksLayerShutdownEventConfigurationDelayUntilElbConnectionsDrained
+    , fmap (("ExecutionTimeout",) . toJSON) _opsWorksLayerShutdownEventConfigurationExecutionTimeout
     ]
 
 -- | Constructor for 'OpsWorksLayerShutdownEventConfiguration' containing

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerVolumeConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksLayerVolumeConfiguration.hs
@@ -27,12 +27,12 @@ instance ToJSON OpsWorksLayerVolumeConfiguration where
   toJSON OpsWorksLayerVolumeConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("Encrypted",) . toJSON . fmap Bool') _opsWorksLayerVolumeConfigurationEncrypted
-    , fmap (("Iops",) . toJSON . fmap Integer') _opsWorksLayerVolumeConfigurationIops
+    [ fmap (("Encrypted",) . toJSON) _opsWorksLayerVolumeConfigurationEncrypted
+    , fmap (("Iops",) . toJSON) _opsWorksLayerVolumeConfigurationIops
     , fmap (("MountPoint",) . toJSON) _opsWorksLayerVolumeConfigurationMountPoint
-    , fmap (("NumberOfDisks",) . toJSON . fmap Integer') _opsWorksLayerVolumeConfigurationNumberOfDisks
-    , fmap (("RaidLevel",) . toJSON . fmap Integer') _opsWorksLayerVolumeConfigurationRaidLevel
-    , fmap (("Size",) . toJSON . fmap Integer') _opsWorksLayerVolumeConfigurationSize
+    , fmap (("NumberOfDisks",) . toJSON) _opsWorksLayerVolumeConfigurationNumberOfDisks
+    , fmap (("RaidLevel",) . toJSON) _opsWorksLayerVolumeConfigurationRaidLevel
+    , fmap (("Size",) . toJSON) _opsWorksLayerVolumeConfigurationSize
     , fmap (("VolumeType",) . toJSON) _opsWorksLayerVolumeConfigurationVolumeType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/OpsWorksStackChefConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/OpsWorksStackChefConfiguration.hs
@@ -23,7 +23,7 @@ instance ToJSON OpsWorksStackChefConfiguration where
     object $
     catMaybes
     [ fmap (("BerkshelfVersion",) . toJSON) _opsWorksStackChefConfigurationBerkshelfVersion
-    , fmap (("ManageBerkshelf",) . toJSON . fmap Bool') _opsWorksStackChefConfigurationManageBerkshelf
+    , fmap (("ManageBerkshelf",) . toJSON) _opsWorksStackChefConfigurationManageBerkshelf
     ]
 
 -- | Constructor for 'OpsWorksStackChefConfiguration' containing required

--- a/library-gen/Stratosphere/ResourceProperties/RDSDBClusterScalingConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/RDSDBClusterScalingConfiguration.hs
@@ -24,10 +24,10 @@ instance ToJSON RDSDBClusterScalingConfiguration where
   toJSON RDSDBClusterScalingConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("AutoPause",) . toJSON . fmap Bool') _rDSDBClusterScalingConfigurationAutoPause
-    , fmap (("MaxCapacity",) . toJSON . fmap Integer') _rDSDBClusterScalingConfigurationMaxCapacity
-    , fmap (("MinCapacity",) . toJSON . fmap Integer') _rDSDBClusterScalingConfigurationMinCapacity
-    , fmap (("SecondsUntilAutoPause",) . toJSON . fmap Integer') _rDSDBClusterScalingConfigurationSecondsUntilAutoPause
+    [ fmap (("AutoPause",) . toJSON) _rDSDBClusterScalingConfigurationAutoPause
+    , fmap (("MaxCapacity",) . toJSON) _rDSDBClusterScalingConfigurationMaxCapacity
+    , fmap (("MinCapacity",) . toJSON) _rDSDBClusterScalingConfigurationMinCapacity
+    , fmap (("SecondsUntilAutoPause",) . toJSON) _rDSDBClusterScalingConfigurationSecondsUntilAutoPause
     ]
 
 -- | Constructor for 'RDSDBClusterScalingConfiguration' containing required

--- a/library-gen/Stratosphere/ResourceProperties/RDSOptionGroupOptionConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/RDSOptionGroupOptionConfiguration.hs
@@ -30,7 +30,7 @@ instance ToJSON RDSOptionGroupOptionConfiguration where
     , (Just . ("OptionName",) . toJSON) _rDSOptionGroupOptionConfigurationOptionName
     , fmap (("OptionSettings",) . toJSON) _rDSOptionGroupOptionConfigurationOptionSettings
     , fmap (("OptionVersion",) . toJSON) _rDSOptionGroupOptionConfigurationOptionVersion
-    , fmap (("Port",) . toJSON . fmap Integer') _rDSOptionGroupOptionConfigurationPort
+    , fmap (("Port",) . toJSON) _rDSOptionGroupOptionConfigurationPort
     , fmap (("VpcSecurityGroupMemberships",) . toJSON) _rDSOptionGroupOptionConfigurationVpcSecurityGroupMemberships
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/Route53HealthCheckHealthCheckConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/Route53HealthCheckHealthCheckConfig.hs
@@ -38,17 +38,17 @@ instance ToJSON Route53HealthCheckHealthCheckConfig where
     catMaybes
     [ fmap (("AlarmIdentifier",) . toJSON) _route53HealthCheckHealthCheckConfigAlarmIdentifier
     , fmap (("ChildHealthChecks",) . toJSON) _route53HealthCheckHealthCheckConfigChildHealthChecks
-    , fmap (("EnableSNI",) . toJSON . fmap Bool') _route53HealthCheckHealthCheckConfigEnableSNI
-    , fmap (("FailureThreshold",) . toJSON . fmap Integer') _route53HealthCheckHealthCheckConfigFailureThreshold
+    , fmap (("EnableSNI",) . toJSON) _route53HealthCheckHealthCheckConfigEnableSNI
+    , fmap (("FailureThreshold",) . toJSON) _route53HealthCheckHealthCheckConfigFailureThreshold
     , fmap (("FullyQualifiedDomainName",) . toJSON) _route53HealthCheckHealthCheckConfigFullyQualifiedDomainName
-    , fmap (("HealthThreshold",) . toJSON . fmap Integer') _route53HealthCheckHealthCheckConfigHealthThreshold
+    , fmap (("HealthThreshold",) . toJSON) _route53HealthCheckHealthCheckConfigHealthThreshold
     , fmap (("IPAddress",) . toJSON) _route53HealthCheckHealthCheckConfigIPAddress
     , fmap (("InsufficientDataHealthStatus",) . toJSON) _route53HealthCheckHealthCheckConfigInsufficientDataHealthStatus
-    , fmap (("Inverted",) . toJSON . fmap Bool') _route53HealthCheckHealthCheckConfigInverted
-    , fmap (("MeasureLatency",) . toJSON . fmap Bool') _route53HealthCheckHealthCheckConfigMeasureLatency
-    , fmap (("Port",) . toJSON . fmap Integer') _route53HealthCheckHealthCheckConfigPort
+    , fmap (("Inverted",) . toJSON) _route53HealthCheckHealthCheckConfigInverted
+    , fmap (("MeasureLatency",) . toJSON) _route53HealthCheckHealthCheckConfigMeasureLatency
+    , fmap (("Port",) . toJSON) _route53HealthCheckHealthCheckConfigPort
     , fmap (("Regions",) . toJSON) _route53HealthCheckHealthCheckConfigRegions
-    , fmap (("RequestInterval",) . toJSON . fmap Integer') _route53HealthCheckHealthCheckConfigRequestInterval
+    , fmap (("RequestInterval",) . toJSON) _route53HealthCheckHealthCheckConfigRequestInterval
     , fmap (("ResourcePath",) . toJSON) _route53HealthCheckHealthCheckConfigResourcePath
     , fmap (("SearchString",) . toJSON) _route53HealthCheckHealthCheckConfigSearchString
     , (Just . ("Type",) . toJSON) _route53HealthCheckHealthCheckConfigType

--- a/library-gen/Stratosphere/ResourceProperties/Route53RecordSetAliasTarget.hs
+++ b/library-gen/Stratosphere/ResourceProperties/Route53RecordSetAliasTarget.hs
@@ -24,7 +24,7 @@ instance ToJSON Route53RecordSetAliasTarget where
     object $
     catMaybes
     [ (Just . ("DNSName",) . toJSON) _route53RecordSetAliasTargetDNSName
-    , fmap (("EvaluateTargetHealth",) . toJSON . fmap Bool') _route53RecordSetAliasTargetEvaluateTargetHealth
+    , fmap (("EvaluateTargetHealth",) . toJSON) _route53RecordSetAliasTargetEvaluateTargetHealth
     , (Just . ("HostedZoneId",) . toJSON) _route53RecordSetAliasTargetHostedZoneId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/Route53RecordSetGroupAliasTarget.hs
+++ b/library-gen/Stratosphere/ResourceProperties/Route53RecordSetGroupAliasTarget.hs
@@ -24,7 +24,7 @@ instance ToJSON Route53RecordSetGroupAliasTarget where
     object $
     catMaybes
     [ (Just . ("DNSName",) . toJSON) _route53RecordSetGroupAliasTargetDNSName
-    , fmap (("EvaluateTargetHealth",) . toJSON . fmap Bool') _route53RecordSetGroupAliasTargetEvaluateTargetHealth
+    , fmap (("EvaluateTargetHealth",) . toJSON) _route53RecordSetGroupAliasTargetEvaluateTargetHealth
     , (Just . ("HostedZoneId",) . toJSON) _route53RecordSetGroupAliasTargetHostedZoneId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/Route53RecordSetGroupRecordSet.hs
+++ b/library-gen/Stratosphere/ResourceProperties/Route53RecordSetGroupRecordSet.hs
@@ -43,14 +43,14 @@ instance ToJSON Route53RecordSetGroupRecordSet where
     , fmap (("HealthCheckId",) . toJSON) _route53RecordSetGroupRecordSetHealthCheckId
     , fmap (("HostedZoneId",) . toJSON) _route53RecordSetGroupRecordSetHostedZoneId
     , fmap (("HostedZoneName",) . toJSON) _route53RecordSetGroupRecordSetHostedZoneName
-    , fmap (("MultiValueAnswer",) . toJSON . fmap Bool') _route53RecordSetGroupRecordSetMultiValueAnswer
+    , fmap (("MultiValueAnswer",) . toJSON) _route53RecordSetGroupRecordSetMultiValueAnswer
     , (Just . ("Name",) . toJSON) _route53RecordSetGroupRecordSetName
     , fmap (("Region",) . toJSON) _route53RecordSetGroupRecordSetRegion
     , fmap (("ResourceRecords",) . toJSON) _route53RecordSetGroupRecordSetResourceRecords
     , fmap (("SetIdentifier",) . toJSON) _route53RecordSetGroupRecordSetSetIdentifier
     , fmap (("TTL",) . toJSON) _route53RecordSetGroupRecordSetTTL
     , (Just . ("Type",) . toJSON) _route53RecordSetGroupRecordSetType
-    , fmap (("Weight",) . toJSON . fmap Integer') _route53RecordSetGroupRecordSetWeight
+    , fmap (("Weight",) . toJSON) _route53RecordSetGroupRecordSetWeight
     ]
 
 -- | Constructor for 'Route53RecordSetGroupRecordSet' containing required

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketAbortIncompleteMultipartUpload.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketAbortIncompleteMultipartUpload.hs
@@ -22,7 +22,7 @@ instance ToJSON S3BucketAbortIncompleteMultipartUpload where
   toJSON S3BucketAbortIncompleteMultipartUpload{..} =
     object $
     catMaybes
-    [ (Just . ("DaysAfterInitiation",) . toJSON . fmap Integer') _s3BucketAbortIncompleteMultipartUploadDaysAfterInitiation
+    [ (Just . ("DaysAfterInitiation",) . toJSON) _s3BucketAbortIncompleteMultipartUploadDaysAfterInitiation
     ]
 
 -- | Constructor for 'S3BucketAbortIncompleteMultipartUpload' containing

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketCorsRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketCorsRule.hs
@@ -31,7 +31,7 @@ instance ToJSON S3BucketCorsRule where
     , (Just . ("AllowedOrigins",) . toJSON) _s3BucketCorsRuleAllowedOrigins
     , fmap (("ExposedHeaders",) . toJSON) _s3BucketCorsRuleExposedHeaders
     , fmap (("Id",) . toJSON) _s3BucketCorsRuleId
-    , fmap (("MaxAge",) . toJSON . fmap Integer') _s3BucketCorsRuleMaxAge
+    , fmap (("MaxAge",) . toJSON) _s3BucketCorsRuleMaxAge
     ]
 
 -- | Constructor for 'S3BucketCorsRule' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketInventoryConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketInventoryConfiguration.hs
@@ -28,7 +28,7 @@ instance ToJSON S3BucketInventoryConfiguration where
     object $
     catMaybes
     [ (Just . ("Destination",) . toJSON) _s3BucketInventoryConfigurationDestination
-    , (Just . ("Enabled",) . toJSON . fmap Bool') _s3BucketInventoryConfigurationEnabled
+    , (Just . ("Enabled",) . toJSON) _s3BucketInventoryConfigurationEnabled
     , (Just . ("Id",) . toJSON) _s3BucketInventoryConfigurationId
     , (Just . ("IncludedObjectVersions",) . toJSON) _s3BucketInventoryConfigurationIncludedObjectVersions
     , fmap (("OptionalFields",) . toJSON) _s3BucketInventoryConfigurationOptionalFields

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketNoncurrentVersionTransition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketNoncurrentVersionTransition.hs
@@ -23,7 +23,7 @@ instance ToJSON S3BucketNoncurrentVersionTransition where
     object $
     catMaybes
     [ (Just . ("StorageClass",) . toJSON) _s3BucketNoncurrentVersionTransitionStorageClass
-    , (Just . ("TransitionInDays",) . toJSON . fmap Integer') _s3BucketNoncurrentVersionTransitionTransitionInDays
+    , (Just . ("TransitionInDays",) . toJSON) _s3BucketNoncurrentVersionTransitionTransitionInDays
     ]
 
 -- | Constructor for 'S3BucketNoncurrentVersionTransition' containing required

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketPublicAccessBlockConfiguration.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketPublicAccessBlockConfiguration.hs
@@ -25,10 +25,10 @@ instance ToJSON S3BucketPublicAccessBlockConfiguration where
   toJSON S3BucketPublicAccessBlockConfiguration{..} =
     object $
     catMaybes
-    [ fmap (("BlockPublicAcls",) . toJSON . fmap Bool') _s3BucketPublicAccessBlockConfigurationBlockPublicAcls
-    , fmap (("BlockPublicPolicy",) . toJSON . fmap Bool') _s3BucketPublicAccessBlockConfigurationBlockPublicPolicy
-    , fmap (("IgnorePublicAcls",) . toJSON . fmap Bool') _s3BucketPublicAccessBlockConfigurationIgnorePublicAcls
-    , fmap (("RestrictPublicBuckets",) . toJSON . fmap Bool') _s3BucketPublicAccessBlockConfigurationRestrictPublicBuckets
+    [ fmap (("BlockPublicAcls",) . toJSON) _s3BucketPublicAccessBlockConfigurationBlockPublicAcls
+    , fmap (("BlockPublicPolicy",) . toJSON) _s3BucketPublicAccessBlockConfigurationBlockPublicPolicy
+    , fmap (("IgnorePublicAcls",) . toJSON) _s3BucketPublicAccessBlockConfigurationIgnorePublicAcls
+    , fmap (("RestrictPublicBuckets",) . toJSON) _s3BucketPublicAccessBlockConfigurationRestrictPublicBuckets
     ]
 
 -- | Constructor for 'S3BucketPublicAccessBlockConfiguration' containing

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketRule.hs
@@ -37,9 +37,9 @@ instance ToJSON S3BucketRule where
     catMaybes
     [ fmap (("AbortIncompleteMultipartUpload",) . toJSON) _s3BucketRuleAbortIncompleteMultipartUpload
     , fmap (("ExpirationDate",) . toJSON) _s3BucketRuleExpirationDate
-    , fmap (("ExpirationInDays",) . toJSON . fmap Integer') _s3BucketRuleExpirationInDays
+    , fmap (("ExpirationInDays",) . toJSON) _s3BucketRuleExpirationInDays
     , fmap (("Id",) . toJSON) _s3BucketRuleId
-    , fmap (("NoncurrentVersionExpirationInDays",) . toJSON . fmap Integer') _s3BucketRuleNoncurrentVersionExpirationInDays
+    , fmap (("NoncurrentVersionExpirationInDays",) . toJSON) _s3BucketRuleNoncurrentVersionExpirationInDays
     , fmap (("NoncurrentVersionTransition",) . toJSON) _s3BucketRuleNoncurrentVersionTransition
     , fmap (("NoncurrentVersionTransitions",) . toJSON) _s3BucketRuleNoncurrentVersionTransitions
     , fmap (("Prefix",) . toJSON) _s3BucketRulePrefix

--- a/library-gen/Stratosphere/ResourceProperties/S3BucketTransition.hs
+++ b/library-gen/Stratosphere/ResourceProperties/S3BucketTransition.hs
@@ -25,7 +25,7 @@ instance ToJSON S3BucketTransition where
     catMaybes
     [ (Just . ("StorageClass",) . toJSON) _s3BucketTransitionStorageClass
     , fmap (("TransitionDate",) . toJSON) _s3BucketTransitionTransitionDate
-    , fmap (("TransitionInDays",) . toJSON . fmap Integer') _s3BucketTransitionTransitionInDays
+    , fmap (("TransitionInDays",) . toJSON) _s3BucketTransitionTransitionInDays
     ]
 
 -- | Constructor for 'S3BucketTransition' containing required fields as

--- a/library-gen/Stratosphere/ResourceProperties/SESConfigurationSetEventDestinationEventDestination.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SESConfigurationSetEventDestinationEventDestination.hs
@@ -29,7 +29,7 @@ instance ToJSON SESConfigurationSetEventDestinationEventDestination where
     object $
     catMaybes
     [ fmap (("CloudWatchDestination",) . toJSON) _sESConfigurationSetEventDestinationEventDestinationCloudWatchDestination
-    , fmap (("Enabled",) . toJSON . fmap Bool') _sESConfigurationSetEventDestinationEventDestinationEnabled
+    , fmap (("Enabled",) . toJSON) _sESConfigurationSetEventDestinationEventDestinationEnabled
     , fmap (("KinesisFirehoseDestination",) . toJSON) _sESConfigurationSetEventDestinationEventDestinationKinesisFirehoseDestination
     , (Just . ("MatchingEventTypes",) . toJSON) _sESConfigurationSetEventDestinationEventDestinationMatchingEventTypes
     , fmap (("Name",) . toJSON) _sESConfigurationSetEventDestinationEventDestinationName

--- a/library-gen/Stratosphere/ResourceProperties/SESReceiptRuleRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SESReceiptRuleRule.hs
@@ -27,10 +27,10 @@ instance ToJSON SESReceiptRuleRule where
     object $
     catMaybes
     [ fmap (("Actions",) . toJSON) _sESReceiptRuleRuleActions
-    , fmap (("Enabled",) . toJSON . fmap Bool') _sESReceiptRuleRuleEnabled
+    , fmap (("Enabled",) . toJSON) _sESReceiptRuleRuleEnabled
     , fmap (("Name",) . toJSON) _sESReceiptRuleRuleName
     , fmap (("Recipients",) . toJSON) _sESReceiptRuleRuleRecipients
-    , fmap (("ScanEnabled",) . toJSON . fmap Bool') _sESReceiptRuleRuleScanEnabled
+    , fmap (("ScanEnabled",) . toJSON) _sESReceiptRuleRuleScanEnabled
     , fmap (("TlsPolicy",) . toJSON) _sESReceiptRuleRuleTlsPolicy
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/SSMMaintenanceWindowTaskMaintenanceWindowRunCommandParameters.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SSMMaintenanceWindowTaskMaintenanceWindowRunCommandParameters.hs
@@ -39,7 +39,7 @@ instance ToJSON SSMMaintenanceWindowTaskMaintenanceWindowRunCommandParameters wh
     , fmap (("OutputS3KeyPrefix",) . toJSON) _sSMMaintenanceWindowTaskMaintenanceWindowRunCommandParametersOutputS3KeyPrefix
     , fmap (("Parameters",) . toJSON) _sSMMaintenanceWindowTaskMaintenanceWindowRunCommandParametersParameters
     , fmap (("ServiceRoleArn",) . toJSON) _sSMMaintenanceWindowTaskMaintenanceWindowRunCommandParametersServiceRoleArn
-    , fmap (("TimeoutSeconds",) . toJSON . fmap Integer') _sSMMaintenanceWindowTaskMaintenanceWindowRunCommandParametersTimeoutSeconds
+    , fmap (("TimeoutSeconds",) . toJSON) _sSMMaintenanceWindowTaskMaintenanceWindowRunCommandParametersTimeoutSeconds
     ]
 
 -- | Constructor for

--- a/library-gen/Stratosphere/ResourceProperties/SSMPatchBaselineRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SSMPatchBaselineRule.hs
@@ -24,9 +24,9 @@ instance ToJSON SSMPatchBaselineRule where
   toJSON SSMPatchBaselineRule{..} =
     object $
     catMaybes
-    [ fmap (("ApproveAfterDays",) . toJSON . fmap Integer') _sSMPatchBaselineRuleApproveAfterDays
+    [ fmap (("ApproveAfterDays",) . toJSON) _sSMPatchBaselineRuleApproveAfterDays
     , fmap (("ComplianceLevel",) . toJSON) _sSMPatchBaselineRuleComplianceLevel
-    , fmap (("EnableNonSecurity",) . toJSON . fmap Bool') _sSMPatchBaselineRuleEnableNonSecurity
+    , fmap (("EnableNonSecurity",) . toJSON) _sSMPatchBaselineRuleEnableNonSecurity
     , fmap (("PatchFilterGroup",) . toJSON) _sSMPatchBaselineRulePatchFilterGroup
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/SageMakerEndpointConfigProductionVariant.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SageMakerEndpointConfigProductionVariant.hs
@@ -28,8 +28,8 @@ instance ToJSON SageMakerEndpointConfigProductionVariant where
     object $
     catMaybes
     [ fmap (("AcceleratorType",) . toJSON) _sageMakerEndpointConfigProductionVariantAcceleratorType
-    , (Just . ("InitialInstanceCount",) . toJSON . fmap Integer') _sageMakerEndpointConfigProductionVariantInitialInstanceCount
-    , (Just . ("InitialVariantWeight",) . toJSON . fmap Double') _sageMakerEndpointConfigProductionVariantInitialVariantWeight
+    , (Just . ("InitialInstanceCount",) . toJSON) _sageMakerEndpointConfigProductionVariantInitialInstanceCount
+    , (Just . ("InitialVariantWeight",) . toJSON) _sageMakerEndpointConfigProductionVariantInitialVariantWeight
     , (Just . ("InstanceType",) . toJSON) _sageMakerEndpointConfigProductionVariantInstanceType
     , (Just . ("ModelName",) . toJSON) _sageMakerEndpointConfigProductionVariantModelName
     , (Just . ("VariantName",) . toJSON) _sageMakerEndpointConfigProductionVariantVariantName

--- a/library-gen/Stratosphere/ResourceProperties/SecretsManagerRotationScheduleRotationRules.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SecretsManagerRotationScheduleRotationRules.hs
@@ -23,7 +23,7 @@ instance ToJSON SecretsManagerRotationScheduleRotationRules where
   toJSON SecretsManagerRotationScheduleRotationRules{..} =
     object $
     catMaybes
-    [ fmap (("AutomaticallyAfterDays",) . toJSON . fmap Integer') _secretsManagerRotationScheduleRotationRulesAutomaticallyAfterDays
+    [ fmap (("AutomaticallyAfterDays",) . toJSON) _secretsManagerRotationScheduleRotationRulesAutomaticallyAfterDays
     ]
 
 -- | Constructor for 'SecretsManagerRotationScheduleRotationRules' containing

--- a/library-gen/Stratosphere/ResourceProperties/SecretsManagerSecretGenerateSecretString.hs
+++ b/library-gen/Stratosphere/ResourceProperties/SecretsManagerSecretGenerateSecretString.hs
@@ -32,14 +32,14 @@ instance ToJSON SecretsManagerSecretGenerateSecretString where
     object $
     catMaybes
     [ fmap (("ExcludeCharacters",) . toJSON) _secretsManagerSecretGenerateSecretStringExcludeCharacters
-    , fmap (("ExcludeLowercase",) . toJSON . fmap Bool') _secretsManagerSecretGenerateSecretStringExcludeLowercase
-    , fmap (("ExcludeNumbers",) . toJSON . fmap Bool') _secretsManagerSecretGenerateSecretStringExcludeNumbers
-    , fmap (("ExcludePunctuation",) . toJSON . fmap Bool') _secretsManagerSecretGenerateSecretStringExcludePunctuation
-    , fmap (("ExcludeUppercase",) . toJSON . fmap Bool') _secretsManagerSecretGenerateSecretStringExcludeUppercase
+    , fmap (("ExcludeLowercase",) . toJSON) _secretsManagerSecretGenerateSecretStringExcludeLowercase
+    , fmap (("ExcludeNumbers",) . toJSON) _secretsManagerSecretGenerateSecretStringExcludeNumbers
+    , fmap (("ExcludePunctuation",) . toJSON) _secretsManagerSecretGenerateSecretStringExcludePunctuation
+    , fmap (("ExcludeUppercase",) . toJSON) _secretsManagerSecretGenerateSecretStringExcludeUppercase
     , fmap (("GenerateStringKey",) . toJSON) _secretsManagerSecretGenerateSecretStringGenerateStringKey
-    , fmap (("IncludeSpace",) . toJSON . fmap Bool') _secretsManagerSecretGenerateSecretStringIncludeSpace
-    , fmap (("PasswordLength",) . toJSON . fmap Integer') _secretsManagerSecretGenerateSecretStringPasswordLength
-    , fmap (("RequireEachIncludedType",) . toJSON . fmap Bool') _secretsManagerSecretGenerateSecretStringRequireEachIncludedType
+    , fmap (("IncludeSpace",) . toJSON) _secretsManagerSecretGenerateSecretStringIncludeSpace
+    , fmap (("PasswordLength",) . toJSON) _secretsManagerSecretGenerateSecretStringPasswordLength
+    , fmap (("RequireEachIncludedType",) . toJSON) _secretsManagerSecretGenerateSecretStringRequireEachIncludedType
     , fmap (("SecretStringTemplate",) . toJSON) _secretsManagerSecretGenerateSecretStringSecretStringTemplate
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/ServiceDiscoveryServiceHealthCheckConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ServiceDiscoveryServiceHealthCheckConfig.hs
@@ -24,7 +24,7 @@ instance ToJSON ServiceDiscoveryServiceHealthCheckConfig where
   toJSON ServiceDiscoveryServiceHealthCheckConfig{..} =
     object $
     catMaybes
-    [ fmap (("FailureThreshold",) . toJSON . fmap Double') _serviceDiscoveryServiceHealthCheckConfigFailureThreshold
+    [ fmap (("FailureThreshold",) . toJSON) _serviceDiscoveryServiceHealthCheckConfigFailureThreshold
     , fmap (("ResourcePath",) . toJSON) _serviceDiscoveryServiceHealthCheckConfigResourcePath
     , (Just . ("Type",) . toJSON) _serviceDiscoveryServiceHealthCheckConfigType
     ]

--- a/library-gen/Stratosphere/ResourceProperties/ServiceDiscoveryServiceHealthCheckCustomConfig.hs
+++ b/library-gen/Stratosphere/ResourceProperties/ServiceDiscoveryServiceHealthCheckCustomConfig.hs
@@ -23,7 +23,7 @@ instance ToJSON ServiceDiscoveryServiceHealthCheckCustomConfig where
   toJSON ServiceDiscoveryServiceHealthCheckCustomConfig{..} =
     object $
     catMaybes
-    [ fmap (("FailureThreshold",) . toJSON . fmap Double') _serviceDiscoveryServiceHealthCheckCustomConfigFailureThreshold
+    [ fmap (("FailureThreshold",) . toJSON) _serviceDiscoveryServiceHealthCheckCustomConfigFailureThreshold
     ]
 
 -- | Constructor for 'ServiceDiscoveryServiceHealthCheckCustomConfig'

--- a/library-gen/Stratosphere/ResourceProperties/WAFRegionalRulePredicate.hs
+++ b/library-gen/Stratosphere/ResourceProperties/WAFRegionalRulePredicate.hs
@@ -24,7 +24,7 @@ instance ToJSON WAFRegionalRulePredicate where
     object $
     catMaybes
     [ (Just . ("DataId",) . toJSON) _wAFRegionalRulePredicateDataId
-    , (Just . ("Negated",) . toJSON . fmap Bool') _wAFRegionalRulePredicateNegated
+    , (Just . ("Negated",) . toJSON) _wAFRegionalRulePredicateNegated
     , (Just . ("Type",) . toJSON) _wAFRegionalRulePredicateType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/WAFRegionalSizeConstraintSetSizeConstraint.hs
+++ b/library-gen/Stratosphere/ResourceProperties/WAFRegionalSizeConstraintSetSizeConstraint.hs
@@ -27,7 +27,7 @@ instance ToJSON WAFRegionalSizeConstraintSetSizeConstraint where
     catMaybes
     [ (Just . ("ComparisonOperator",) . toJSON) _wAFRegionalSizeConstraintSetSizeConstraintComparisonOperator
     , (Just . ("FieldToMatch",) . toJSON) _wAFRegionalSizeConstraintSetSizeConstraintFieldToMatch
-    , (Just . ("Size",) . toJSON . fmap Integer') _wAFRegionalSizeConstraintSetSizeConstraintSize
+    , (Just . ("Size",) . toJSON) _wAFRegionalSizeConstraintSetSizeConstraintSize
     , (Just . ("TextTransformation",) . toJSON) _wAFRegionalSizeConstraintSetSizeConstraintTextTransformation
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/WAFRegionalWebACLRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/WAFRegionalWebACLRule.hs
@@ -24,7 +24,7 @@ instance ToJSON WAFRegionalWebACLRule where
     object $
     catMaybes
     [ (Just . ("Action",) . toJSON) _wAFRegionalWebACLRuleAction
-    , (Just . ("Priority",) . toJSON . fmap Integer') _wAFRegionalWebACLRulePriority
+    , (Just . ("Priority",) . toJSON) _wAFRegionalWebACLRulePriority
     , (Just . ("RuleId",) . toJSON) _wAFRegionalWebACLRuleRuleId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/WAFRulePredicate.hs
+++ b/library-gen/Stratosphere/ResourceProperties/WAFRulePredicate.hs
@@ -24,7 +24,7 @@ instance ToJSON WAFRulePredicate where
     object $
     catMaybes
     [ (Just . ("DataId",) . toJSON) _wAFRulePredicateDataId
-    , (Just . ("Negated",) . toJSON . fmap Bool') _wAFRulePredicateNegated
+    , (Just . ("Negated",) . toJSON) _wAFRulePredicateNegated
     , (Just . ("Type",) . toJSON) _wAFRulePredicateType
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/WAFSizeConstraintSetSizeConstraint.hs
+++ b/library-gen/Stratosphere/ResourceProperties/WAFSizeConstraintSetSizeConstraint.hs
@@ -26,7 +26,7 @@ instance ToJSON WAFSizeConstraintSetSizeConstraint where
     catMaybes
     [ (Just . ("ComparisonOperator",) . toJSON) _wAFSizeConstraintSetSizeConstraintComparisonOperator
     , (Just . ("FieldToMatch",) . toJSON) _wAFSizeConstraintSetSizeConstraintFieldToMatch
-    , (Just . ("Size",) . toJSON . fmap Integer') _wAFSizeConstraintSetSizeConstraintSize
+    , (Just . ("Size",) . toJSON) _wAFSizeConstraintSetSizeConstraintSize
     , (Just . ("TextTransformation",) . toJSON) _wAFSizeConstraintSetSizeConstraintTextTransformation
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/WAFWebACLActivatedRule.hs
+++ b/library-gen/Stratosphere/ResourceProperties/WAFWebACLActivatedRule.hs
@@ -24,7 +24,7 @@ instance ToJSON WAFWebACLActivatedRule where
     object $
     catMaybes
     [ fmap (("Action",) . toJSON) _wAFWebACLActivatedRuleAction
-    , (Just . ("Priority",) . toJSON . fmap Integer') _wAFWebACLActivatedRulePriority
+    , (Just . ("Priority",) . toJSON) _wAFWebACLActivatedRulePriority
     , (Just . ("RuleId",) . toJSON) _wAFWebACLActivatedRuleRuleId
     ]
 

--- a/library-gen/Stratosphere/ResourceProperties/WorkSpacesWorkspaceWorkspaceProperties.hs
+++ b/library-gen/Stratosphere/ResourceProperties/WorkSpacesWorkspaceWorkspaceProperties.hs
@@ -27,10 +27,10 @@ instance ToJSON WorkSpacesWorkspaceWorkspaceProperties where
     object $
     catMaybes
     [ fmap (("ComputeTypeName",) . toJSON) _workSpacesWorkspaceWorkspacePropertiesComputeTypeName
-    , fmap (("RootVolumeSizeGib",) . toJSON . fmap Integer') _workSpacesWorkspaceWorkspacePropertiesRootVolumeSizeGib
+    , fmap (("RootVolumeSizeGib",) . toJSON) _workSpacesWorkspaceWorkspacePropertiesRootVolumeSizeGib
     , fmap (("RunningMode",) . toJSON) _workSpacesWorkspaceWorkspacePropertiesRunningMode
-    , fmap (("RunningModeAutoStopTimeoutInMinutes",) . toJSON . fmap Integer') _workSpacesWorkspaceWorkspacePropertiesRunningModeAutoStopTimeoutInMinutes
-    , fmap (("UserVolumeSizeGib",) . toJSON . fmap Integer') _workSpacesWorkspaceWorkspacePropertiesUserVolumeSizeGib
+    , fmap (("RunningModeAutoStopTimeoutInMinutes",) . toJSON) _workSpacesWorkspaceWorkspacePropertiesRunningModeAutoStopTimeoutInMinutes
+    , fmap (("UserVolumeSizeGib",) . toJSON) _workSpacesWorkspaceWorkspacePropertiesUserVolumeSizeGib
     ]
 
 -- | Constructor for 'WorkSpacesWorkspaceWorkspaceProperties' containing

--- a/library-gen/Stratosphere/Resources/AmazonMQBroker.hs
+++ b/library-gen/Stratosphere/Resources/AmazonMQBroker.hs
@@ -40,7 +40,7 @@ instance ToResourceProperties AmazonMQBroker where
     { resourcePropertiesType = "AWS::AmazonMQ::Broker"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("AutoMinorVersionUpgrade",) . toJSON . fmap Bool') _amazonMQBrokerAutoMinorVersionUpgrade
+        [ (Just . ("AutoMinorVersionUpgrade",) . toJSON) _amazonMQBrokerAutoMinorVersionUpgrade
         , (Just . ("BrokerName",) . toJSON) _amazonMQBrokerBrokerName
         , fmap (("Configuration",) . toJSON) _amazonMQBrokerConfiguration
         , (Just . ("DeploymentMode",) . toJSON) _amazonMQBrokerDeploymentMode
@@ -49,7 +49,7 @@ instance ToResourceProperties AmazonMQBroker where
         , (Just . ("HostInstanceType",) . toJSON) _amazonMQBrokerHostInstanceType
         , fmap (("Logs",) . toJSON) _amazonMQBrokerLogs
         , fmap (("MaintenanceWindowStartTime",) . toJSON) _amazonMQBrokerMaintenanceWindowStartTime
-        , (Just . ("PubliclyAccessible",) . toJSON . fmap Bool') _amazonMQBrokerPubliclyAccessible
+        , (Just . ("PubliclyAccessible",) . toJSON) _amazonMQBrokerPubliclyAccessible
         , fmap (("SecurityGroups",) . toJSON) _amazonMQBrokerSecurityGroups
         , fmap (("SubnetIds",) . toJSON) _amazonMQBrokerSubnetIds
         , fmap (("Tags",) . toJSON) _amazonMQBrokerTags

--- a/library-gen/Stratosphere/Resources/ApiGatewayApiKey.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayApiKey.hs
@@ -31,8 +31,8 @@ instance ToResourceProperties ApiGatewayApiKey where
         hashMapFromList $ catMaybes
         [ fmap (("CustomerId",) . toJSON) _apiGatewayApiKeyCustomerId
         , fmap (("Description",) . toJSON) _apiGatewayApiKeyDescription
-        , fmap (("Enabled",) . toJSON . fmap Bool') _apiGatewayApiKeyEnabled
-        , fmap (("GenerateDistinctId",) . toJSON . fmap Bool') _apiGatewayApiKeyGenerateDistinctId
+        , fmap (("Enabled",) . toJSON) _apiGatewayApiKeyEnabled
+        , fmap (("GenerateDistinctId",) . toJSON) _apiGatewayApiKeyGenerateDistinctId
         , fmap (("Name",) . toJSON) _apiGatewayApiKeyName
         , fmap (("StageKeys",) . toJSON) _apiGatewayApiKeyStageKeys
         , fmap (("Value",) . toJSON) _apiGatewayApiKeyValue

--- a/library-gen/Stratosphere/Resources/ApiGatewayAuthorizer.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayAuthorizer.hs
@@ -34,7 +34,7 @@ instance ToResourceProperties ApiGatewayAuthorizer where
         hashMapFromList $ catMaybes
         [ fmap (("AuthType",) . toJSON) _apiGatewayAuthorizerAuthType
         , fmap (("AuthorizerCredentials",) . toJSON) _apiGatewayAuthorizerAuthorizerCredentials
-        , fmap (("AuthorizerResultTtlInSeconds",) . toJSON . fmap Integer') _apiGatewayAuthorizerAuthorizerResultTtlInSeconds
+        , fmap (("AuthorizerResultTtlInSeconds",) . toJSON) _apiGatewayAuthorizerAuthorizerResultTtlInSeconds
         , fmap (("AuthorizerUri",) . toJSON) _apiGatewayAuthorizerAuthorizerUri
         , fmap (("IdentitySource",) . toJSON) _apiGatewayAuthorizerIdentitySource
         , fmap (("IdentityValidationExpression",) . toJSON) _apiGatewayAuthorizerIdentityValidationExpression

--- a/library-gen/Stratosphere/Resources/ApiGatewayMethod.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayMethod.hs
@@ -37,7 +37,7 @@ instance ToResourceProperties ApiGatewayMethod where
     { resourcePropertiesType = "AWS::ApiGateway::Method"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("ApiKeyRequired",) . toJSON . fmap Bool') _apiGatewayMethodApiKeyRequired
+        [ fmap (("ApiKeyRequired",) . toJSON) _apiGatewayMethodApiKeyRequired
         , fmap (("AuthorizationScopes",) . toJSON) _apiGatewayMethodAuthorizationScopes
         , fmap (("AuthorizationType",) . toJSON) _apiGatewayMethodAuthorizationType
         , fmap (("AuthorizerId",) . toJSON) _apiGatewayMethodAuthorizerId

--- a/library-gen/Stratosphere/Resources/ApiGatewayRequestValidator.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayRequestValidator.hs
@@ -28,8 +28,8 @@ instance ToResourceProperties ApiGatewayRequestValidator where
         hashMapFromList $ catMaybes
         [ fmap (("Name",) . toJSON) _apiGatewayRequestValidatorName
         , (Just . ("RestApiId",) . toJSON) _apiGatewayRequestValidatorRestApiId
-        , fmap (("ValidateRequestBody",) . toJSON . fmap Bool') _apiGatewayRequestValidatorValidateRequestBody
-        , fmap (("ValidateRequestParameters",) . toJSON . fmap Bool') _apiGatewayRequestValidatorValidateRequestParameters
+        , fmap (("ValidateRequestBody",) . toJSON) _apiGatewayRequestValidatorValidateRequestBody
+        , fmap (("ValidateRequestParameters",) . toJSON) _apiGatewayRequestValidatorValidateRequestParameters
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/ApiGatewayRestApi.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayRestApi.hs
@@ -42,8 +42,8 @@ instance ToResourceProperties ApiGatewayRestApi where
         , fmap (("CloneFrom",) . toJSON) _apiGatewayRestApiCloneFrom
         , fmap (("Description",) . toJSON) _apiGatewayRestApiDescription
         , fmap (("EndpointConfiguration",) . toJSON) _apiGatewayRestApiEndpointConfiguration
-        , fmap (("FailOnWarnings",) . toJSON . fmap Bool') _apiGatewayRestApiFailOnWarnings
-        , fmap (("MinimumCompressionSize",) . toJSON . fmap Integer') _apiGatewayRestApiMinimumCompressionSize
+        , fmap (("FailOnWarnings",) . toJSON) _apiGatewayRestApiFailOnWarnings
+        , fmap (("MinimumCompressionSize",) . toJSON) _apiGatewayRestApiMinimumCompressionSize
         , fmap (("Name",) . toJSON) _apiGatewayRestApiName
         , fmap (("Parameters",) . toJSON) _apiGatewayRestApiParameters
         , fmap (("Policy",) . toJSON) _apiGatewayRestApiPolicy

--- a/library-gen/Stratosphere/Resources/ApiGatewayStage.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayStage.hs
@@ -40,7 +40,7 @@ instance ToResourceProperties ApiGatewayStage where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("AccessLogSetting",) . toJSON) _apiGatewayStageAccessLogSetting
-        , fmap (("CacheClusterEnabled",) . toJSON . fmap Bool') _apiGatewayStageCacheClusterEnabled
+        , fmap (("CacheClusterEnabled",) . toJSON) _apiGatewayStageCacheClusterEnabled
         , fmap (("CacheClusterSize",) . toJSON) _apiGatewayStageCacheClusterSize
         , fmap (("CanarySetting",) . toJSON) _apiGatewayStageCanarySetting
         , fmap (("ClientCertificateId",) . toJSON) _apiGatewayStageClientCertificateId
@@ -51,7 +51,7 @@ instance ToResourceProperties ApiGatewayStage where
         , (Just . ("RestApiId",) . toJSON) _apiGatewayStageRestApiId
         , fmap (("StageName",) . toJSON) _apiGatewayStageStageName
         , fmap (("Tags",) . toJSON) _apiGatewayStageTags
-        , fmap (("TracingEnabled",) . toJSON . fmap Bool') _apiGatewayStageTracingEnabled
+        , fmap (("TracingEnabled",) . toJSON) _apiGatewayStageTracingEnabled
         , fmap (("Variables",) . toJSON) _apiGatewayStageVariables
         ]
     }

--- a/library-gen/Stratosphere/Resources/ApiGatewayV2Api.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayV2Api.hs
@@ -31,7 +31,7 @@ instance ToResourceProperties ApiGatewayV2Api where
         hashMapFromList $ catMaybes
         [ fmap (("ApiKeySelectionExpression",) . toJSON) _apiGatewayV2ApiApiKeySelectionExpression
         , fmap (("Description",) . toJSON) _apiGatewayV2ApiDescription
-        , fmap (("DisableSchemaValidation",) . toJSON . fmap Bool') _apiGatewayV2ApiDisableSchemaValidation
+        , fmap (("DisableSchemaValidation",) . toJSON) _apiGatewayV2ApiDisableSchemaValidation
         , (Just . ("Name",) . toJSON) _apiGatewayV2ApiName
         , (Just . ("ProtocolType",) . toJSON) _apiGatewayV2ApiProtocolType
         , (Just . ("RouteSelectionExpression",) . toJSON) _apiGatewayV2ApiRouteSelectionExpression

--- a/library-gen/Stratosphere/Resources/ApiGatewayV2Authorizer.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayV2Authorizer.hs
@@ -32,7 +32,7 @@ instance ToResourceProperties ApiGatewayV2Authorizer where
         hashMapFromList $ catMaybes
         [ (Just . ("ApiId",) . toJSON) _apiGatewayV2AuthorizerApiId
         , fmap (("AuthorizerCredentialsArn",) . toJSON) _apiGatewayV2AuthorizerAuthorizerCredentialsArn
-        , fmap (("AuthorizerResultTtlInSeconds",) . toJSON . fmap Integer') _apiGatewayV2AuthorizerAuthorizerResultTtlInSeconds
+        , fmap (("AuthorizerResultTtlInSeconds",) . toJSON) _apiGatewayV2AuthorizerAuthorizerResultTtlInSeconds
         , (Just . ("AuthorizerType",) . toJSON) _apiGatewayV2AuthorizerAuthorizerType
         , (Just . ("AuthorizerUri",) . toJSON) _apiGatewayV2AuthorizerAuthorizerUri
         , (Just . ("IdentitySource",) . toJSON) _apiGatewayV2AuthorizerIdentitySource

--- a/library-gen/Stratosphere/Resources/ApiGatewayV2Integration.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayV2Integration.hs
@@ -47,7 +47,7 @@ instance ToResourceProperties ApiGatewayV2Integration where
         , fmap (("RequestParameters",) . toJSON) _apiGatewayV2IntegrationRequestParameters
         , fmap (("RequestTemplates",) . toJSON) _apiGatewayV2IntegrationRequestTemplates
         , fmap (("TemplateSelectionExpression",) . toJSON) _apiGatewayV2IntegrationTemplateSelectionExpression
-        , fmap (("TimeoutInMillis",) . toJSON . fmap Integer') _apiGatewayV2IntegrationTimeoutInMillis
+        , fmap (("TimeoutInMillis",) . toJSON) _apiGatewayV2IntegrationTimeoutInMillis
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/ApiGatewayV2Route.hs
+++ b/library-gen/Stratosphere/Resources/ApiGatewayV2Route.hs
@@ -35,7 +35,7 @@ instance ToResourceProperties ApiGatewayV2Route where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("ApiId",) . toJSON) _apiGatewayV2RouteApiId
-        , fmap (("ApiKeyRequired",) . toJSON . fmap Bool') _apiGatewayV2RouteApiKeyRequired
+        , fmap (("ApiKeyRequired",) . toJSON) _apiGatewayV2RouteApiKeyRequired
         , fmap (("AuthorizationScopes",) . toJSON) _apiGatewayV2RouteAuthorizationScopes
         , fmap (("AuthorizationType",) . toJSON) _apiGatewayV2RouteAuthorizationType
         , fmap (("AuthorizerId",) . toJSON) _apiGatewayV2RouteAuthorizerId

--- a/library-gen/Stratosphere/Resources/AppStreamFleet.hs
+++ b/library-gen/Stratosphere/Resources/AppStreamFleet.hs
@@ -39,15 +39,15 @@ instance ToResourceProperties AppStreamFleet where
         hashMapFromList $ catMaybes
         [ (Just . ("ComputeCapacity",) . toJSON) _appStreamFleetComputeCapacity
         , fmap (("Description",) . toJSON) _appStreamFleetDescription
-        , fmap (("DisconnectTimeoutInSeconds",) . toJSON . fmap Integer') _appStreamFleetDisconnectTimeoutInSeconds
+        , fmap (("DisconnectTimeoutInSeconds",) . toJSON) _appStreamFleetDisconnectTimeoutInSeconds
         , fmap (("DisplayName",) . toJSON) _appStreamFleetDisplayName
         , fmap (("DomainJoinInfo",) . toJSON) _appStreamFleetDomainJoinInfo
-        , fmap (("EnableDefaultInternetAccess",) . toJSON . fmap Bool') _appStreamFleetEnableDefaultInternetAccess
+        , fmap (("EnableDefaultInternetAccess",) . toJSON) _appStreamFleetEnableDefaultInternetAccess
         , fmap (("FleetType",) . toJSON) _appStreamFleetFleetType
         , fmap (("ImageArn",) . toJSON) _appStreamFleetImageArn
         , fmap (("ImageName",) . toJSON) _appStreamFleetImageName
         , (Just . ("InstanceType",) . toJSON) _appStreamFleetInstanceType
-        , fmap (("MaxUserDurationInSeconds",) . toJSON . fmap Integer') _appStreamFleetMaxUserDurationInSeconds
+        , fmap (("MaxUserDurationInSeconds",) . toJSON) _appStreamFleetMaxUserDurationInSeconds
         , fmap (("Name",) . toJSON) _appStreamFleetName
         , fmap (("VpcConfig",) . toJSON) _appStreamFleetVpcConfig
         ]

--- a/library-gen/Stratosphere/Resources/AppStreamImageBuilder.hs
+++ b/library-gen/Stratosphere/Resources/AppStreamImageBuilder.hs
@@ -37,7 +37,7 @@ instance ToResourceProperties AppStreamImageBuilder where
         , fmap (("Description",) . toJSON) _appStreamImageBuilderDescription
         , fmap (("DisplayName",) . toJSON) _appStreamImageBuilderDisplayName
         , fmap (("DomainJoinInfo",) . toJSON) _appStreamImageBuilderDomainJoinInfo
-        , fmap (("EnableDefaultInternetAccess",) . toJSON . fmap Bool') _appStreamImageBuilderEnableDefaultInternetAccess
+        , fmap (("EnableDefaultInternetAccess",) . toJSON) _appStreamImageBuilderEnableDefaultInternetAccess
         , fmap (("ImageArn",) . toJSON) _appStreamImageBuilderImageArn
         , fmap (("ImageName",) . toJSON) _appStreamImageBuilderImageName
         , (Just . ("InstanceType",) . toJSON) _appStreamImageBuilderInstanceType

--- a/library-gen/Stratosphere/Resources/AppStreamStack.hs
+++ b/library-gen/Stratosphere/Resources/AppStreamStack.hs
@@ -36,7 +36,7 @@ instance ToResourceProperties AppStreamStack where
         hashMapFromList $ catMaybes
         [ fmap (("ApplicationSettings",) . toJSON) _appStreamStackApplicationSettings
         , fmap (("AttributesToDelete",) . toJSON) _appStreamStackAttributesToDelete
-        , fmap (("DeleteStorageConnectors",) . toJSON . fmap Bool') _appStreamStackDeleteStorageConnectors
+        , fmap (("DeleteStorageConnectors",) . toJSON) _appStreamStackDeleteStorageConnectors
         , fmap (("Description",) . toJSON) _appStreamStackDescription
         , fmap (("DisplayName",) . toJSON) _appStreamStackDisplayName
         , fmap (("FeedbackURL",) . toJSON) _appStreamStackFeedbackURL

--- a/library-gen/Stratosphere/Resources/AppStreamStackUserAssociation.hs
+++ b/library-gen/Stratosphere/Resources/AppStreamStackUserAssociation.hs
@@ -27,7 +27,7 @@ instance ToResourceProperties AppStreamStackUserAssociation where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("AuthenticationType",) . toJSON) _appStreamStackUserAssociationAuthenticationType
-        , fmap (("SendEmailNotification",) . toJSON . fmap Bool') _appStreamStackUserAssociationSendEmailNotification
+        , fmap (("SendEmailNotification",) . toJSON) _appStreamStackUserAssociationSendEmailNotification
         , (Just . ("StackName",) . toJSON) _appStreamStackUserAssociationStackName
         , (Just . ("UserName",) . toJSON) _appStreamStackUserAssociationUserName
         ]

--- a/library-gen/Stratosphere/Resources/AppSyncApiKey.hs
+++ b/library-gen/Stratosphere/Resources/AppSyncApiKey.hs
@@ -27,7 +27,7 @@ instance ToResourceProperties AppSyncApiKey where
         hashMapFromList $ catMaybes
         [ (Just . ("ApiId",) . toJSON) _appSyncApiKeyApiId
         , fmap (("Description",) . toJSON) _appSyncApiKeyDescription
-        , fmap (("Expires",) . toJSON . fmap Double') _appSyncApiKeyExpires
+        , fmap (("Expires",) . toJSON) _appSyncApiKeyExpires
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/ApplicationAutoScalingScalableTarget.hs
+++ b/library-gen/Stratosphere/Resources/ApplicationAutoScalingScalableTarget.hs
@@ -29,8 +29,8 @@ instance ToResourceProperties ApplicationAutoScalingScalableTarget where
     { resourcePropertiesType = "AWS::ApplicationAutoScaling::ScalableTarget"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("MaxCapacity",) . toJSON . fmap Integer') _applicationAutoScalingScalableTargetMaxCapacity
-        , (Just . ("MinCapacity",) . toJSON . fmap Integer') _applicationAutoScalingScalableTargetMinCapacity
+        [ (Just . ("MaxCapacity",) . toJSON) _applicationAutoScalingScalableTargetMaxCapacity
+        , (Just . ("MinCapacity",) . toJSON) _applicationAutoScalingScalableTargetMinCapacity
         , (Just . ("ResourceId",) . toJSON) _applicationAutoScalingScalableTargetResourceId
         , (Just . ("RoleARN",) . toJSON) _applicationAutoScalingScalableTargetRoleARN
         , (Just . ("ScalableDimension",) . toJSON) _applicationAutoScalingScalableTargetScalableDimension

--- a/library-gen/Stratosphere/Resources/AutoScalingAutoScalingGroup.hs
+++ b/library-gen/Stratosphere/Resources/AutoScalingAutoScalingGroup.hs
@@ -53,7 +53,7 @@ instance ToResourceProperties AutoScalingAutoScalingGroup where
         , fmap (("AvailabilityZones",) . toJSON) _autoScalingAutoScalingGroupAvailabilityZones
         , fmap (("Cooldown",) . toJSON) _autoScalingAutoScalingGroupCooldown
         , fmap (("DesiredCapacity",) . toJSON) _autoScalingAutoScalingGroupDesiredCapacity
-        , fmap (("HealthCheckGracePeriod",) . toJSON . fmap Integer') _autoScalingAutoScalingGroupHealthCheckGracePeriod
+        , fmap (("HealthCheckGracePeriod",) . toJSON) _autoScalingAutoScalingGroupHealthCheckGracePeriod
         , fmap (("HealthCheckType",) . toJSON) _autoScalingAutoScalingGroupHealthCheckType
         , fmap (("InstanceId",) . toJSON) _autoScalingAutoScalingGroupInstanceId
         , fmap (("LaunchConfigurationName",) . toJSON) _autoScalingAutoScalingGroupLaunchConfigurationName

--- a/library-gen/Stratosphere/Resources/AutoScalingLaunchConfiguration.hs
+++ b/library-gen/Stratosphere/Resources/AutoScalingLaunchConfiguration.hs
@@ -40,15 +40,15 @@ instance ToResourceProperties AutoScalingLaunchConfiguration where
     { resourcePropertiesType = "AWS::AutoScaling::LaunchConfiguration"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AssociatePublicIpAddress",) . toJSON . fmap Bool') _autoScalingLaunchConfigurationAssociatePublicIpAddress
+        [ fmap (("AssociatePublicIpAddress",) . toJSON) _autoScalingLaunchConfigurationAssociatePublicIpAddress
         , fmap (("BlockDeviceMappings",) . toJSON) _autoScalingLaunchConfigurationBlockDeviceMappings
         , fmap (("ClassicLinkVPCId",) . toJSON) _autoScalingLaunchConfigurationClassicLinkVPCId
         , fmap (("ClassicLinkVPCSecurityGroups",) . toJSON) _autoScalingLaunchConfigurationClassicLinkVPCSecurityGroups
-        , fmap (("EbsOptimized",) . toJSON . fmap Bool') _autoScalingLaunchConfigurationEbsOptimized
+        , fmap (("EbsOptimized",) . toJSON) _autoScalingLaunchConfigurationEbsOptimized
         , fmap (("IamInstanceProfile",) . toJSON) _autoScalingLaunchConfigurationIamInstanceProfile
         , (Just . ("ImageId",) . toJSON) _autoScalingLaunchConfigurationImageId
         , fmap (("InstanceId",) . toJSON) _autoScalingLaunchConfigurationInstanceId
-        , fmap (("InstanceMonitoring",) . toJSON . fmap Bool') _autoScalingLaunchConfigurationInstanceMonitoring
+        , fmap (("InstanceMonitoring",) . toJSON) _autoScalingLaunchConfigurationInstanceMonitoring
         , (Just . ("InstanceType",) . toJSON) _autoScalingLaunchConfigurationInstanceType
         , fmap (("KernelId",) . toJSON) _autoScalingLaunchConfigurationKernelId
         , fmap (("KeyName",) . toJSON) _autoScalingLaunchConfigurationKeyName

--- a/library-gen/Stratosphere/Resources/AutoScalingLifecycleHook.hs
+++ b/library-gen/Stratosphere/Resources/AutoScalingLifecycleHook.hs
@@ -32,7 +32,7 @@ instance ToResourceProperties AutoScalingLifecycleHook where
         hashMapFromList $ catMaybes
         [ (Just . ("AutoScalingGroupName",) . toJSON) _autoScalingLifecycleHookAutoScalingGroupName
         , fmap (("DefaultResult",) . toJSON) _autoScalingLifecycleHookDefaultResult
-        , fmap (("HeartbeatTimeout",) . toJSON . fmap Integer') _autoScalingLifecycleHookHeartbeatTimeout
+        , fmap (("HeartbeatTimeout",) . toJSON) _autoScalingLifecycleHookHeartbeatTimeout
         , fmap (("LifecycleHookName",) . toJSON) _autoScalingLifecycleHookLifecycleHookName
         , (Just . ("LifecycleTransition",) . toJSON) _autoScalingLifecycleHookLifecycleTransition
         , fmap (("NotificationMetadata",) . toJSON) _autoScalingLifecycleHookNotificationMetadata

--- a/library-gen/Stratosphere/Resources/AutoScalingScalingPolicy.hs
+++ b/library-gen/Stratosphere/Resources/AutoScalingScalingPolicy.hs
@@ -36,11 +36,11 @@ instance ToResourceProperties AutoScalingScalingPolicy where
         [ fmap (("AdjustmentType",) . toJSON) _autoScalingScalingPolicyAdjustmentType
         , (Just . ("AutoScalingGroupName",) . toJSON) _autoScalingScalingPolicyAutoScalingGroupName
         , fmap (("Cooldown",) . toJSON) _autoScalingScalingPolicyCooldown
-        , fmap (("EstimatedInstanceWarmup",) . toJSON . fmap Integer') _autoScalingScalingPolicyEstimatedInstanceWarmup
+        , fmap (("EstimatedInstanceWarmup",) . toJSON) _autoScalingScalingPolicyEstimatedInstanceWarmup
         , fmap (("MetricAggregationType",) . toJSON) _autoScalingScalingPolicyMetricAggregationType
-        , fmap (("MinAdjustmentMagnitude",) . toJSON . fmap Integer') _autoScalingScalingPolicyMinAdjustmentMagnitude
+        , fmap (("MinAdjustmentMagnitude",) . toJSON) _autoScalingScalingPolicyMinAdjustmentMagnitude
         , fmap (("PolicyType",) . toJSON) _autoScalingScalingPolicyPolicyType
-        , fmap (("ScalingAdjustment",) . toJSON . fmap Integer') _autoScalingScalingPolicyScalingAdjustment
+        , fmap (("ScalingAdjustment",) . toJSON) _autoScalingScalingPolicyScalingAdjustment
         , fmap (("StepAdjustments",) . toJSON) _autoScalingScalingPolicyStepAdjustments
         , fmap (("TargetTrackingConfiguration",) . toJSON) _autoScalingScalingPolicyTargetTrackingConfiguration
         ]

--- a/library-gen/Stratosphere/Resources/AutoScalingScheduledAction.hs
+++ b/library-gen/Stratosphere/Resources/AutoScalingScheduledAction.hs
@@ -30,10 +30,10 @@ instance ToResourceProperties AutoScalingScheduledAction where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("AutoScalingGroupName",) . toJSON) _autoScalingScheduledActionAutoScalingGroupName
-        , fmap (("DesiredCapacity",) . toJSON . fmap Integer') _autoScalingScheduledActionDesiredCapacity
+        , fmap (("DesiredCapacity",) . toJSON) _autoScalingScheduledActionDesiredCapacity
         , fmap (("EndTime",) . toJSON) _autoScalingScheduledActionEndTime
-        , fmap (("MaxSize",) . toJSON . fmap Integer') _autoScalingScheduledActionMaxSize
-        , fmap (("MinSize",) . toJSON . fmap Integer') _autoScalingScheduledActionMinSize
+        , fmap (("MaxSize",) . toJSON) _autoScalingScheduledActionMaxSize
+        , fmap (("MinSize",) . toJSON) _autoScalingScheduledActionMinSize
         , fmap (("Recurrence",) . toJSON) _autoScalingScheduledActionRecurrence
         , fmap (("StartTime",) . toJSON) _autoScalingScheduledActionStartTime
         ]

--- a/library-gen/Stratosphere/Resources/BatchJobQueue.hs
+++ b/library-gen/Stratosphere/Resources/BatchJobQueue.hs
@@ -28,7 +28,7 @@ instance ToResourceProperties BatchJobQueue where
         hashMapFromList $ catMaybes
         [ (Just . ("ComputeEnvironmentOrder",) . toJSON) _batchJobQueueComputeEnvironmentOrder
         , fmap (("JobQueueName",) . toJSON) _batchJobQueueJobQueueName
-        , (Just . ("Priority",) . toJSON . fmap Integer') _batchJobQueuePriority
+        , (Just . ("Priority",) . toJSON) _batchJobQueuePriority
         , fmap (("State",) . toJSON) _batchJobQueueState
         ]
     }

--- a/library-gen/Stratosphere/Resources/Cloud9EnvironmentEC2.hs
+++ b/library-gen/Stratosphere/Resources/Cloud9EnvironmentEC2.hs
@@ -29,7 +29,7 @@ instance ToResourceProperties Cloud9EnvironmentEC2 where
     { resourcePropertiesType = "AWS::Cloud9::EnvironmentEC2"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AutomaticStopTimeMinutes",) . toJSON . fmap Integer') _cloud9EnvironmentEC2AutomaticStopTimeMinutes
+        [ fmap (("AutomaticStopTimeMinutes",) . toJSON) _cloud9EnvironmentEC2AutomaticStopTimeMinutes
         , fmap (("Description",) . toJSON) _cloud9EnvironmentEC2Description
         , (Just . ("InstanceType",) . toJSON) _cloud9EnvironmentEC2InstanceType
         , fmap (("Name",) . toJSON) _cloud9EnvironmentEC2Name

--- a/library-gen/Stratosphere/Resources/CloudFormationStack.hs
+++ b/library-gen/Stratosphere/Resources/CloudFormationStack.hs
@@ -31,7 +31,7 @@ instance ToResourceProperties CloudFormationStack where
         , fmap (("Parameters",) . toJSON) _cloudFormationStackParameters
         , fmap (("Tags",) . toJSON) _cloudFormationStackTags
         , (Just . ("TemplateURL",) . toJSON) _cloudFormationStackTemplateURL
-        , fmap (("TimeoutInMinutes",) . toJSON . fmap Integer') _cloudFormationStackTimeoutInMinutes
+        , fmap (("TimeoutInMinutes",) . toJSON) _cloudFormationStackTimeoutInMinutes
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/CloudFormationWaitCondition.hs
+++ b/library-gen/Stratosphere/Resources/CloudFormationWaitCondition.hs
@@ -25,7 +25,7 @@ instance ToResourceProperties CloudFormationWaitCondition where
     { resourcePropertiesType = "AWS::CloudFormation::WaitCondition"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Count",) . toJSON . fmap Integer') _cloudFormationWaitConditionCount
+        [ fmap (("Count",) . toJSON) _cloudFormationWaitConditionCount
         , fmap (("Handle",) . toJSON) _cloudFormationWaitConditionHandle
         , fmap (("Timeout",) . toJSON) _cloudFormationWaitConditionTimeout
         ]

--- a/library-gen/Stratosphere/Resources/CloudTrailTrail.hs
+++ b/library-gen/Stratosphere/Resources/CloudTrailTrail.hs
@@ -38,11 +38,11 @@ instance ToResourceProperties CloudTrailTrail where
         hashMapFromList $ catMaybes
         [ fmap (("CloudWatchLogsLogGroupArn",) . toJSON) _cloudTrailTrailCloudWatchLogsLogGroupArn
         , fmap (("CloudWatchLogsRoleArn",) . toJSON) _cloudTrailTrailCloudWatchLogsRoleArn
-        , fmap (("EnableLogFileValidation",) . toJSON . fmap Bool') _cloudTrailTrailEnableLogFileValidation
+        , fmap (("EnableLogFileValidation",) . toJSON) _cloudTrailTrailEnableLogFileValidation
         , fmap (("EventSelectors",) . toJSON) _cloudTrailTrailEventSelectors
-        , fmap (("IncludeGlobalServiceEvents",) . toJSON . fmap Bool') _cloudTrailTrailIncludeGlobalServiceEvents
-        , (Just . ("IsLogging",) . toJSON . fmap Bool') _cloudTrailTrailIsLogging
-        , fmap (("IsMultiRegionTrail",) . toJSON . fmap Bool') _cloudTrailTrailIsMultiRegionTrail
+        , fmap (("IncludeGlobalServiceEvents",) . toJSON) _cloudTrailTrailIncludeGlobalServiceEvents
+        , (Just . ("IsLogging",) . toJSON) _cloudTrailTrailIsLogging
+        , fmap (("IsMultiRegionTrail",) . toJSON) _cloudTrailTrailIsMultiRegionTrail
         , fmap (("KMSKeyId",) . toJSON) _cloudTrailTrailKMSKeyId
         , (Just . ("S3BucketName",) . toJSON) _cloudTrailTrailS3BucketName
         , fmap (("S3KeyPrefix",) . toJSON) _cloudTrailTrailS3KeyPrefix

--- a/library-gen/Stratosphere/Resources/CloudWatchAlarm.hs
+++ b/library-gen/Stratosphere/Resources/CloudWatchAlarm.hs
@@ -43,24 +43,24 @@ instance ToResourceProperties CloudWatchAlarm where
     { resourcePropertiesType = "AWS::CloudWatch::Alarm"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("ActionsEnabled",) . toJSON . fmap Bool') _cloudWatchAlarmActionsEnabled
+        [ fmap (("ActionsEnabled",) . toJSON) _cloudWatchAlarmActionsEnabled
         , fmap (("AlarmActions",) . toJSON) _cloudWatchAlarmAlarmActions
         , fmap (("AlarmDescription",) . toJSON) _cloudWatchAlarmAlarmDescription
         , fmap (("AlarmName",) . toJSON) _cloudWatchAlarmAlarmName
         , (Just . ("ComparisonOperator",) . toJSON) _cloudWatchAlarmComparisonOperator
-        , fmap (("DatapointsToAlarm",) . toJSON . fmap Integer') _cloudWatchAlarmDatapointsToAlarm
+        , fmap (("DatapointsToAlarm",) . toJSON) _cloudWatchAlarmDatapointsToAlarm
         , fmap (("Dimensions",) . toJSON) _cloudWatchAlarmDimensions
         , fmap (("EvaluateLowSampleCountPercentile",) . toJSON) _cloudWatchAlarmEvaluateLowSampleCountPercentile
-        , (Just . ("EvaluationPeriods",) . toJSON . fmap Integer') _cloudWatchAlarmEvaluationPeriods
+        , (Just . ("EvaluationPeriods",) . toJSON) _cloudWatchAlarmEvaluationPeriods
         , fmap (("ExtendedStatistic",) . toJSON) _cloudWatchAlarmExtendedStatistic
         , fmap (("InsufficientDataActions",) . toJSON) _cloudWatchAlarmInsufficientDataActions
         , fmap (("MetricName",) . toJSON) _cloudWatchAlarmMetricName
         , fmap (("Metrics",) . toJSON) _cloudWatchAlarmMetrics
         , fmap (("Namespace",) . toJSON) _cloudWatchAlarmNamespace
         , fmap (("OKActions",) . toJSON) _cloudWatchAlarmOKActions
-        , fmap (("Period",) . toJSON . fmap Integer') _cloudWatchAlarmPeriod
+        , fmap (("Period",) . toJSON) _cloudWatchAlarmPeriod
         , fmap (("Statistic",) . toJSON) _cloudWatchAlarmStatistic
-        , (Just . ("Threshold",) . toJSON . fmap Double') _cloudWatchAlarmThreshold
+        , (Just . ("Threshold",) . toJSON) _cloudWatchAlarmThreshold
         , fmap (("TreatMissingData",) . toJSON) _cloudWatchAlarmTreatMissingData
         , fmap (("Unit",) . toJSON) _cloudWatchAlarmUnit
         ]

--- a/library-gen/Stratosphere/Resources/CodeBuildProject.hs
+++ b/library-gen/Stratosphere/Resources/CodeBuildProject.hs
@@ -47,20 +47,20 @@ instance ToResourceProperties CodeBuildProject where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("Artifacts",) . toJSON) _codeBuildProjectArtifacts
-        , fmap (("BadgeEnabled",) . toJSON . fmap Bool') _codeBuildProjectBadgeEnabled
+        , fmap (("BadgeEnabled",) . toJSON) _codeBuildProjectBadgeEnabled
         , fmap (("Cache",) . toJSON) _codeBuildProjectCache
         , fmap (("Description",) . toJSON) _codeBuildProjectDescription
         , fmap (("EncryptionKey",) . toJSON) _codeBuildProjectEncryptionKey
         , (Just . ("Environment",) . toJSON) _codeBuildProjectEnvironment
         , fmap (("LogsConfig",) . toJSON) _codeBuildProjectLogsConfig
         , fmap (("Name",) . toJSON) _codeBuildProjectName
-        , fmap (("QueuedTimeoutInMinutes",) . toJSON . fmap Integer') _codeBuildProjectQueuedTimeoutInMinutes
+        , fmap (("QueuedTimeoutInMinutes",) . toJSON) _codeBuildProjectQueuedTimeoutInMinutes
         , fmap (("SecondaryArtifacts",) . toJSON) _codeBuildProjectSecondaryArtifacts
         , fmap (("SecondarySources",) . toJSON) _codeBuildProjectSecondarySources
         , (Just . ("ServiceRole",) . toJSON) _codeBuildProjectServiceRole
         , (Just . ("Source",) . toJSON) _codeBuildProjectSource
         , fmap (("Tags",) . toJSON) _codeBuildProjectTags
-        , fmap (("TimeoutInMinutes",) . toJSON . fmap Integer') _codeBuildProjectTimeoutInMinutes
+        , fmap (("TimeoutInMinutes",) . toJSON) _codeBuildProjectTimeoutInMinutes
         , fmap (("Triggers",) . toJSON) _codeBuildProjectTriggers
         , fmap (("VpcConfig",) . toJSON) _codeBuildProjectVpcConfig
         ]

--- a/library-gen/Stratosphere/Resources/CodePipelinePipeline.hs
+++ b/library-gen/Stratosphere/Resources/CodePipelinePipeline.hs
@@ -36,7 +36,7 @@ instance ToResourceProperties CodePipelinePipeline where
         , fmap (("ArtifactStores",) . toJSON) _codePipelinePipelineArtifactStores
         , fmap (("DisableInboundStageTransitions",) . toJSON) _codePipelinePipelineDisableInboundStageTransitions
         , fmap (("Name",) . toJSON) _codePipelinePipelineName
-        , fmap (("RestartExecutionOnUpdate",) . toJSON . fmap Bool') _codePipelinePipelineRestartExecutionOnUpdate
+        , fmap (("RestartExecutionOnUpdate",) . toJSON) _codePipelinePipelineRestartExecutionOnUpdate
         , (Just . ("RoleArn",) . toJSON) _codePipelinePipelineRoleArn
         , (Just . ("Stages",) . toJSON) _codePipelinePipelineStages
         ]

--- a/library-gen/Stratosphere/Resources/CodePipelineWebhook.hs
+++ b/library-gen/Stratosphere/Resources/CodePipelineWebhook.hs
@@ -35,10 +35,10 @@ instance ToResourceProperties CodePipelineWebhook where
         , (Just . ("AuthenticationConfiguration",) . toJSON) _codePipelineWebhookAuthenticationConfiguration
         , (Just . ("Filters",) . toJSON) _codePipelineWebhookFilters
         , fmap (("Name",) . toJSON) _codePipelineWebhookName
-        , fmap (("RegisterWithThirdParty",) . toJSON . fmap Bool') _codePipelineWebhookRegisterWithThirdParty
+        , fmap (("RegisterWithThirdParty",) . toJSON) _codePipelineWebhookRegisterWithThirdParty
         , (Just . ("TargetAction",) . toJSON) _codePipelineWebhookTargetAction
         , (Just . ("TargetPipeline",) . toJSON) _codePipelineWebhookTargetPipeline
-        , (Just . ("TargetPipelineVersion",) . toJSON . fmap Integer') _codePipelineWebhookTargetPipelineVersion
+        , (Just . ("TargetPipelineVersion",) . toJSON) _codePipelineWebhookTargetPipelineVersion
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/CognitoIdentityPool.hs
+++ b/library-gen/Stratosphere/Resources/CognitoIdentityPool.hs
@@ -34,7 +34,7 @@ instance ToResourceProperties CognitoIdentityPool where
     { resourcePropertiesType = "AWS::Cognito::IdentityPool"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("AllowUnauthenticatedIdentities",) . toJSON . fmap Bool') _cognitoIdentityPoolAllowUnauthenticatedIdentities
+        [ (Just . ("AllowUnauthenticatedIdentities",) . toJSON) _cognitoIdentityPoolAllowUnauthenticatedIdentities
         , fmap (("CognitoEvents",) . toJSON) _cognitoIdentityPoolCognitoEvents
         , fmap (("CognitoIdentityProviders",) . toJSON) _cognitoIdentityPoolCognitoIdentityProviders
         , fmap (("CognitoStreams",) . toJSON) _cognitoIdentityPoolCognitoStreams

--- a/library-gen/Stratosphere/Resources/CognitoUserPoolClient.hs
+++ b/library-gen/Stratosphere/Resources/CognitoUserPoolClient.hs
@@ -31,9 +31,9 @@ instance ToResourceProperties CognitoUserPoolClient where
         hashMapFromList $ catMaybes
         [ fmap (("ClientName",) . toJSON) _cognitoUserPoolClientClientName
         , fmap (("ExplicitAuthFlows",) . toJSON) _cognitoUserPoolClientExplicitAuthFlows
-        , fmap (("GenerateSecret",) . toJSON . fmap Bool') _cognitoUserPoolClientGenerateSecret
+        , fmap (("GenerateSecret",) . toJSON) _cognitoUserPoolClientGenerateSecret
         , fmap (("ReadAttributes",) . toJSON) _cognitoUserPoolClientReadAttributes
-        , fmap (("RefreshTokenValidity",) . toJSON . fmap Double') _cognitoUserPoolClientRefreshTokenValidity
+        , fmap (("RefreshTokenValidity",) . toJSON) _cognitoUserPoolClientRefreshTokenValidity
         , (Just . ("UserPoolId",) . toJSON) _cognitoUserPoolClientUserPoolId
         , fmap (("WriteAttributes",) . toJSON) _cognitoUserPoolClientWriteAttributes
         ]

--- a/library-gen/Stratosphere/Resources/CognitoUserPoolGroup.hs
+++ b/library-gen/Stratosphere/Resources/CognitoUserPoolGroup.hs
@@ -29,7 +29,7 @@ instance ToResourceProperties CognitoUserPoolGroup where
         hashMapFromList $ catMaybes
         [ fmap (("Description",) . toJSON) _cognitoUserPoolGroupDescription
         , fmap (("GroupName",) . toJSON) _cognitoUserPoolGroupGroupName
-        , fmap (("Precedence",) . toJSON . fmap Double') _cognitoUserPoolGroupPrecedence
+        , fmap (("Precedence",) . toJSON) _cognitoUserPoolGroupPrecedence
         , fmap (("RoleArn",) . toJSON) _cognitoUserPoolGroupRoleArn
         , (Just . ("UserPoolId",) . toJSON) _cognitoUserPoolGroupUserPoolId
         ]

--- a/library-gen/Stratosphere/Resources/CognitoUserPoolUser.hs
+++ b/library-gen/Stratosphere/Resources/CognitoUserPoolUser.hs
@@ -30,7 +30,7 @@ instance ToResourceProperties CognitoUserPoolUser where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("DesiredDeliveryMediums",) . toJSON) _cognitoUserPoolUserDesiredDeliveryMediums
-        , fmap (("ForceAliasCreation",) . toJSON . fmap Bool') _cognitoUserPoolUserForceAliasCreation
+        , fmap (("ForceAliasCreation",) . toJSON) _cognitoUserPoolUserForceAliasCreation
         , fmap (("MessageAction",) . toJSON) _cognitoUserPoolUserMessageAction
         , fmap (("UserAttributes",) . toJSON) _cognitoUserPoolUserUserAttributes
         , (Just . ("UserPoolId",) . toJSON) _cognitoUserPoolUserUserPoolId

--- a/library-gen/Stratosphere/Resources/DAXCluster.hs
+++ b/library-gen/Stratosphere/Resources/DAXCluster.hs
@@ -43,7 +43,7 @@ instance ToResourceProperties DAXCluster where
         , fmap (("NotificationTopicARN",) . toJSON) _dAXClusterNotificationTopicARN
         , fmap (("ParameterGroupName",) . toJSON) _dAXClusterParameterGroupName
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _dAXClusterPreferredMaintenanceWindow
-        , (Just . ("ReplicationFactor",) . toJSON . fmap Integer') _dAXClusterReplicationFactor
+        , (Just . ("ReplicationFactor",) . toJSON) _dAXClusterReplicationFactor
         , fmap (("SSESpecification",) . toJSON) _dAXClusterSSESpecification
         , fmap (("SecurityGroupIds",) . toJSON) _dAXClusterSecurityGroupIds
         , fmap (("SubnetGroupName",) . toJSON) _dAXClusterSubnetGroupName

--- a/library-gen/Stratosphere/Resources/DMSEndpoint.hs
+++ b/library-gen/Stratosphere/Resources/DMSEndpoint.hs
@@ -57,7 +57,7 @@ instance ToResourceProperties DMSEndpoint where
         , fmap (("KmsKeyId",) . toJSON) _dMSEndpointKmsKeyId
         , fmap (("MongoDbSettings",) . toJSON) _dMSEndpointMongoDbSettings
         , fmap (("Password",) . toJSON) _dMSEndpointPassword
-        , fmap (("Port",) . toJSON . fmap Integer') _dMSEndpointPort
+        , fmap (("Port",) . toJSON) _dMSEndpointPort
         , fmap (("S3Settings",) . toJSON) _dMSEndpointS3Settings
         , fmap (("ServerName",) . toJSON) _dMSEndpointServerName
         , fmap (("SslMode",) . toJSON) _dMSEndpointSslMode

--- a/library-gen/Stratosphere/Resources/DMSEventSubscription.hs
+++ b/library-gen/Stratosphere/Resources/DMSEventSubscription.hs
@@ -29,7 +29,7 @@ instance ToResourceProperties DMSEventSubscription where
     { resourcePropertiesType = "AWS::DMS::EventSubscription"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Enabled",) . toJSON . fmap Bool') _dMSEventSubscriptionEnabled
+        [ fmap (("Enabled",) . toJSON) _dMSEventSubscriptionEnabled
         , fmap (("EventCategories",) . toJSON) _dMSEventSubscriptionEventCategories
         , (Just . ("SnsTopicArn",) . toJSON) _dMSEventSubscriptionSnsTopicArn
         , fmap (("SourceIds",) . toJSON) _dMSEventSubscriptionSourceIds

--- a/library-gen/Stratosphere/Resources/DMSReplicationInstance.hs
+++ b/library-gen/Stratosphere/Resources/DMSReplicationInstance.hs
@@ -36,15 +36,15 @@ instance ToResourceProperties DMSReplicationInstance where
     { resourcePropertiesType = "AWS::DMS::ReplicationInstance"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AllocatedStorage",) . toJSON . fmap Integer') _dMSReplicationInstanceAllocatedStorage
-        , fmap (("AllowMajorVersionUpgrade",) . toJSON . fmap Bool') _dMSReplicationInstanceAllowMajorVersionUpgrade
-        , fmap (("AutoMinorVersionUpgrade",) . toJSON . fmap Bool') _dMSReplicationInstanceAutoMinorVersionUpgrade
+        [ fmap (("AllocatedStorage",) . toJSON) _dMSReplicationInstanceAllocatedStorage
+        , fmap (("AllowMajorVersionUpgrade",) . toJSON) _dMSReplicationInstanceAllowMajorVersionUpgrade
+        , fmap (("AutoMinorVersionUpgrade",) . toJSON) _dMSReplicationInstanceAutoMinorVersionUpgrade
         , fmap (("AvailabilityZone",) . toJSON) _dMSReplicationInstanceAvailabilityZone
         , fmap (("EngineVersion",) . toJSON) _dMSReplicationInstanceEngineVersion
         , fmap (("KmsKeyId",) . toJSON) _dMSReplicationInstanceKmsKeyId
-        , fmap (("MultiAZ",) . toJSON . fmap Bool') _dMSReplicationInstanceMultiAZ
+        , fmap (("MultiAZ",) . toJSON) _dMSReplicationInstanceMultiAZ
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _dMSReplicationInstancePreferredMaintenanceWindow
-        , fmap (("PubliclyAccessible",) . toJSON . fmap Bool') _dMSReplicationInstancePubliclyAccessible
+        , fmap (("PubliclyAccessible",) . toJSON) _dMSReplicationInstancePubliclyAccessible
         , (Just . ("ReplicationInstanceClass",) . toJSON) _dMSReplicationInstanceReplicationInstanceClass
         , fmap (("ReplicationInstanceIdentifier",) . toJSON) _dMSReplicationInstanceReplicationInstanceIdentifier
         , fmap (("ReplicationSubnetGroupIdentifier",) . toJSON) _dMSReplicationInstanceReplicationSubnetGroupIdentifier

--- a/library-gen/Stratosphere/Resources/DMSReplicationTask.hs
+++ b/library-gen/Stratosphere/Resources/DMSReplicationTask.hs
@@ -31,7 +31,7 @@ instance ToResourceProperties DMSReplicationTask where
     { resourcePropertiesType = "AWS::DMS::ReplicationTask"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("CdcStartTime",) . toJSON . fmap Double') _dMSReplicationTaskCdcStartTime
+        [ fmap (("CdcStartTime",) . toJSON) _dMSReplicationTaskCdcStartTime
         , (Just . ("MigrationType",) . toJSON) _dMSReplicationTaskMigrationType
         , (Just . ("ReplicationInstanceArn",) . toJSON) _dMSReplicationTaskReplicationInstanceArn
         , fmap (("ReplicationTaskIdentifier",) . toJSON) _dMSReplicationTaskReplicationTaskIdentifier

--- a/library-gen/Stratosphere/Resources/DataPipelinePipeline.hs
+++ b/library-gen/Stratosphere/Resources/DataPipelinePipeline.hs
@@ -32,7 +32,7 @@ instance ToResourceProperties DataPipelinePipeline where
     { resourcePropertiesType = "AWS::DataPipeline::Pipeline"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Activate",) . toJSON . fmap Bool') _dataPipelinePipelineActivate
+        [ fmap (("Activate",) . toJSON) _dataPipelinePipelineActivate
         , fmap (("Description",) . toJSON) _dataPipelinePipelineDescription
         , (Just . ("Name",) . toJSON) _dataPipelinePipelineName
         , (Just . ("ParameterObjects",) . toJSON) _dataPipelinePipelineParameterObjects

--- a/library-gen/Stratosphere/Resources/DirectoryServiceMicrosoftAD.hs
+++ b/library-gen/Stratosphere/Resources/DirectoryServiceMicrosoftAD.hs
@@ -29,9 +29,9 @@ instance ToResourceProperties DirectoryServiceMicrosoftAD where
     { resourcePropertiesType = "AWS::DirectoryService::MicrosoftAD"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("CreateAlias",) . toJSON . fmap Bool') _directoryServiceMicrosoftADCreateAlias
+        [ fmap (("CreateAlias",) . toJSON) _directoryServiceMicrosoftADCreateAlias
         , fmap (("Edition",) . toJSON) _directoryServiceMicrosoftADEdition
-        , fmap (("EnableSso",) . toJSON . fmap Bool') _directoryServiceMicrosoftADEnableSso
+        , fmap (("EnableSso",) . toJSON) _directoryServiceMicrosoftADEnableSso
         , (Just . ("Name",) . toJSON) _directoryServiceMicrosoftADName
         , (Just . ("Password",) . toJSON) _directoryServiceMicrosoftADPassword
         , fmap (("ShortName",) . toJSON) _directoryServiceMicrosoftADShortName

--- a/library-gen/Stratosphere/Resources/DirectoryServiceSimpleAD.hs
+++ b/library-gen/Stratosphere/Resources/DirectoryServiceSimpleAD.hs
@@ -30,9 +30,9 @@ instance ToResourceProperties DirectoryServiceSimpleAD where
     { resourcePropertiesType = "AWS::DirectoryService::SimpleAD"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("CreateAlias",) . toJSON . fmap Bool') _directoryServiceSimpleADCreateAlias
+        [ fmap (("CreateAlias",) . toJSON) _directoryServiceSimpleADCreateAlias
         , fmap (("Description",) . toJSON) _directoryServiceSimpleADDescription
-        , fmap (("EnableSso",) . toJSON . fmap Bool') _directoryServiceSimpleADEnableSso
+        , fmap (("EnableSso",) . toJSON) _directoryServiceSimpleADEnableSso
         , (Just . ("Name",) . toJSON) _directoryServiceSimpleADName
         , (Just . ("Password",) . toJSON) _directoryServiceSimpleADPassword
         , fmap (("ShortName",) . toJSON) _directoryServiceSimpleADShortName

--- a/library-gen/Stratosphere/Resources/DocDBDBCluster.hs
+++ b/library-gen/Stratosphere/Resources/DocDBDBCluster.hs
@@ -39,7 +39,7 @@ instance ToResourceProperties DocDBDBCluster where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("AvailabilityZones",) . toJSON) _docDBDBClusterAvailabilityZones
-        , fmap (("BackupRetentionPeriod",) . toJSON . fmap Integer') _docDBDBClusterBackupRetentionPeriod
+        , fmap (("BackupRetentionPeriod",) . toJSON) _docDBDBClusterBackupRetentionPeriod
         , fmap (("DBClusterIdentifier",) . toJSON) _docDBDBClusterDBClusterIdentifier
         , fmap (("DBClusterParameterGroupName",) . toJSON) _docDBDBClusterDBClusterParameterGroupName
         , fmap (("DBSubnetGroupName",) . toJSON) _docDBDBClusterDBSubnetGroupName
@@ -47,11 +47,11 @@ instance ToResourceProperties DocDBDBCluster where
         , fmap (("KmsKeyId",) . toJSON) _docDBDBClusterKmsKeyId
         , fmap (("MasterUserPassword",) . toJSON) _docDBDBClusterMasterUserPassword
         , fmap (("MasterUsername",) . toJSON) _docDBDBClusterMasterUsername
-        , fmap (("Port",) . toJSON . fmap Integer') _docDBDBClusterPort
+        , fmap (("Port",) . toJSON) _docDBDBClusterPort
         , fmap (("PreferredBackupWindow",) . toJSON) _docDBDBClusterPreferredBackupWindow
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _docDBDBClusterPreferredMaintenanceWindow
         , fmap (("SnapshotIdentifier",) . toJSON) _docDBDBClusterSnapshotIdentifier
-        , fmap (("StorageEncrypted",) . toJSON . fmap Bool') _docDBDBClusterStorageEncrypted
+        , fmap (("StorageEncrypted",) . toJSON) _docDBDBClusterStorageEncrypted
         , fmap (("Tags",) . toJSON) _docDBDBClusterTags
         , fmap (("VpcSecurityGroupIds",) . toJSON) _docDBDBClusterVpcSecurityGroupIds
         ]

--- a/library-gen/Stratosphere/Resources/DocDBDBInstance.hs
+++ b/library-gen/Stratosphere/Resources/DocDBDBInstance.hs
@@ -29,7 +29,7 @@ instance ToResourceProperties DocDBDBInstance where
     { resourcePropertiesType = "AWS::DocDB::DBInstance"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AutoMinorVersionUpgrade",) . toJSON . fmap Bool') _docDBDBInstanceAutoMinorVersionUpgrade
+        [ fmap (("AutoMinorVersionUpgrade",) . toJSON) _docDBDBInstanceAutoMinorVersionUpgrade
         , fmap (("AvailabilityZone",) . toJSON) _docDBDBInstanceAvailabilityZone
         , (Just . ("DBClusterIdentifier",) . toJSON) _docDBDBInstanceDBClusterIdentifier
         , (Just . ("DBInstanceClass",) . toJSON) _docDBDBInstanceDBInstanceClass

--- a/library-gen/Stratosphere/Resources/EC2CustomerGateway.hs
+++ b/library-gen/Stratosphere/Resources/EC2CustomerGateway.hs
@@ -26,7 +26,7 @@ instance ToResourceProperties EC2CustomerGateway where
     { resourcePropertiesType = "AWS::EC2::CustomerGateway"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("BgpAsn",) . toJSON . fmap Integer') _eC2CustomerGatewayBgpAsn
+        [ (Just . ("BgpAsn",) . toJSON) _eC2CustomerGatewayBgpAsn
         , (Just . ("IpAddress",) . toJSON) _eC2CustomerGatewayIpAddress
         , fmap (("Tags",) . toJSON) _eC2CustomerGatewayTags
         , (Just . ("Type",) . toJSON) _eC2CustomerGatewayType

--- a/library-gen/Stratosphere/Resources/EC2DHCPOptions.hs
+++ b/library-gen/Stratosphere/Resources/EC2DHCPOptions.hs
@@ -31,7 +31,7 @@ instance ToResourceProperties EC2DHCPOptions where
         [ fmap (("DomainName",) . toJSON) _eC2DHCPOptionsDomainName
         , fmap (("DomainNameServers",) . toJSON) _eC2DHCPOptionsDomainNameServers
         , fmap (("NetbiosNameServers",) . toJSON) _eC2DHCPOptionsNetbiosNameServers
-        , fmap (("NetbiosNodeType",) . toJSON . fmap Integer') _eC2DHCPOptionsNetbiosNodeType
+        , fmap (("NetbiosNodeType",) . toJSON) _eC2DHCPOptionsNetbiosNodeType
         , fmap (("NtpServers",) . toJSON) _eC2DHCPOptionsNtpServers
         , fmap (("Tags",) . toJSON) _eC2DHCPOptionsTags
         ]

--- a/library-gen/Stratosphere/Resources/EC2EC2Fleet.hs
+++ b/library-gen/Stratosphere/Resources/EC2EC2Fleet.hs
@@ -40,11 +40,11 @@ instance ToResourceProperties EC2EC2Fleet where
         [ fmap (("ExcessCapacityTerminationPolicy",) . toJSON) _eC2EC2FleetExcessCapacityTerminationPolicy
         , (Just . ("LaunchTemplateConfigs",) . toJSON) _eC2EC2FleetLaunchTemplateConfigs
         , fmap (("OnDemandOptions",) . toJSON) _eC2EC2FleetOnDemandOptions
-        , fmap (("ReplaceUnhealthyInstances",) . toJSON . fmap Bool') _eC2EC2FleetReplaceUnhealthyInstances
+        , fmap (("ReplaceUnhealthyInstances",) . toJSON) _eC2EC2FleetReplaceUnhealthyInstances
         , fmap (("SpotOptions",) . toJSON) _eC2EC2FleetSpotOptions
         , fmap (("TagSpecifications",) . toJSON) _eC2EC2FleetTagSpecifications
         , (Just . ("TargetCapacitySpecification",) . toJSON) _eC2EC2FleetTargetCapacitySpecification
-        , fmap (("TerminateInstancesWithExpiration",) . toJSON . fmap Bool') _eC2EC2FleetTerminateInstancesWithExpiration
+        , fmap (("TerminateInstancesWithExpiration",) . toJSON) _eC2EC2FleetTerminateInstancesWithExpiration
         , fmap (("Type",) . toJSON) _eC2EC2FleetType
         , fmap (("ValidFrom",) . toJSON) _eC2EC2FleetValidFrom
         , fmap (("ValidUntil",) . toJSON) _eC2EC2FleetValidUntil

--- a/library-gen/Stratosphere/Resources/EC2Instance.hs
+++ b/library-gen/Stratosphere/Resources/EC2Instance.hs
@@ -71,8 +71,8 @@ instance ToResourceProperties EC2Instance where
         , fmap (("AvailabilityZone",) . toJSON) _eC2InstanceAvailabilityZone
         , fmap (("BlockDeviceMappings",) . toJSON) _eC2InstanceBlockDeviceMappings
         , fmap (("CreditSpecification",) . toJSON) _eC2InstanceCreditSpecification
-        , fmap (("DisableApiTermination",) . toJSON . fmap Bool') _eC2InstanceDisableApiTermination
-        , fmap (("EbsOptimized",) . toJSON . fmap Bool') _eC2InstanceEbsOptimized
+        , fmap (("DisableApiTermination",) . toJSON) _eC2InstanceDisableApiTermination
+        , fmap (("EbsOptimized",) . toJSON) _eC2InstanceEbsOptimized
         , fmap (("ElasticGpuSpecifications",) . toJSON) _eC2InstanceElasticGpuSpecifications
         , fmap (("ElasticInferenceAccelerators",) . toJSON) _eC2InstanceElasticInferenceAccelerators
         , fmap (("HostId",) . toJSON) _eC2InstanceHostId
@@ -80,20 +80,20 @@ instance ToResourceProperties EC2Instance where
         , fmap (("ImageId",) . toJSON) _eC2InstanceImageId
         , fmap (("InstanceInitiatedShutdownBehavior",) . toJSON) _eC2InstanceInstanceInitiatedShutdownBehavior
         , fmap (("InstanceType",) . toJSON) _eC2InstanceInstanceType
-        , fmap (("Ipv6AddressCount",) . toJSON . fmap Integer') _eC2InstanceIpv6AddressCount
+        , fmap (("Ipv6AddressCount",) . toJSON) _eC2InstanceIpv6AddressCount
         , fmap (("Ipv6Addresses",) . toJSON) _eC2InstanceIpv6Addresses
         , fmap (("KernelId",) . toJSON) _eC2InstanceKernelId
         , fmap (("KeyName",) . toJSON) _eC2InstanceKeyName
         , fmap (("LaunchTemplate",) . toJSON) _eC2InstanceLaunchTemplate
         , fmap (("LicenseSpecifications",) . toJSON) _eC2InstanceLicenseSpecifications
-        , fmap (("Monitoring",) . toJSON . fmap Bool') _eC2InstanceMonitoring
+        , fmap (("Monitoring",) . toJSON) _eC2InstanceMonitoring
         , fmap (("NetworkInterfaces",) . toJSON) _eC2InstanceNetworkInterfaces
         , fmap (("PlacementGroupName",) . toJSON) _eC2InstancePlacementGroupName
         , fmap (("PrivateIpAddress",) . toJSON) _eC2InstancePrivateIpAddress
         , fmap (("RamdiskId",) . toJSON) _eC2InstanceRamdiskId
         , fmap (("SecurityGroupIds",) . toJSON) _eC2InstanceSecurityGroupIds
         , fmap (("SecurityGroups",) . toJSON) _eC2InstanceSecurityGroups
-        , fmap (("SourceDestCheck",) . toJSON . fmap Bool') _eC2InstanceSourceDestCheck
+        , fmap (("SourceDestCheck",) . toJSON) _eC2InstanceSourceDestCheck
         , fmap (("SsmAssociations",) . toJSON) _eC2InstanceSsmAssociations
         , fmap (("SubnetId",) . toJSON) _eC2InstanceSubnetId
         , fmap (("Tags",) . toJSON) _eC2InstanceTags

--- a/library-gen/Stratosphere/Resources/EC2NetworkAclEntry.hs
+++ b/library-gen/Stratosphere/Resources/EC2NetworkAclEntry.hs
@@ -33,14 +33,14 @@ instance ToResourceProperties EC2NetworkAclEntry where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("CidrBlock",) . toJSON) _eC2NetworkAclEntryCidrBlock
-        , fmap (("Egress",) . toJSON . fmap Bool') _eC2NetworkAclEntryEgress
+        , fmap (("Egress",) . toJSON) _eC2NetworkAclEntryEgress
         , fmap (("Icmp",) . toJSON) _eC2NetworkAclEntryIcmp
         , fmap (("Ipv6CidrBlock",) . toJSON) _eC2NetworkAclEntryIpv6CidrBlock
         , (Just . ("NetworkAclId",) . toJSON) _eC2NetworkAclEntryNetworkAclId
         , fmap (("PortRange",) . toJSON) _eC2NetworkAclEntryPortRange
-        , (Just . ("Protocol",) . toJSON . fmap Integer') _eC2NetworkAclEntryProtocol
+        , (Just . ("Protocol",) . toJSON) _eC2NetworkAclEntryProtocol
         , (Just . ("RuleAction",) . toJSON) _eC2NetworkAclEntryRuleAction
-        , (Just . ("RuleNumber",) . toJSON . fmap Integer') _eC2NetworkAclEntryRuleNumber
+        , (Just . ("RuleNumber",) . toJSON) _eC2NetworkAclEntryRuleNumber
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/EC2NetworkInterface.hs
+++ b/library-gen/Stratosphere/Resources/EC2NetworkInterface.hs
@@ -38,12 +38,12 @@ instance ToResourceProperties EC2NetworkInterface where
         [ fmap (("Description",) . toJSON) _eC2NetworkInterfaceDescription
         , fmap (("GroupSet",) . toJSON) _eC2NetworkInterfaceGroupSet
         , fmap (("InterfaceType",) . toJSON) _eC2NetworkInterfaceInterfaceType
-        , fmap (("Ipv6AddressCount",) . toJSON . fmap Integer') _eC2NetworkInterfaceIpv6AddressCount
+        , fmap (("Ipv6AddressCount",) . toJSON) _eC2NetworkInterfaceIpv6AddressCount
         , fmap (("Ipv6Addresses",) . toJSON) _eC2NetworkInterfaceIpv6Addresses
         , fmap (("PrivateIpAddress",) . toJSON) _eC2NetworkInterfacePrivateIpAddress
         , fmap (("PrivateIpAddresses",) . toJSON) _eC2NetworkInterfacePrivateIpAddresses
-        , fmap (("SecondaryPrivateIpAddressCount",) . toJSON . fmap Integer') _eC2NetworkInterfaceSecondaryPrivateIpAddressCount
-        , fmap (("SourceDestCheck",) . toJSON . fmap Bool') _eC2NetworkInterfaceSourceDestCheck
+        , fmap (("SecondaryPrivateIpAddressCount",) . toJSON) _eC2NetworkInterfaceSecondaryPrivateIpAddressCount
+        , fmap (("SourceDestCheck",) . toJSON) _eC2NetworkInterfaceSourceDestCheck
         , (Just . ("SubnetId",) . toJSON) _eC2NetworkInterfaceSubnetId
         , fmap (("Tags",) . toJSON) _eC2NetworkInterfaceTags
         ]

--- a/library-gen/Stratosphere/Resources/EC2NetworkInterfaceAttachment.hs
+++ b/library-gen/Stratosphere/Resources/EC2NetworkInterfaceAttachment.hs
@@ -26,7 +26,7 @@ instance ToResourceProperties EC2NetworkInterfaceAttachment where
     { resourcePropertiesType = "AWS::EC2::NetworkInterfaceAttachment"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("DeleteOnTermination",) . toJSON . fmap Bool') _eC2NetworkInterfaceAttachmentDeleteOnTermination
+        [ fmap (("DeleteOnTermination",) . toJSON) _eC2NetworkInterfaceAttachmentDeleteOnTermination
         , (Just . ("DeviceIndex",) . toJSON) _eC2NetworkInterfaceAttachmentDeviceIndex
         , (Just . ("InstanceId",) . toJSON) _eC2NetworkInterfaceAttachmentInstanceId
         , (Just . ("NetworkInterfaceId",) . toJSON) _eC2NetworkInterfaceAttachmentNetworkInterfaceId

--- a/library-gen/Stratosphere/Resources/EC2SecurityGroupEgress.hs
+++ b/library-gen/Stratosphere/Resources/EC2SecurityGroupEgress.hs
@@ -36,10 +36,10 @@ instance ToResourceProperties EC2SecurityGroupEgress where
         , fmap (("Description",) . toJSON) _eC2SecurityGroupEgressDescription
         , fmap (("DestinationPrefixListId",) . toJSON) _eC2SecurityGroupEgressDestinationPrefixListId
         , fmap (("DestinationSecurityGroupId",) . toJSON) _eC2SecurityGroupEgressDestinationSecurityGroupId
-        , fmap (("FromPort",) . toJSON . fmap Integer') _eC2SecurityGroupEgressFromPort
+        , fmap (("FromPort",) . toJSON) _eC2SecurityGroupEgressFromPort
         , (Just . ("GroupId",) . toJSON) _eC2SecurityGroupEgressGroupId
         , (Just . ("IpProtocol",) . toJSON) _eC2SecurityGroupEgressIpProtocol
-        , fmap (("ToPort",) . toJSON . fmap Integer') _eC2SecurityGroupEgressToPort
+        , fmap (("ToPort",) . toJSON) _eC2SecurityGroupEgressToPort
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/EC2SecurityGroupIngress.hs
+++ b/library-gen/Stratosphere/Resources/EC2SecurityGroupIngress.hs
@@ -37,7 +37,7 @@ instance ToResourceProperties EC2SecurityGroupIngress where
         [ fmap (("CidrIp",) . toJSON) _eC2SecurityGroupIngressCidrIp
         , fmap (("CidrIpv6",) . toJSON) _eC2SecurityGroupIngressCidrIpv6
         , fmap (("Description",) . toJSON) _eC2SecurityGroupIngressDescription
-        , fmap (("FromPort",) . toJSON . fmap Integer') _eC2SecurityGroupIngressFromPort
+        , fmap (("FromPort",) . toJSON) _eC2SecurityGroupIngressFromPort
         , fmap (("GroupId",) . toJSON) _eC2SecurityGroupIngressGroupId
         , fmap (("GroupName",) . toJSON) _eC2SecurityGroupIngressGroupName
         , (Just . ("IpProtocol",) . toJSON) _eC2SecurityGroupIngressIpProtocol
@@ -45,7 +45,7 @@ instance ToResourceProperties EC2SecurityGroupIngress where
         , fmap (("SourceSecurityGroupId",) . toJSON) _eC2SecurityGroupIngressSourceSecurityGroupId
         , fmap (("SourceSecurityGroupName",) . toJSON) _eC2SecurityGroupIngressSourceSecurityGroupName
         , fmap (("SourceSecurityGroupOwnerId",) . toJSON) _eC2SecurityGroupIngressSourceSecurityGroupOwnerId
-        , fmap (("ToPort",) . toJSON . fmap Integer') _eC2SecurityGroupIngressToPort
+        , fmap (("ToPort",) . toJSON) _eC2SecurityGroupIngressToPort
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/EC2Subnet.hs
+++ b/library-gen/Stratosphere/Resources/EC2Subnet.hs
@@ -29,11 +29,11 @@ instance ToResourceProperties EC2Subnet where
     { resourcePropertiesType = "AWS::EC2::Subnet"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AssignIpv6AddressOnCreation",) . toJSON . fmap Bool') _eC2SubnetAssignIpv6AddressOnCreation
+        [ fmap (("AssignIpv6AddressOnCreation",) . toJSON) _eC2SubnetAssignIpv6AddressOnCreation
         , fmap (("AvailabilityZone",) . toJSON) _eC2SubnetAvailabilityZone
         , (Just . ("CidrBlock",) . toJSON) _eC2SubnetCidrBlock
         , fmap (("Ipv6CidrBlock",) . toJSON) _eC2SubnetIpv6CidrBlock
-        , fmap (("MapPublicIpOnLaunch",) . toJSON . fmap Bool') _eC2SubnetMapPublicIpOnLaunch
+        , fmap (("MapPublicIpOnLaunch",) . toJSON) _eC2SubnetMapPublicIpOnLaunch
         , fmap (("Tags",) . toJSON) _eC2SubnetTags
         , (Just . ("VpcId",) . toJSON) _eC2SubnetVpcId
         ]

--- a/library-gen/Stratosphere/Resources/EC2TransitGateway.hs
+++ b/library-gen/Stratosphere/Resources/EC2TransitGateway.hs
@@ -30,7 +30,7 @@ instance ToResourceProperties EC2TransitGateway where
     { resourcePropertiesType = "AWS::EC2::TransitGateway"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AmazonSideAsn",) . toJSON . fmap Integer') _eC2TransitGatewayAmazonSideAsn
+        [ fmap (("AmazonSideAsn",) . toJSON) _eC2TransitGatewayAmazonSideAsn
         , fmap (("AutoAcceptSharedAttachments",) . toJSON) _eC2TransitGatewayAutoAcceptSharedAttachments
         , fmap (("DefaultRouteTableAssociation",) . toJSON) _eC2TransitGatewayDefaultRouteTableAssociation
         , fmap (("DefaultRouteTablePropagation",) . toJSON) _eC2TransitGatewayDefaultRouteTablePropagation

--- a/library-gen/Stratosphere/Resources/EC2TransitGatewayRoute.hs
+++ b/library-gen/Stratosphere/Resources/EC2TransitGatewayRoute.hs
@@ -26,7 +26,7 @@ instance ToResourceProperties EC2TransitGatewayRoute where
     { resourcePropertiesType = "AWS::EC2::TransitGatewayRoute"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Blackhole",) . toJSON . fmap Bool') _eC2TransitGatewayRouteBlackhole
+        [ fmap (("Blackhole",) . toJSON) _eC2TransitGatewayRouteBlackhole
         , fmap (("DestinationCidrBlock",) . toJSON) _eC2TransitGatewayRouteDestinationCidrBlock
         , fmap (("TransitGatewayAttachmentId",) . toJSON) _eC2TransitGatewayRouteTransitGatewayAttachmentId
         , (Just . ("TransitGatewayRouteTableId",) . toJSON) _eC2TransitGatewayRouteTransitGatewayRouteTableId

--- a/library-gen/Stratosphere/Resources/EC2TrunkInterfaceAssociation.hs
+++ b/library-gen/Stratosphere/Resources/EC2TrunkInterfaceAssociation.hs
@@ -27,9 +27,9 @@ instance ToResourceProperties EC2TrunkInterfaceAssociation where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("BranchInterfaceId",) . toJSON) _eC2TrunkInterfaceAssociationBranchInterfaceId
-        , fmap (("GREKey",) . toJSON . fmap Integer') _eC2TrunkInterfaceAssociationGREKey
+        , fmap (("GREKey",) . toJSON) _eC2TrunkInterfaceAssociationGREKey
         , (Just . ("TrunkInterfaceId",) . toJSON) _eC2TrunkInterfaceAssociationTrunkInterfaceId
-        , fmap (("VLANId",) . toJSON . fmap Integer') _eC2TrunkInterfaceAssociationVLANId
+        , fmap (("VLANId",) . toJSON) _eC2TrunkInterfaceAssociationVLANId
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/EC2VPC.hs
+++ b/library-gen/Stratosphere/Resources/EC2VPC.hs
@@ -28,8 +28,8 @@ instance ToResourceProperties EC2VPC where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("CidrBlock",) . toJSON) _eC2VPCCidrBlock
-        , fmap (("EnableDnsHostnames",) . toJSON . fmap Bool') _eC2VPCEnableDnsHostnames
-        , fmap (("EnableDnsSupport",) . toJSON . fmap Bool') _eC2VPCEnableDnsSupport
+        , fmap (("EnableDnsHostnames",) . toJSON) _eC2VPCEnableDnsHostnames
+        , fmap (("EnableDnsSupport",) . toJSON) _eC2VPCEnableDnsSupport
         , fmap (("InstanceTenancy",) . toJSON) _eC2VPCInstanceTenancy
         , fmap (("Tags",) . toJSON) _eC2VPCTags
         ]

--- a/library-gen/Stratosphere/Resources/EC2VPCCidrBlock.hs
+++ b/library-gen/Stratosphere/Resources/EC2VPCCidrBlock.hs
@@ -25,7 +25,7 @@ instance ToResourceProperties EC2VPCCidrBlock where
     { resourcePropertiesType = "AWS::EC2::VPCCidrBlock"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AmazonProvidedIpv6CidrBlock",) . toJSON . fmap Bool') _eC2VPCCidrBlockAmazonProvidedIpv6CidrBlock
+        [ fmap (("AmazonProvidedIpv6CidrBlock",) . toJSON) _eC2VPCCidrBlockAmazonProvidedIpv6CidrBlock
         , fmap (("CidrBlock",) . toJSON) _eC2VPCCidrBlockCidrBlock
         , (Just . ("VpcId",) . toJSON) _eC2VPCCidrBlockVpcId
         ]

--- a/library-gen/Stratosphere/Resources/EC2VPCEndpoint.hs
+++ b/library-gen/Stratosphere/Resources/EC2VPCEndpoint.hs
@@ -31,7 +31,7 @@ instance ToResourceProperties EC2VPCEndpoint where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("PolicyDocument",) . toJSON) _eC2VPCEndpointPolicyDocument
-        , fmap (("PrivateDnsEnabled",) . toJSON . fmap Bool') _eC2VPCEndpointPrivateDnsEnabled
+        , fmap (("PrivateDnsEnabled",) . toJSON) _eC2VPCEndpointPrivateDnsEnabled
         , fmap (("RouteTableIds",) . toJSON) _eC2VPCEndpointRouteTableIds
         , fmap (("SecurityGroupIds",) . toJSON) _eC2VPCEndpointSecurityGroupIds
         , (Just . ("ServiceName",) . toJSON) _eC2VPCEndpointServiceName

--- a/library-gen/Stratosphere/Resources/EC2VPNConnection.hs
+++ b/library-gen/Stratosphere/Resources/EC2VPNConnection.hs
@@ -30,7 +30,7 @@ instance ToResourceProperties EC2VPNConnection where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("CustomerGatewayId",) . toJSON) _eC2VPNConnectionCustomerGatewayId
-        , fmap (("StaticRoutesOnly",) . toJSON . fmap Bool') _eC2VPNConnectionStaticRoutesOnly
+        , fmap (("StaticRoutesOnly",) . toJSON) _eC2VPNConnectionStaticRoutesOnly
         , fmap (("Tags",) . toJSON) _eC2VPNConnectionTags
         , (Just . ("Type",) . toJSON) _eC2VPNConnectionType
         , (Just . ("VpnGatewayId",) . toJSON) _eC2VPNConnectionVpnGatewayId

--- a/library-gen/Stratosphere/Resources/EC2VPNGateway.hs
+++ b/library-gen/Stratosphere/Resources/EC2VPNGateway.hs
@@ -25,7 +25,7 @@ instance ToResourceProperties EC2VPNGateway where
     { resourcePropertiesType = "AWS::EC2::VPNGateway"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AmazonSideAsn",) . toJSON . fmap Integer') _eC2VPNGatewayAmazonSideAsn
+        [ fmap (("AmazonSideAsn",) . toJSON) _eC2VPNGatewayAmazonSideAsn
         , fmap (("Tags",) . toJSON) _eC2VPNGatewayTags
         , (Just . ("Type",) . toJSON) _eC2VPNGatewayType
         ]

--- a/library-gen/Stratosphere/Resources/EC2Volume.hs
+++ b/library-gen/Stratosphere/Resources/EC2Volume.hs
@@ -31,12 +31,12 @@ instance ToResourceProperties EC2Volume where
     { resourcePropertiesType = "AWS::EC2::Volume"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AutoEnableIO",) . toJSON . fmap Bool') _eC2VolumeAutoEnableIO
+        [ fmap (("AutoEnableIO",) . toJSON) _eC2VolumeAutoEnableIO
         , (Just . ("AvailabilityZone",) . toJSON) _eC2VolumeAvailabilityZone
-        , fmap (("Encrypted",) . toJSON . fmap Bool') _eC2VolumeEncrypted
-        , fmap (("Iops",) . toJSON . fmap Integer') _eC2VolumeIops
+        , fmap (("Encrypted",) . toJSON) _eC2VolumeEncrypted
+        , fmap (("Iops",) . toJSON) _eC2VolumeIops
         , fmap (("KmsKeyId",) . toJSON) _eC2VolumeKmsKeyId
-        , fmap (("Size",) . toJSON . fmap Integer') _eC2VolumeSize
+        , fmap (("Size",) . toJSON) _eC2VolumeSize
         , fmap (("SnapshotId",) . toJSON) _eC2VolumeSnapshotId
         , fmap (("Tags",) . toJSON) _eC2VolumeTags
         , fmap (("VolumeType",) . toJSON) _eC2VolumeVolumeType

--- a/library-gen/Stratosphere/Resources/ECSService.hs
+++ b/library-gen/Stratosphere/Resources/ECSService.hs
@@ -44,8 +44,8 @@ instance ToResourceProperties ECSService where
         hashMapFromList $ catMaybes
         [ fmap (("Cluster",) . toJSON) _eCSServiceCluster
         , fmap (("DeploymentConfiguration",) . toJSON) _eCSServiceDeploymentConfiguration
-        , fmap (("DesiredCount",) . toJSON . fmap Integer') _eCSServiceDesiredCount
-        , fmap (("HealthCheckGracePeriodSeconds",) . toJSON . fmap Integer') _eCSServiceHealthCheckGracePeriodSeconds
+        , fmap (("DesiredCount",) . toJSON) _eCSServiceDesiredCount
+        , fmap (("HealthCheckGracePeriodSeconds",) . toJSON) _eCSServiceHealthCheckGracePeriodSeconds
         , fmap (("LaunchType",) . toJSON) _eCSServiceLaunchType
         , fmap (("LoadBalancers",) . toJSON) _eCSServiceLoadBalancers
         , fmap (("NetworkConfiguration",) . toJSON) _eCSServiceNetworkConfiguration

--- a/library-gen/Stratosphere/Resources/EFSFileSystem.hs
+++ b/library-gen/Stratosphere/Resources/EFSFileSystem.hs
@@ -28,11 +28,11 @@ instance ToResourceProperties EFSFileSystem where
     { resourcePropertiesType = "AWS::EFS::FileSystem"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Encrypted",) . toJSON . fmap Bool') _eFSFileSystemEncrypted
+        [ fmap (("Encrypted",) . toJSON) _eFSFileSystemEncrypted
         , fmap (("FileSystemTags",) . toJSON) _eFSFileSystemFileSystemTags
         , fmap (("KmsKeyId",) . toJSON) _eFSFileSystemKmsKeyId
         , fmap (("PerformanceMode",) . toJSON) _eFSFileSystemPerformanceMode
-        , fmap (("ProvisionedThroughputInMibps",) . toJSON . fmap Double') _eFSFileSystemProvisionedThroughputInMibps
+        , fmap (("ProvisionedThroughputInMibps",) . toJSON) _eFSFileSystemProvisionedThroughputInMibps
         , fmap (("ThroughputMode",) . toJSON) _eFSFileSystemThroughputMode
         ]
     }

--- a/library-gen/Stratosphere/Resources/EMRCluster.hs
+++ b/library-gen/Stratosphere/Resources/EMRCluster.hs
@@ -53,7 +53,7 @@ instance ToResourceProperties EMRCluster where
         , fmap (("BootstrapActions",) . toJSON) _eMRClusterBootstrapActions
         , fmap (("Configurations",) . toJSON) _eMRClusterConfigurations
         , fmap (("CustomAmiId",) . toJSON) _eMRClusterCustomAmiId
-        , fmap (("EbsRootVolumeSize",) . toJSON . fmap Integer') _eMRClusterEbsRootVolumeSize
+        , fmap (("EbsRootVolumeSize",) . toJSON) _eMRClusterEbsRootVolumeSize
         , (Just . ("Instances",) . toJSON) _eMRClusterInstances
         , (Just . ("JobFlowRole",) . toJSON) _eMRClusterJobFlowRole
         , fmap (("KerberosAttributes",) . toJSON) _eMRClusterKerberosAttributes
@@ -65,7 +65,7 @@ instance ToResourceProperties EMRCluster where
         , (Just . ("ServiceRole",) . toJSON) _eMRClusterServiceRole
         , fmap (("Steps",) . toJSON) _eMRClusterSteps
         , fmap (("Tags",) . toJSON) _eMRClusterTags
-        , fmap (("VisibleToAllUsers",) . toJSON . fmap Bool') _eMRClusterVisibleToAllUsers
+        , fmap (("VisibleToAllUsers",) . toJSON) _eMRClusterVisibleToAllUsers
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/EMRInstanceFleetConfig.hs
+++ b/library-gen/Stratosphere/Resources/EMRInstanceFleetConfig.hs
@@ -35,8 +35,8 @@ instance ToResourceProperties EMRInstanceFleetConfig where
         , fmap (("InstanceTypeConfigs",) . toJSON) _eMRInstanceFleetConfigInstanceTypeConfigs
         , fmap (("LaunchSpecifications",) . toJSON) _eMRInstanceFleetConfigLaunchSpecifications
         , fmap (("Name",) . toJSON) _eMRInstanceFleetConfigName
-        , fmap (("TargetOnDemandCapacity",) . toJSON . fmap Integer') _eMRInstanceFleetConfigTargetOnDemandCapacity
-        , fmap (("TargetSpotCapacity",) . toJSON . fmap Integer') _eMRInstanceFleetConfigTargetSpotCapacity
+        , fmap (("TargetOnDemandCapacity",) . toJSON) _eMRInstanceFleetConfigTargetOnDemandCapacity
+        , fmap (("TargetSpotCapacity",) . toJSON) _eMRInstanceFleetConfigTargetSpotCapacity
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/EMRInstanceGroupConfig.hs
+++ b/library-gen/Stratosphere/Resources/EMRInstanceGroupConfig.hs
@@ -38,7 +38,7 @@ instance ToResourceProperties EMRInstanceGroupConfig where
         , fmap (("BidPrice",) . toJSON) _eMRInstanceGroupConfigBidPrice
         , fmap (("Configurations",) . toJSON) _eMRInstanceGroupConfigConfigurations
         , fmap (("EbsConfiguration",) . toJSON) _eMRInstanceGroupConfigEbsConfiguration
-        , (Just . ("InstanceCount",) . toJSON . fmap Integer') _eMRInstanceGroupConfigInstanceCount
+        , (Just . ("InstanceCount",) . toJSON) _eMRInstanceGroupConfigInstanceCount
         , (Just . ("InstanceRole",) . toJSON) _eMRInstanceGroupConfigInstanceRole
         , (Just . ("InstanceType",) . toJSON) _eMRInstanceGroupConfigInstanceType
         , (Just . ("JobFlowId",) . toJSON) _eMRInstanceGroupConfigJobFlowId

--- a/library-gen/Stratosphere/Resources/ElastiCacheCacheCluster.hs
+++ b/library-gen/Stratosphere/Resources/ElastiCacheCacheCluster.hs
@@ -44,7 +44,7 @@ instance ToResourceProperties ElastiCacheCacheCluster where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("AZMode",) . toJSON) _elastiCacheCacheClusterAZMode
-        , fmap (("AutoMinorVersionUpgrade",) . toJSON . fmap Bool') _elastiCacheCacheClusterAutoMinorVersionUpgrade
+        , fmap (("AutoMinorVersionUpgrade",) . toJSON) _elastiCacheCacheClusterAutoMinorVersionUpgrade
         , (Just . ("CacheNodeType",) . toJSON) _elastiCacheCacheClusterCacheNodeType
         , fmap (("CacheParameterGroupName",) . toJSON) _elastiCacheCacheClusterCacheParameterGroupName
         , fmap (("CacheSecurityGroupNames",) . toJSON) _elastiCacheCacheClusterCacheSecurityGroupNames
@@ -53,14 +53,14 @@ instance ToResourceProperties ElastiCacheCacheCluster where
         , (Just . ("Engine",) . toJSON) _elastiCacheCacheClusterEngine
         , fmap (("EngineVersion",) . toJSON) _elastiCacheCacheClusterEngineVersion
         , fmap (("NotificationTopicArn",) . toJSON) _elastiCacheCacheClusterNotificationTopicArn
-        , (Just . ("NumCacheNodes",) . toJSON . fmap Integer') _elastiCacheCacheClusterNumCacheNodes
-        , fmap (("Port",) . toJSON . fmap Integer') _elastiCacheCacheClusterPort
+        , (Just . ("NumCacheNodes",) . toJSON) _elastiCacheCacheClusterNumCacheNodes
+        , fmap (("Port",) . toJSON) _elastiCacheCacheClusterPort
         , fmap (("PreferredAvailabilityZone",) . toJSON) _elastiCacheCacheClusterPreferredAvailabilityZone
         , fmap (("PreferredAvailabilityZones",) . toJSON) _elastiCacheCacheClusterPreferredAvailabilityZones
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _elastiCacheCacheClusterPreferredMaintenanceWindow
         , fmap (("SnapshotArns",) . toJSON) _elastiCacheCacheClusterSnapshotArns
         , fmap (("SnapshotName",) . toJSON) _elastiCacheCacheClusterSnapshotName
-        , fmap (("SnapshotRetentionLimit",) . toJSON . fmap Integer') _elastiCacheCacheClusterSnapshotRetentionLimit
+        , fmap (("SnapshotRetentionLimit",) . toJSON) _elastiCacheCacheClusterSnapshotRetentionLimit
         , fmap (("SnapshotWindow",) . toJSON) _elastiCacheCacheClusterSnapshotWindow
         , fmap (("Tags",) . toJSON) _elastiCacheCacheClusterTags
         , fmap (("VpcSecurityGroupIds",) . toJSON) _elastiCacheCacheClusterVpcSecurityGroupIds

--- a/library-gen/Stratosphere/Resources/ElastiCacheReplicationGroup.hs
+++ b/library-gen/Stratosphere/Resources/ElastiCacheReplicationGroup.hs
@@ -52,10 +52,10 @@ instance ToResourceProperties ElastiCacheReplicationGroup where
     { resourcePropertiesType = "AWS::ElastiCache::ReplicationGroup"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AtRestEncryptionEnabled",) . toJSON . fmap Bool') _elastiCacheReplicationGroupAtRestEncryptionEnabled
+        [ fmap (("AtRestEncryptionEnabled",) . toJSON) _elastiCacheReplicationGroupAtRestEncryptionEnabled
         , fmap (("AuthToken",) . toJSON) _elastiCacheReplicationGroupAuthToken
-        , fmap (("AutoMinorVersionUpgrade",) . toJSON . fmap Bool') _elastiCacheReplicationGroupAutoMinorVersionUpgrade
-        , fmap (("AutomaticFailoverEnabled",) . toJSON . fmap Bool') _elastiCacheReplicationGroupAutomaticFailoverEnabled
+        , fmap (("AutoMinorVersionUpgrade",) . toJSON) _elastiCacheReplicationGroupAutoMinorVersionUpgrade
+        , fmap (("AutomaticFailoverEnabled",) . toJSON) _elastiCacheReplicationGroupAutomaticFailoverEnabled
         , fmap (("CacheNodeType",) . toJSON) _elastiCacheReplicationGroupCacheNodeType
         , fmap (("CacheParameterGroupName",) . toJSON) _elastiCacheReplicationGroupCacheParameterGroupName
         , fmap (("CacheSecurityGroupNames",) . toJSON) _elastiCacheReplicationGroupCacheSecurityGroupNames
@@ -64,23 +64,23 @@ instance ToResourceProperties ElastiCacheReplicationGroup where
         , fmap (("EngineVersion",) . toJSON) _elastiCacheReplicationGroupEngineVersion
         , fmap (("NodeGroupConfiguration",) . toJSON) _elastiCacheReplicationGroupNodeGroupConfiguration
         , fmap (("NotificationTopicArn",) . toJSON) _elastiCacheReplicationGroupNotificationTopicArn
-        , fmap (("NumCacheClusters",) . toJSON . fmap Integer') _elastiCacheReplicationGroupNumCacheClusters
-        , fmap (("NumNodeGroups",) . toJSON . fmap Integer') _elastiCacheReplicationGroupNumNodeGroups
-        , fmap (("Port",) . toJSON . fmap Integer') _elastiCacheReplicationGroupPort
+        , fmap (("NumCacheClusters",) . toJSON) _elastiCacheReplicationGroupNumCacheClusters
+        , fmap (("NumNodeGroups",) . toJSON) _elastiCacheReplicationGroupNumNodeGroups
+        , fmap (("Port",) . toJSON) _elastiCacheReplicationGroupPort
         , fmap (("PreferredCacheClusterAZs",) . toJSON) _elastiCacheReplicationGroupPreferredCacheClusterAZs
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _elastiCacheReplicationGroupPreferredMaintenanceWindow
         , fmap (("PrimaryClusterId",) . toJSON) _elastiCacheReplicationGroupPrimaryClusterId
-        , fmap (("ReplicasPerNodeGroup",) . toJSON . fmap Integer') _elastiCacheReplicationGroupReplicasPerNodeGroup
+        , fmap (("ReplicasPerNodeGroup",) . toJSON) _elastiCacheReplicationGroupReplicasPerNodeGroup
         , (Just . ("ReplicationGroupDescription",) . toJSON) _elastiCacheReplicationGroupReplicationGroupDescription
         , fmap (("ReplicationGroupId",) . toJSON) _elastiCacheReplicationGroupReplicationGroupId
         , fmap (("SecurityGroupIds",) . toJSON) _elastiCacheReplicationGroupSecurityGroupIds
         , fmap (("SnapshotArns",) . toJSON) _elastiCacheReplicationGroupSnapshotArns
         , fmap (("SnapshotName",) . toJSON) _elastiCacheReplicationGroupSnapshotName
-        , fmap (("SnapshotRetentionLimit",) . toJSON . fmap Integer') _elastiCacheReplicationGroupSnapshotRetentionLimit
+        , fmap (("SnapshotRetentionLimit",) . toJSON) _elastiCacheReplicationGroupSnapshotRetentionLimit
         , fmap (("SnapshotWindow",) . toJSON) _elastiCacheReplicationGroupSnapshotWindow
         , fmap (("SnapshottingClusterId",) . toJSON) _elastiCacheReplicationGroupSnapshottingClusterId
         , fmap (("Tags",) . toJSON) _elastiCacheReplicationGroupTags
-        , fmap (("TransitEncryptionEnabled",) . toJSON . fmap Bool') _elastiCacheReplicationGroupTransitEncryptionEnabled
+        , fmap (("TransitEncryptionEnabled",) . toJSON) _elastiCacheReplicationGroupTransitEncryptionEnabled
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/ElasticLoadBalancingLoadBalancer.hs
+++ b/library-gen/Stratosphere/Resources/ElasticLoadBalancingLoadBalancer.hs
@@ -51,7 +51,7 @@ instance ToResourceProperties ElasticLoadBalancingLoadBalancer where
         , fmap (("AvailabilityZones",) . toJSON) _elasticLoadBalancingLoadBalancerAvailabilityZones
         , fmap (("ConnectionDrainingPolicy",) . toJSON) _elasticLoadBalancingLoadBalancerConnectionDrainingPolicy
         , fmap (("ConnectionSettings",) . toJSON) _elasticLoadBalancingLoadBalancerConnectionSettings
-        , fmap (("CrossZone",) . toJSON . fmap Bool') _elasticLoadBalancingLoadBalancerCrossZone
+        , fmap (("CrossZone",) . toJSON) _elasticLoadBalancingLoadBalancerCrossZone
         , fmap (("HealthCheck",) . toJSON) _elasticLoadBalancingLoadBalancerHealthCheck
         , fmap (("Instances",) . toJSON) _elasticLoadBalancingLoadBalancerInstances
         , fmap (("LBCookieStickinessPolicy",) . toJSON) _elasticLoadBalancingLoadBalancerLBCookieStickinessPolicy

--- a/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2Listener.hs
+++ b/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2Listener.hs
@@ -32,7 +32,7 @@ instance ToResourceProperties ElasticLoadBalancingV2Listener where
         [ fmap (("Certificates",) . toJSON) _elasticLoadBalancingV2ListenerCertificates
         , (Just . ("DefaultActions",) . toJSON) _elasticLoadBalancingV2ListenerDefaultActions
         , (Just . ("LoadBalancerArn",) . toJSON) _elasticLoadBalancingV2ListenerLoadBalancerArn
-        , (Just . ("Port",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerPort
+        , (Just . ("Port",) . toJSON) _elasticLoadBalancingV2ListenerPort
         , (Just . ("Protocol",) . toJSON) _elasticLoadBalancingV2ListenerProtocol
         , fmap (("SslPolicy",) . toJSON) _elasticLoadBalancingV2ListenerSslPolicy
         ]

--- a/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2ListenerRule.hs
+++ b/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2ListenerRule.hs
@@ -30,7 +30,7 @@ instance ToResourceProperties ElasticLoadBalancingV2ListenerRule where
         [ (Just . ("Actions",) . toJSON) _elasticLoadBalancingV2ListenerRuleActions
         , (Just . ("Conditions",) . toJSON) _elasticLoadBalancingV2ListenerRuleConditions
         , (Just . ("ListenerArn",) . toJSON) _elasticLoadBalancingV2ListenerRuleListenerArn
-        , (Just . ("Priority",) . toJSON . fmap Integer') _elasticLoadBalancingV2ListenerRulePriority
+        , (Just . ("Priority",) . toJSON) _elasticLoadBalancingV2ListenerRulePriority
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2TargetGroup.hs
+++ b/library-gen/Stratosphere/Resources/ElasticLoadBalancingV2TargetGroup.hs
@@ -42,22 +42,22 @@ instance ToResourceProperties ElasticLoadBalancingV2TargetGroup where
     { resourcePropertiesType = "AWS::ElasticLoadBalancingV2::TargetGroup"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("HealthCheckEnabled",) . toJSON . fmap Bool') _elasticLoadBalancingV2TargetGroupHealthCheckEnabled
-        , fmap (("HealthCheckIntervalSeconds",) . toJSON . fmap Integer') _elasticLoadBalancingV2TargetGroupHealthCheckIntervalSeconds
+        [ fmap (("HealthCheckEnabled",) . toJSON) _elasticLoadBalancingV2TargetGroupHealthCheckEnabled
+        , fmap (("HealthCheckIntervalSeconds",) . toJSON) _elasticLoadBalancingV2TargetGroupHealthCheckIntervalSeconds
         , fmap (("HealthCheckPath",) . toJSON) _elasticLoadBalancingV2TargetGroupHealthCheckPath
         , fmap (("HealthCheckPort",) . toJSON) _elasticLoadBalancingV2TargetGroupHealthCheckPort
         , fmap (("HealthCheckProtocol",) . toJSON) _elasticLoadBalancingV2TargetGroupHealthCheckProtocol
-        , fmap (("HealthCheckTimeoutSeconds",) . toJSON . fmap Integer') _elasticLoadBalancingV2TargetGroupHealthCheckTimeoutSeconds
-        , fmap (("HealthyThresholdCount",) . toJSON . fmap Integer') _elasticLoadBalancingV2TargetGroupHealthyThresholdCount
+        , fmap (("HealthCheckTimeoutSeconds",) . toJSON) _elasticLoadBalancingV2TargetGroupHealthCheckTimeoutSeconds
+        , fmap (("HealthyThresholdCount",) . toJSON) _elasticLoadBalancingV2TargetGroupHealthyThresholdCount
         , fmap (("Matcher",) . toJSON) _elasticLoadBalancingV2TargetGroupMatcher
         , fmap (("Name",) . toJSON) _elasticLoadBalancingV2TargetGroupName
-        , fmap (("Port",) . toJSON . fmap Integer') _elasticLoadBalancingV2TargetGroupPort
+        , fmap (("Port",) . toJSON) _elasticLoadBalancingV2TargetGroupPort
         , fmap (("Protocol",) . toJSON) _elasticLoadBalancingV2TargetGroupProtocol
         , fmap (("Tags",) . toJSON) _elasticLoadBalancingV2TargetGroupTags
         , fmap (("TargetGroupAttributes",) . toJSON) _elasticLoadBalancingV2TargetGroupTargetGroupAttributes
         , fmap (("TargetType",) . toJSON) _elasticLoadBalancingV2TargetGroupTargetType
         , fmap (("Targets",) . toJSON) _elasticLoadBalancingV2TargetGroupTargets
-        , fmap (("UnhealthyThresholdCount",) . toJSON . fmap Integer') _elasticLoadBalancingV2TargetGroupUnhealthyThresholdCount
+        , fmap (("UnhealthyThresholdCount",) . toJSON) _elasticLoadBalancingV2TargetGroupUnhealthyThresholdCount
         , fmap (("VpcId",) . toJSON) _elasticLoadBalancingV2TargetGroupVpcId
         ]
     }

--- a/library-gen/Stratosphere/Resources/FSxFileSystem.hs
+++ b/library-gen/Stratosphere/Resources/FSxFileSystem.hs
@@ -38,7 +38,7 @@ instance ToResourceProperties FSxFileSystem where
         , fmap (("KmsKeyId",) . toJSON) _fSxFileSystemKmsKeyId
         , fmap (("LustreConfiguration",) . toJSON) _fSxFileSystemLustreConfiguration
         , fmap (("SecurityGroupIds",) . toJSON) _fSxFileSystemSecurityGroupIds
-        , fmap (("StorageCapacity",) . toJSON . fmap Integer') _fSxFileSystemStorageCapacity
+        , fmap (("StorageCapacity",) . toJSON) _fSxFileSystemStorageCapacity
         , fmap (("SubnetIds",) . toJSON) _fSxFileSystemSubnetIds
         , fmap (("Tags",) . toJSON) _fSxFileSystemTags
         , fmap (("WindowsConfiguration",) . toJSON) _fSxFileSystemWindowsConfiguration

--- a/library-gen/Stratosphere/Resources/GameLiftFleet.hs
+++ b/library-gen/Stratosphere/Resources/GameLiftFleet.hs
@@ -35,12 +35,12 @@ instance ToResourceProperties GameLiftFleet where
         hashMapFromList $ catMaybes
         [ (Just . ("BuildId",) . toJSON) _gameLiftFleetBuildId
         , fmap (("Description",) . toJSON) _gameLiftFleetDescription
-        , (Just . ("DesiredEC2Instances",) . toJSON . fmap Integer') _gameLiftFleetDesiredEC2Instances
+        , (Just . ("DesiredEC2Instances",) . toJSON) _gameLiftFleetDesiredEC2Instances
         , fmap (("EC2InboundPermissions",) . toJSON) _gameLiftFleetEC2InboundPermissions
         , (Just . ("EC2InstanceType",) . toJSON) _gameLiftFleetEC2InstanceType
         , fmap (("LogPaths",) . toJSON) _gameLiftFleetLogPaths
-        , fmap (("MaxSize",) . toJSON . fmap Integer') _gameLiftFleetMaxSize
-        , fmap (("MinSize",) . toJSON . fmap Integer') _gameLiftFleetMinSize
+        , fmap (("MaxSize",) . toJSON) _gameLiftFleetMaxSize
+        , fmap (("MinSize",) . toJSON) _gameLiftFleetMinSize
         , (Just . ("Name",) . toJSON) _gameLiftFleetName
         , fmap (("ServerLaunchParameters",) . toJSON) _gameLiftFleetServerLaunchParameters
         , (Just . ("ServerLaunchPath",) . toJSON) _gameLiftFleetServerLaunchPath

--- a/library-gen/Stratosphere/Resources/GlueDevEndpoint.hs
+++ b/library-gen/Stratosphere/Resources/GlueDevEndpoint.hs
@@ -33,7 +33,7 @@ instance ToResourceProperties GlueDevEndpoint where
         [ fmap (("EndpointName",) . toJSON) _glueDevEndpointEndpointName
         , fmap (("ExtraJarsS3Path",) . toJSON) _glueDevEndpointExtraJarsS3Path
         , fmap (("ExtraPythonLibsS3Path",) . toJSON) _glueDevEndpointExtraPythonLibsS3Path
-        , fmap (("NumberOfNodes",) . toJSON . fmap Integer') _glueDevEndpointNumberOfNodes
+        , fmap (("NumberOfNodes",) . toJSON) _glueDevEndpointNumberOfNodes
         , (Just . ("PublicKey",) . toJSON) _glueDevEndpointPublicKey
         , (Just . ("RoleArn",) . toJSON) _glueDevEndpointRoleArn
         , fmap (("SecurityGroupIds",) . toJSON) _glueDevEndpointSecurityGroupIds

--- a/library-gen/Stratosphere/Resources/GlueJob.hs
+++ b/library-gen/Stratosphere/Resources/GlueJob.hs
@@ -34,14 +34,14 @@ instance ToResourceProperties GlueJob where
     { resourcePropertiesType = "AWS::Glue::Job"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AllocatedCapacity",) . toJSON . fmap Double') _glueJobAllocatedCapacity
+        [ fmap (("AllocatedCapacity",) . toJSON) _glueJobAllocatedCapacity
         , (Just . ("Command",) . toJSON) _glueJobCommand
         , fmap (("Connections",) . toJSON) _glueJobConnections
         , fmap (("DefaultArguments",) . toJSON) _glueJobDefaultArguments
         , fmap (("Description",) . toJSON) _glueJobDescription
         , fmap (("ExecutionProperty",) . toJSON) _glueJobExecutionProperty
         , fmap (("LogUri",) . toJSON) _glueJobLogUri
-        , fmap (("MaxRetries",) . toJSON . fmap Double') _glueJobMaxRetries
+        , fmap (("MaxRetries",) . toJSON) _glueJobMaxRetries
         , fmap (("Name",) . toJSON) _glueJobName
         , (Just . ("Role",) . toJSON) _glueJobRole
         ]

--- a/library-gen/Stratosphere/Resources/GuardDutyDetector.hs
+++ b/library-gen/Stratosphere/Resources/GuardDutyDetector.hs
@@ -24,7 +24,7 @@ instance ToResourceProperties GuardDutyDetector where
     { resourcePropertiesType = "AWS::GuardDuty::Detector"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("Enable",) . toJSON . fmap Bool') _guardDutyDetectorEnable
+        [ (Just . ("Enable",) . toJSON) _guardDutyDetectorEnable
         , fmap (("FindingPublishingFrequency",) . toJSON) _guardDutyDetectorFindingPublishingFrequency
         ]
     }

--- a/library-gen/Stratosphere/Resources/GuardDutyFilter.hs
+++ b/library-gen/Stratosphere/Resources/GuardDutyFilter.hs
@@ -33,7 +33,7 @@ instance ToResourceProperties GuardDutyFilter where
         , (Just . ("DetectorId",) . toJSON) _guardDutyFilterDetectorId
         , (Just . ("FindingCriteria",) . toJSON) _guardDutyFilterFindingCriteria
         , fmap (("Name",) . toJSON) _guardDutyFilterName
-        , (Just . ("Rank",) . toJSON . fmap Integer') _guardDutyFilterRank
+        , (Just . ("Rank",) . toJSON) _guardDutyFilterRank
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/GuardDutyIPSet.hs
+++ b/library-gen/Stratosphere/Resources/GuardDutyIPSet.hs
@@ -27,7 +27,7 @@ instance ToResourceProperties GuardDutyIPSet where
     { resourcePropertiesType = "AWS::GuardDuty::IPSet"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("Activate",) . toJSON . fmap Bool') _guardDutyIPSetActivate
+        [ (Just . ("Activate",) . toJSON) _guardDutyIPSetActivate
         , (Just . ("DetectorId",) . toJSON) _guardDutyIPSetDetectorId
         , (Just . ("Format",) . toJSON) _guardDutyIPSetFormat
         , (Just . ("Location",) . toJSON) _guardDutyIPSetLocation

--- a/library-gen/Stratosphere/Resources/GuardDutyMember.hs
+++ b/library-gen/Stratosphere/Resources/GuardDutyMember.hs
@@ -29,7 +29,7 @@ instance ToResourceProperties GuardDutyMember where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("DetectorId",) . toJSON) _guardDutyMemberDetectorId
-        , fmap (("DisableEmailNotification",) . toJSON . fmap Bool') _guardDutyMemberDisableEmailNotification
+        , fmap (("DisableEmailNotification",) . toJSON) _guardDutyMemberDisableEmailNotification
         , (Just . ("Email",) . toJSON) _guardDutyMemberEmail
         , (Just . ("MemberId",) . toJSON) _guardDutyMemberMemberId
         , fmap (("Message",) . toJSON) _guardDutyMemberMessage

--- a/library-gen/Stratosphere/Resources/GuardDutyThreatIntelSet.hs
+++ b/library-gen/Stratosphere/Resources/GuardDutyThreatIntelSet.hs
@@ -27,7 +27,7 @@ instance ToResourceProperties GuardDutyThreatIntelSet where
     { resourcePropertiesType = "AWS::GuardDuty::ThreatIntelSet"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("Activate",) . toJSON . fmap Bool') _guardDutyThreatIntelSetActivate
+        [ (Just . ("Activate",) . toJSON) _guardDutyThreatIntelSetActivate
         , (Just . ("DetectorId",) . toJSON) _guardDutyThreatIntelSetDetectorId
         , (Just . ("Format",) . toJSON) _guardDutyThreatIntelSetFormat
         , (Just . ("Location",) . toJSON) _guardDutyThreatIntelSetLocation

--- a/library-gen/Stratosphere/Resources/IAMAccessKey.hs
+++ b/library-gen/Stratosphere/Resources/IAMAccessKey.hs
@@ -25,7 +25,7 @@ instance ToResourceProperties IAMAccessKey where
     { resourcePropertiesType = "AWS::IAM::AccessKey"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Serial",) . toJSON . fmap Integer') _iAMAccessKeySerial
+        [ fmap (("Serial",) . toJSON) _iAMAccessKeySerial
         , fmap (("Status",) . toJSON) _iAMAccessKeyStatus
         , (Just . ("UserName",) . toJSON) _iAMAccessKeyUserName
         ]

--- a/library-gen/Stratosphere/Resources/IAMRole.hs
+++ b/library-gen/Stratosphere/Resources/IAMRole.hs
@@ -31,7 +31,7 @@ instance ToResourceProperties IAMRole where
         hashMapFromList $ catMaybes
         [ (Just . ("AssumeRolePolicyDocument",) . toJSON) _iAMRoleAssumeRolePolicyDocument
         , fmap (("ManagedPolicyArns",) . toJSON) _iAMRoleManagedPolicyArns
-        , fmap (("MaxSessionDuration",) . toJSON . fmap Integer') _iAMRoleMaxSessionDuration
+        , fmap (("MaxSessionDuration",) . toJSON) _iAMRoleMaxSessionDuration
         , fmap (("Path",) . toJSON) _iAMRolePath
         , fmap (("PermissionsBoundary",) . toJSON) _iAMRolePermissionsBoundary
         , fmap (("Policies",) . toJSON) _iAMRolePolicies

--- a/library-gen/Stratosphere/Resources/InspectorAssessmentTemplate.hs
+++ b/library-gen/Stratosphere/Resources/InspectorAssessmentTemplate.hs
@@ -29,7 +29,7 @@ instance ToResourceProperties InspectorAssessmentTemplate where
         hashMapFromList $ catMaybes
         [ (Just . ("AssessmentTargetArn",) . toJSON) _inspectorAssessmentTemplateAssessmentTargetArn
         , fmap (("AssessmentTemplateName",) . toJSON) _inspectorAssessmentTemplateAssessmentTemplateName
-        , (Just . ("DurationInSeconds",) . toJSON . fmap Integer') _inspectorAssessmentTemplateDurationInSeconds
+        , (Just . ("DurationInSeconds",) . toJSON) _inspectorAssessmentTemplateDurationInSeconds
         , (Just . ("RulesPackageArns",) . toJSON) _inspectorAssessmentTemplateRulesPackageArns
         , fmap (("UserAttributesForFindings",) . toJSON) _inspectorAssessmentTemplateUserAttributesForFindings
         ]

--- a/library-gen/Stratosphere/Resources/IoT1ClickDevice.hs
+++ b/library-gen/Stratosphere/Resources/IoT1ClickDevice.hs
@@ -25,7 +25,7 @@ instance ToResourceProperties IoT1ClickDevice where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ (Just . ("DeviceId",) . toJSON) _ioT1ClickDeviceDeviceId
-        , (Just . ("Enabled",) . toJSON . fmap Bool') _ioT1ClickDeviceEnabled
+        , (Just . ("Enabled",) . toJSON) _ioT1ClickDeviceEnabled
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/KMSKey.hs
+++ b/library-gen/Stratosphere/Resources/KMSKey.hs
@@ -30,11 +30,11 @@ instance ToResourceProperties KMSKey where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("Description",) . toJSON) _kMSKeyDescription
-        , fmap (("EnableKeyRotation",) . toJSON . fmap Bool') _kMSKeyEnableKeyRotation
-        , fmap (("Enabled",) . toJSON . fmap Bool') _kMSKeyEnabled
+        , fmap (("EnableKeyRotation",) . toJSON) _kMSKeyEnableKeyRotation
+        , fmap (("Enabled",) . toJSON) _kMSKeyEnabled
         , (Just . ("KeyPolicy",) . toJSON) _kMSKeyKeyPolicy
         , fmap (("KeyUsage",) . toJSON) _kMSKeyKeyUsage
-        , fmap (("PendingWindowInDays",) . toJSON . fmap Integer') _kMSKeyPendingWindowInDays
+        , fmap (("PendingWindowInDays",) . toJSON) _kMSKeyPendingWindowInDays
         , fmap (("Tags",) . toJSON) _kMSKeyTags
         ]
     }

--- a/library-gen/Stratosphere/Resources/KinesisStream.hs
+++ b/library-gen/Stratosphere/Resources/KinesisStream.hs
@@ -29,8 +29,8 @@ instance ToResourceProperties KinesisStream where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("Name",) . toJSON) _kinesisStreamName
-        , fmap (("RetentionPeriodHours",) . toJSON . fmap Integer') _kinesisStreamRetentionPeriodHours
-        , (Just . ("ShardCount",) . toJSON . fmap Integer') _kinesisStreamShardCount
+        , fmap (("RetentionPeriodHours",) . toJSON) _kinesisStreamRetentionPeriodHours
+        , (Just . ("ShardCount",) . toJSON) _kinesisStreamShardCount
         , fmap (("StreamEncryption",) . toJSON) _kinesisStreamStreamEncryption
         , fmap (("Tags",) . toJSON) _kinesisStreamTags
         ]

--- a/library-gen/Stratosphere/Resources/LambdaEventSourceMapping.hs
+++ b/library-gen/Stratosphere/Resources/LambdaEventSourceMapping.hs
@@ -27,8 +27,8 @@ instance ToResourceProperties LambdaEventSourceMapping where
     { resourcePropertiesType = "AWS::Lambda::EventSourceMapping"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("BatchSize",) . toJSON . fmap Integer') _lambdaEventSourceMappingBatchSize
-        , fmap (("Enabled",) . toJSON . fmap Bool') _lambdaEventSourceMappingEnabled
+        [ fmap (("BatchSize",) . toJSON) _lambdaEventSourceMappingBatchSize
+        , fmap (("Enabled",) . toJSON) _lambdaEventSourceMappingEnabled
         , (Just . ("EventSourceArn",) . toJSON) _lambdaEventSourceMappingEventSourceArn
         , (Just . ("FunctionName",) . toJSON) _lambdaEventSourceMappingFunctionName
         , fmap (("StartingPosition",) . toJSON) _lambdaEventSourceMappingStartingPosition

--- a/library-gen/Stratosphere/Resources/LambdaFunction.hs
+++ b/library-gen/Stratosphere/Resources/LambdaFunction.hs
@@ -52,12 +52,12 @@ instance ToResourceProperties LambdaFunction where
         , (Just . ("Handler",) . toJSON) _lambdaFunctionHandler
         , fmap (("KmsKeyArn",) . toJSON) _lambdaFunctionKmsKeyArn
         , fmap (("Layers",) . toJSON) _lambdaFunctionLayers
-        , fmap (("MemorySize",) . toJSON . fmap Integer') _lambdaFunctionMemorySize
-        , fmap (("ReservedConcurrentExecutions",) . toJSON . fmap Integer') _lambdaFunctionReservedConcurrentExecutions
+        , fmap (("MemorySize",) . toJSON) _lambdaFunctionMemorySize
+        , fmap (("ReservedConcurrentExecutions",) . toJSON) _lambdaFunctionReservedConcurrentExecutions
         , (Just . ("Role",) . toJSON) _lambdaFunctionRole
         , (Just . ("Runtime",) . toJSON) _lambdaFunctionRuntime
         , fmap (("Tags",) . toJSON) _lambdaFunctionTags
-        , fmap (("Timeout",) . toJSON . fmap Integer') _lambdaFunctionTimeout
+        , fmap (("Timeout",) . toJSON) _lambdaFunctionTimeout
         , fmap (("TracingConfig",) . toJSON) _lambdaFunctionTracingConfig
         , fmap (("VpcConfig",) . toJSON) _lambdaFunctionVpcConfig
         ]

--- a/library-gen/Stratosphere/Resources/LogsLogGroup.hs
+++ b/library-gen/Stratosphere/Resources/LogsLogGroup.hs
@@ -25,7 +25,7 @@ instance ToResourceProperties LogsLogGroup where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("LogGroupName",) . toJSON) _logsLogGroupLogGroupName
-        , fmap (("RetentionInDays",) . toJSON . fmap Integer') _logsLogGroupRetentionInDays
+        , fmap (("RetentionInDays",) . toJSON) _logsLogGroupRetentionInDays
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/NeptuneDBCluster.hs
+++ b/library-gen/Stratosphere/Resources/NeptuneDBCluster.hs
@@ -37,17 +37,17 @@ instance ToResourceProperties NeptuneDBCluster where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("AvailabilityZones",) . toJSON) _neptuneDBClusterAvailabilityZones
-        , fmap (("BackupRetentionPeriod",) . toJSON . fmap Integer') _neptuneDBClusterBackupRetentionPeriod
+        , fmap (("BackupRetentionPeriod",) . toJSON) _neptuneDBClusterBackupRetentionPeriod
         , fmap (("DBClusterIdentifier",) . toJSON) _neptuneDBClusterDBClusterIdentifier
         , fmap (("DBClusterParameterGroupName",) . toJSON) _neptuneDBClusterDBClusterParameterGroupName
         , fmap (("DBSubnetGroupName",) . toJSON) _neptuneDBClusterDBSubnetGroupName
-        , fmap (("IamAuthEnabled",) . toJSON . fmap Bool') _neptuneDBClusterIamAuthEnabled
+        , fmap (("IamAuthEnabled",) . toJSON) _neptuneDBClusterIamAuthEnabled
         , fmap (("KmsKeyId",) . toJSON) _neptuneDBClusterKmsKeyId
-        , fmap (("Port",) . toJSON . fmap Integer') _neptuneDBClusterPort
+        , fmap (("Port",) . toJSON) _neptuneDBClusterPort
         , fmap (("PreferredBackupWindow",) . toJSON) _neptuneDBClusterPreferredBackupWindow
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _neptuneDBClusterPreferredMaintenanceWindow
         , fmap (("SnapshotIdentifier",) . toJSON) _neptuneDBClusterSnapshotIdentifier
-        , fmap (("StorageEncrypted",) . toJSON . fmap Bool') _neptuneDBClusterStorageEncrypted
+        , fmap (("StorageEncrypted",) . toJSON) _neptuneDBClusterStorageEncrypted
         , fmap (("Tags",) . toJSON) _neptuneDBClusterTags
         , fmap (("VpcSecurityGroupIds",) . toJSON) _neptuneDBClusterVpcSecurityGroupIds
         ]

--- a/library-gen/Stratosphere/Resources/NeptuneDBInstance.hs
+++ b/library-gen/Stratosphere/Resources/NeptuneDBInstance.hs
@@ -33,8 +33,8 @@ instance ToResourceProperties NeptuneDBInstance where
     { resourcePropertiesType = "AWS::Neptune::DBInstance"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AllowMajorVersionUpgrade",) . toJSON . fmap Bool') _neptuneDBInstanceAllowMajorVersionUpgrade
-        , fmap (("AutoMinorVersionUpgrade",) . toJSON . fmap Bool') _neptuneDBInstanceAutoMinorVersionUpgrade
+        [ fmap (("AllowMajorVersionUpgrade",) . toJSON) _neptuneDBInstanceAllowMajorVersionUpgrade
+        , fmap (("AutoMinorVersionUpgrade",) . toJSON) _neptuneDBInstanceAutoMinorVersionUpgrade
         , fmap (("AvailabilityZone",) . toJSON) _neptuneDBInstanceAvailabilityZone
         , fmap (("DBClusterIdentifier",) . toJSON) _neptuneDBInstanceDBClusterIdentifier
         , (Just . ("DBInstanceClass",) . toJSON) _neptuneDBInstanceDBInstanceClass

--- a/library-gen/Stratosphere/Resources/OpsWorksApp.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksApp.hs
@@ -42,7 +42,7 @@ instance ToResourceProperties OpsWorksApp where
         , fmap (("DataSources",) . toJSON) _opsWorksAppDataSources
         , fmap (("Description",) . toJSON) _opsWorksAppDescription
         , fmap (("Domains",) . toJSON) _opsWorksAppDomains
-        , fmap (("EnableSsl",) . toJSON . fmap Bool') _opsWorksAppEnableSsl
+        , fmap (("EnableSsl",) . toJSON) _opsWorksAppEnableSsl
         , fmap (("Environment",) . toJSON) _opsWorksAppEnvironment
         , (Just . ("Name",) . toJSON) _opsWorksAppName
         , fmap (("Shortname",) . toJSON) _opsWorksAppShortname

--- a/library-gen/Stratosphere/Resources/OpsWorksCMServer.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksCMServer.hs
@@ -39,10 +39,10 @@ instance ToResourceProperties OpsWorksCMServer where
     { resourcePropertiesType = "AWS::OpsWorksCM::Server"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AssociatePublicIpAddress",) . toJSON . fmap Bool') _opsWorksCMServerAssociatePublicIpAddress
+        [ fmap (("AssociatePublicIpAddress",) . toJSON) _opsWorksCMServerAssociatePublicIpAddress
         , fmap (("BackupId",) . toJSON) _opsWorksCMServerBackupId
-        , fmap (("BackupRetentionCount",) . toJSON . fmap Integer') _opsWorksCMServerBackupRetentionCount
-        , fmap (("DisableAutomatedBackup",) . toJSON . fmap Bool') _opsWorksCMServerDisableAutomatedBackup
+        , fmap (("BackupRetentionCount",) . toJSON) _opsWorksCMServerBackupRetentionCount
+        , fmap (("DisableAutomatedBackup",) . toJSON) _opsWorksCMServerDisableAutomatedBackup
         , fmap (("Engine",) . toJSON) _opsWorksCMServerEngine
         , fmap (("EngineAttributes",) . toJSON) _opsWorksCMServerEngineAttributes
         , fmap (("EngineModel",) . toJSON) _opsWorksCMServerEngineModel

--- a/library-gen/Stratosphere/Resources/OpsWorksInstance.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksInstance.hs
@@ -50,10 +50,10 @@ instance ToResourceProperties OpsWorksInstance where
         , fmap (("AutoScalingType",) . toJSON) _opsWorksInstanceAutoScalingType
         , fmap (("AvailabilityZone",) . toJSON) _opsWorksInstanceAvailabilityZone
         , fmap (("BlockDeviceMappings",) . toJSON) _opsWorksInstanceBlockDeviceMappings
-        , fmap (("EbsOptimized",) . toJSON . fmap Bool') _opsWorksInstanceEbsOptimized
+        , fmap (("EbsOptimized",) . toJSON) _opsWorksInstanceEbsOptimized
         , fmap (("ElasticIps",) . toJSON) _opsWorksInstanceElasticIps
         , fmap (("Hostname",) . toJSON) _opsWorksInstanceHostname
-        , fmap (("InstallUpdatesOnBoot",) . toJSON . fmap Bool') _opsWorksInstanceInstallUpdatesOnBoot
+        , fmap (("InstallUpdatesOnBoot",) . toJSON) _opsWorksInstanceInstallUpdatesOnBoot
         , (Just . ("InstanceType",) . toJSON) _opsWorksInstanceInstanceType
         , (Just . ("LayerIds",) . toJSON) _opsWorksInstanceLayerIds
         , fmap (("Os",) . toJSON) _opsWorksInstanceOs

--- a/library-gen/Stratosphere/Resources/OpsWorksLayer.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksLayer.hs
@@ -46,14 +46,14 @@ instance ToResourceProperties OpsWorksLayer where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("Attributes",) . toJSON) _opsWorksLayerAttributes
-        , (Just . ("AutoAssignElasticIps",) . toJSON . fmap Bool') _opsWorksLayerAutoAssignElasticIps
-        , (Just . ("AutoAssignPublicIps",) . toJSON . fmap Bool') _opsWorksLayerAutoAssignPublicIps
+        , (Just . ("AutoAssignElasticIps",) . toJSON) _opsWorksLayerAutoAssignElasticIps
+        , (Just . ("AutoAssignPublicIps",) . toJSON) _opsWorksLayerAutoAssignPublicIps
         , fmap (("CustomInstanceProfileArn",) . toJSON) _opsWorksLayerCustomInstanceProfileArn
         , fmap (("CustomJson",) . toJSON) _opsWorksLayerCustomJson
         , fmap (("CustomRecipes",) . toJSON) _opsWorksLayerCustomRecipes
         , fmap (("CustomSecurityGroupIds",) . toJSON) _opsWorksLayerCustomSecurityGroupIds
-        , (Just . ("EnableAutoHealing",) . toJSON . fmap Bool') _opsWorksLayerEnableAutoHealing
-        , fmap (("InstallUpdatesOnBoot",) . toJSON . fmap Bool') _opsWorksLayerInstallUpdatesOnBoot
+        , (Just . ("EnableAutoHealing",) . toJSON) _opsWorksLayerEnableAutoHealing
+        , fmap (("InstallUpdatesOnBoot",) . toJSON) _opsWorksLayerInstallUpdatesOnBoot
         , fmap (("LifecycleEventConfiguration",) . toJSON) _opsWorksLayerLifecycleEventConfiguration
         , fmap (("LoadBasedAutoScaling",) . toJSON) _opsWorksLayerLoadBasedAutoScaling
         , (Just . ("Name",) . toJSON) _opsWorksLayerName
@@ -62,7 +62,7 @@ instance ToResourceProperties OpsWorksLayer where
         , (Just . ("StackId",) . toJSON) _opsWorksLayerStackId
         , fmap (("Tags",) . toJSON) _opsWorksLayerTags
         , (Just . ("Type",) . toJSON) _opsWorksLayerType
-        , fmap (("UseEbsOptimizedInstances",) . toJSON . fmap Bool') _opsWorksLayerUseEbsOptimizedInstances
+        , fmap (("UseEbsOptimizedInstances",) . toJSON) _opsWorksLayerUseEbsOptimizedInstances
         , fmap (("VolumeConfigurations",) . toJSON) _opsWorksLayerVolumeConfigurations
         ]
     }

--- a/library-gen/Stratosphere/Resources/OpsWorksStack.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksStack.hs
@@ -56,7 +56,7 @@ instance ToResourceProperties OpsWorksStack where
         , fmap (("Attributes",) . toJSON) _opsWorksStackAttributes
         , fmap (("ChefConfiguration",) . toJSON) _opsWorksStackChefConfiguration
         , fmap (("CloneAppIds",) . toJSON) _opsWorksStackCloneAppIds
-        , fmap (("ClonePermissions",) . toJSON . fmap Bool') _opsWorksStackClonePermissions
+        , fmap (("ClonePermissions",) . toJSON) _opsWorksStackClonePermissions
         , fmap (("ConfigurationManager",) . toJSON) _opsWorksStackConfigurationManager
         , fmap (("CustomCookbooksSource",) . toJSON) _opsWorksStackCustomCookbooksSource
         , fmap (("CustomJson",) . toJSON) _opsWorksStackCustomJson
@@ -74,8 +74,8 @@ instance ToResourceProperties OpsWorksStack where
         , (Just . ("ServiceRoleArn",) . toJSON) _opsWorksStackServiceRoleArn
         , fmap (("SourceStackId",) . toJSON) _opsWorksStackSourceStackId
         , fmap (("Tags",) . toJSON) _opsWorksStackTags
-        , fmap (("UseCustomCookbooks",) . toJSON . fmap Bool') _opsWorksStackUseCustomCookbooks
-        , fmap (("UseOpsworksSecurityGroups",) . toJSON . fmap Bool') _opsWorksStackUseOpsworksSecurityGroups
+        , fmap (("UseCustomCookbooks",) . toJSON) _opsWorksStackUseCustomCookbooks
+        , fmap (("UseOpsworksSecurityGroups",) . toJSON) _opsWorksStackUseOpsworksSecurityGroups
         , fmap (("VpcId",) . toJSON) _opsWorksStackVpcId
         ]
     }

--- a/library-gen/Stratosphere/Resources/OpsWorksUserProfile.hs
+++ b/library-gen/Stratosphere/Resources/OpsWorksUserProfile.hs
@@ -26,7 +26,7 @@ instance ToResourceProperties OpsWorksUserProfile where
     { resourcePropertiesType = "AWS::OpsWorks::UserProfile"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AllowSelfManagement",) . toJSON . fmap Bool') _opsWorksUserProfileAllowSelfManagement
+        [ fmap (("AllowSelfManagement",) . toJSON) _opsWorksUserProfileAllowSelfManagement
         , (Just . ("IamUserArn",) . toJSON) _opsWorksUserProfileIamUserArn
         , fmap (("SshPublicKey",) . toJSON) _opsWorksUserProfileSshPublicKey
         , fmap (("SshUsername",) . toJSON) _opsWorksUserProfileSshUsername

--- a/library-gen/Stratosphere/Resources/RAMResourceShare.hs
+++ b/library-gen/Stratosphere/Resources/RAMResourceShare.hs
@@ -27,7 +27,7 @@ instance ToResourceProperties RAMResourceShare where
     { resourcePropertiesType = "AWS::RAM::ResourceShare"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AllowExternalPrincipals",) . toJSON . fmap Bool') _rAMResourceShareAllowExternalPrincipals
+        [ fmap (("AllowExternalPrincipals",) . toJSON) _rAMResourceShareAllowExternalPrincipals
         , (Just . ("Name",) . toJSON) _rAMResourceShareName
         , fmap (("Principals",) . toJSON) _rAMResourceSharePrincipals
         , fmap (("ResourceArns",) . toJSON) _rAMResourceShareResourceArns

--- a/library-gen/Stratosphere/Resources/RDSDBCluster.hs
+++ b/library-gen/Stratosphere/Resources/RDSDBCluster.hs
@@ -50,29 +50,29 @@ instance ToResourceProperties RDSDBCluster where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("AvailabilityZones",) . toJSON) _rDSDBClusterAvailabilityZones
-        , fmap (("BacktrackWindow",) . toJSON . fmap Integer') _rDSDBClusterBacktrackWindow
-        , fmap (("BackupRetentionPeriod",) . toJSON . fmap Integer') _rDSDBClusterBackupRetentionPeriod
+        , fmap (("BacktrackWindow",) . toJSON) _rDSDBClusterBacktrackWindow
+        , fmap (("BackupRetentionPeriod",) . toJSON) _rDSDBClusterBackupRetentionPeriod
         , fmap (("DBClusterIdentifier",) . toJSON) _rDSDBClusterDBClusterIdentifier
         , fmap (("DBClusterParameterGroupName",) . toJSON) _rDSDBClusterDBClusterParameterGroupName
         , fmap (("DBSubnetGroupName",) . toJSON) _rDSDBClusterDBSubnetGroupName
         , fmap (("DatabaseName",) . toJSON) _rDSDBClusterDatabaseName
-        , fmap (("DeletionProtection",) . toJSON . fmap Bool') _rDSDBClusterDeletionProtection
+        , fmap (("DeletionProtection",) . toJSON) _rDSDBClusterDeletionProtection
         , fmap (("EnableCloudwatchLogsExports",) . toJSON) _rDSDBClusterEnableCloudwatchLogsExports
-        , fmap (("EnableIAMDatabaseAuthentication",) . toJSON . fmap Bool') _rDSDBClusterEnableIAMDatabaseAuthentication
+        , fmap (("EnableIAMDatabaseAuthentication",) . toJSON) _rDSDBClusterEnableIAMDatabaseAuthentication
         , (Just . ("Engine",) . toJSON) _rDSDBClusterEngine
         , fmap (("EngineMode",) . toJSON) _rDSDBClusterEngineMode
         , fmap (("EngineVersion",) . toJSON) _rDSDBClusterEngineVersion
         , fmap (("KmsKeyId",) . toJSON) _rDSDBClusterKmsKeyId
         , fmap (("MasterUserPassword",) . toJSON) _rDSDBClusterMasterUserPassword
         , fmap (("MasterUsername",) . toJSON) _rDSDBClusterMasterUsername
-        , fmap (("Port",) . toJSON . fmap Integer') _rDSDBClusterPort
+        , fmap (("Port",) . toJSON) _rDSDBClusterPort
         , fmap (("PreferredBackupWindow",) . toJSON) _rDSDBClusterPreferredBackupWindow
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _rDSDBClusterPreferredMaintenanceWindow
         , fmap (("ReplicationSourceIdentifier",) . toJSON) _rDSDBClusterReplicationSourceIdentifier
         , fmap (("ScalingConfiguration",) . toJSON) _rDSDBClusterScalingConfiguration
         , fmap (("SnapshotIdentifier",) . toJSON) _rDSDBClusterSnapshotIdentifier
         , fmap (("SourceRegion",) . toJSON) _rDSDBClusterSourceRegion
-        , fmap (("StorageEncrypted",) . toJSON . fmap Bool') _rDSDBClusterStorageEncrypted
+        , fmap (("StorageEncrypted",) . toJSON) _rDSDBClusterStorageEncrypted
         , fmap (("Tags",) . toJSON) _rDSDBClusterTags
         , fmap (("VpcSecurityGroupIds",) . toJSON) _rDSDBClusterVpcSecurityGroupIds
         ]

--- a/library-gen/Stratosphere/Resources/RDSDBInstance.hs
+++ b/library-gen/Stratosphere/Resources/RDSDBInstance.hs
@@ -73,12 +73,12 @@ instance ToResourceProperties RDSDBInstance where
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
         [ fmap (("AllocatedStorage",) . toJSON) _rDSDBInstanceAllocatedStorage
-        , fmap (("AllowMajorVersionUpgrade",) . toJSON . fmap Bool') _rDSDBInstanceAllowMajorVersionUpgrade
-        , fmap (("AutoMinorVersionUpgrade",) . toJSON . fmap Bool') _rDSDBInstanceAutoMinorVersionUpgrade
+        , fmap (("AllowMajorVersionUpgrade",) . toJSON) _rDSDBInstanceAllowMajorVersionUpgrade
+        , fmap (("AutoMinorVersionUpgrade",) . toJSON) _rDSDBInstanceAutoMinorVersionUpgrade
         , fmap (("AvailabilityZone",) . toJSON) _rDSDBInstanceAvailabilityZone
         , fmap (("BackupRetentionPeriod",) . toJSON) _rDSDBInstanceBackupRetentionPeriod
         , fmap (("CharacterSetName",) . toJSON) _rDSDBInstanceCharacterSetName
-        , fmap (("CopyTagsToSnapshot",) . toJSON . fmap Bool') _rDSDBInstanceCopyTagsToSnapshot
+        , fmap (("CopyTagsToSnapshot",) . toJSON) _rDSDBInstanceCopyTagsToSnapshot
         , fmap (("DBClusterIdentifier",) . toJSON) _rDSDBInstanceDBClusterIdentifier
         , (Just . ("DBInstanceClass",) . toJSON) _rDSDBInstanceDBInstanceClass
         , fmap (("DBInstanceIdentifier",) . toJSON) _rDSDBInstanceDBInstanceIdentifier
@@ -87,39 +87,39 @@ instance ToResourceProperties RDSDBInstance where
         , fmap (("DBSecurityGroups",) . toJSON) _rDSDBInstanceDBSecurityGroups
         , fmap (("DBSnapshotIdentifier",) . toJSON) _rDSDBInstanceDBSnapshotIdentifier
         , fmap (("DBSubnetGroupName",) . toJSON) _rDSDBInstanceDBSubnetGroupName
-        , fmap (("DeleteAutomatedBackups",) . toJSON . fmap Bool') _rDSDBInstanceDeleteAutomatedBackups
-        , fmap (("DeletionProtection",) . toJSON . fmap Bool') _rDSDBInstanceDeletionProtection
+        , fmap (("DeleteAutomatedBackups",) . toJSON) _rDSDBInstanceDeleteAutomatedBackups
+        , fmap (("DeletionProtection",) . toJSON) _rDSDBInstanceDeletionProtection
         , fmap (("Domain",) . toJSON) _rDSDBInstanceDomain
         , fmap (("DomainIAMRoleName",) . toJSON) _rDSDBInstanceDomainIAMRoleName
         , fmap (("EnableCloudwatchLogsExports",) . toJSON) _rDSDBInstanceEnableCloudwatchLogsExports
-        , fmap (("EnableIAMDatabaseAuthentication",) . toJSON . fmap Bool') _rDSDBInstanceEnableIAMDatabaseAuthentication
-        , fmap (("EnablePerformanceInsights",) . toJSON . fmap Bool') _rDSDBInstanceEnablePerformanceInsights
+        , fmap (("EnableIAMDatabaseAuthentication",) . toJSON) _rDSDBInstanceEnableIAMDatabaseAuthentication
+        , fmap (("EnablePerformanceInsights",) . toJSON) _rDSDBInstanceEnablePerformanceInsights
         , fmap (("Engine",) . toJSON) _rDSDBInstanceEngine
         , fmap (("EngineVersion",) . toJSON) _rDSDBInstanceEngineVersion
-        , fmap (("Iops",) . toJSON . fmap Integer') _rDSDBInstanceIops
+        , fmap (("Iops",) . toJSON) _rDSDBInstanceIops
         , fmap (("KmsKeyId",) . toJSON) _rDSDBInstanceKmsKeyId
         , fmap (("LicenseModel",) . toJSON) _rDSDBInstanceLicenseModel
         , fmap (("MasterUserPassword",) . toJSON) _rDSDBInstanceMasterUserPassword
         , fmap (("MasterUsername",) . toJSON) _rDSDBInstanceMasterUsername
-        , fmap (("MonitoringInterval",) . toJSON . fmap Integer') _rDSDBInstanceMonitoringInterval
+        , fmap (("MonitoringInterval",) . toJSON) _rDSDBInstanceMonitoringInterval
         , fmap (("MonitoringRoleArn",) . toJSON) _rDSDBInstanceMonitoringRoleArn
-        , fmap (("MultiAZ",) . toJSON . fmap Bool') _rDSDBInstanceMultiAZ
+        , fmap (("MultiAZ",) . toJSON) _rDSDBInstanceMultiAZ
         , fmap (("OptionGroupName",) . toJSON) _rDSDBInstanceOptionGroupName
         , fmap (("PerformanceInsightsKMSKeyId",) . toJSON) _rDSDBInstancePerformanceInsightsKMSKeyId
-        , fmap (("PerformanceInsightsRetentionPeriod",) . toJSON . fmap Integer') _rDSDBInstancePerformanceInsightsRetentionPeriod
+        , fmap (("PerformanceInsightsRetentionPeriod",) . toJSON) _rDSDBInstancePerformanceInsightsRetentionPeriod
         , fmap (("Port",) . toJSON) _rDSDBInstancePort
         , fmap (("PreferredBackupWindow",) . toJSON) _rDSDBInstancePreferredBackupWindow
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _rDSDBInstancePreferredMaintenanceWindow
         , fmap (("ProcessorFeatures",) . toJSON) _rDSDBInstanceProcessorFeatures
-        , fmap (("PromotionTier",) . toJSON . fmap Integer') _rDSDBInstancePromotionTier
-        , fmap (("PubliclyAccessible",) . toJSON . fmap Bool') _rDSDBInstancePubliclyAccessible
+        , fmap (("PromotionTier",) . toJSON) _rDSDBInstancePromotionTier
+        , fmap (("PubliclyAccessible",) . toJSON) _rDSDBInstancePubliclyAccessible
         , fmap (("SourceDBInstanceIdentifier",) . toJSON) _rDSDBInstanceSourceDBInstanceIdentifier
         , fmap (("SourceRegion",) . toJSON) _rDSDBInstanceSourceRegion
-        , fmap (("StorageEncrypted",) . toJSON . fmap Bool') _rDSDBInstanceStorageEncrypted
+        , fmap (("StorageEncrypted",) . toJSON) _rDSDBInstanceStorageEncrypted
         , fmap (("StorageType",) . toJSON) _rDSDBInstanceStorageType
         , fmap (("Tags",) . toJSON) _rDSDBInstanceTags
         , fmap (("Timezone",) . toJSON) _rDSDBInstanceTimezone
-        , fmap (("UseDefaultProcessorFeatures",) . toJSON . fmap Bool') _rDSDBInstanceUseDefaultProcessorFeatures
+        , fmap (("UseDefaultProcessorFeatures",) . toJSON) _rDSDBInstanceUseDefaultProcessorFeatures
         , fmap (("VPCSecurityGroups",) . toJSON) _rDSDBInstanceVPCSecurityGroups
         ]
     }

--- a/library-gen/Stratosphere/Resources/RDSEventSubscription.hs
+++ b/library-gen/Stratosphere/Resources/RDSEventSubscription.hs
@@ -27,7 +27,7 @@ instance ToResourceProperties RDSEventSubscription where
     { resourcePropertiesType = "AWS::RDS::EventSubscription"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Enabled",) . toJSON . fmap Bool') _rDSEventSubscriptionEnabled
+        [ fmap (("Enabled",) . toJSON) _rDSEventSubscriptionEnabled
         , fmap (("EventCategories",) . toJSON) _rDSEventSubscriptionEventCategories
         , (Just . ("SnsTopicArn",) . toJSON) _rDSEventSubscriptionSnsTopicArn
         , fmap (("SourceIds",) . toJSON) _rDSEventSubscriptionSourceIds

--- a/library-gen/Stratosphere/Resources/RedshiftCluster.hs
+++ b/library-gen/Stratosphere/Resources/RedshiftCluster.hs
@@ -52,8 +52,8 @@ instance ToResourceProperties RedshiftCluster where
     { resourcePropertiesType = "AWS::Redshift::Cluster"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("AllowVersionUpgrade",) . toJSON . fmap Bool') _redshiftClusterAllowVersionUpgrade
-        , fmap (("AutomatedSnapshotRetentionPeriod",) . toJSON . fmap Integer') _redshiftClusterAutomatedSnapshotRetentionPeriod
+        [ fmap (("AllowVersionUpgrade",) . toJSON) _redshiftClusterAllowVersionUpgrade
+        , fmap (("AutomatedSnapshotRetentionPeriod",) . toJSON) _redshiftClusterAutomatedSnapshotRetentionPeriod
         , fmap (("AvailabilityZone",) . toJSON) _redshiftClusterAvailabilityZone
         , fmap (("ClusterIdentifier",) . toJSON) _redshiftClusterClusterIdentifier
         , fmap (("ClusterParameterGroupName",) . toJSON) _redshiftClusterClusterParameterGroupName
@@ -63,7 +63,7 @@ instance ToResourceProperties RedshiftCluster where
         , fmap (("ClusterVersion",) . toJSON) _redshiftClusterClusterVersion
         , (Just . ("DBName",) . toJSON) _redshiftClusterDBName
         , fmap (("ElasticIp",) . toJSON) _redshiftClusterElasticIp
-        , fmap (("Encrypted",) . toJSON . fmap Bool') _redshiftClusterEncrypted
+        , fmap (("Encrypted",) . toJSON) _redshiftClusterEncrypted
         , fmap (("HsmClientCertificateIdentifier",) . toJSON) _redshiftClusterHsmClientCertificateIdentifier
         , fmap (("HsmConfigurationIdentifier",) . toJSON) _redshiftClusterHsmConfigurationIdentifier
         , fmap (("IamRoles",) . toJSON) _redshiftClusterIamRoles
@@ -72,11 +72,11 @@ instance ToResourceProperties RedshiftCluster where
         , (Just . ("MasterUserPassword",) . toJSON) _redshiftClusterMasterUserPassword
         , (Just . ("MasterUsername",) . toJSON) _redshiftClusterMasterUsername
         , (Just . ("NodeType",) . toJSON) _redshiftClusterNodeType
-        , fmap (("NumberOfNodes",) . toJSON . fmap Integer') _redshiftClusterNumberOfNodes
+        , fmap (("NumberOfNodes",) . toJSON) _redshiftClusterNumberOfNodes
         , fmap (("OwnerAccount",) . toJSON) _redshiftClusterOwnerAccount
-        , fmap (("Port",) . toJSON . fmap Integer') _redshiftClusterPort
+        , fmap (("Port",) . toJSON) _redshiftClusterPort
         , fmap (("PreferredMaintenanceWindow",) . toJSON) _redshiftClusterPreferredMaintenanceWindow
-        , fmap (("PubliclyAccessible",) . toJSON . fmap Bool') _redshiftClusterPubliclyAccessible
+        , fmap (("PubliclyAccessible",) . toJSON) _redshiftClusterPubliclyAccessible
         , fmap (("SnapshotClusterIdentifier",) . toJSON) _redshiftClusterSnapshotClusterIdentifier
         , fmap (("SnapshotIdentifier",) . toJSON) _redshiftClusterSnapshotIdentifier
         , fmap (("Tags",) . toJSON) _redshiftClusterTags

--- a/library-gen/Stratosphere/Resources/Route53RecordSet.hs
+++ b/library-gen/Stratosphere/Resources/Route53RecordSet.hs
@@ -45,14 +45,14 @@ instance ToResourceProperties Route53RecordSet where
         , fmap (("HealthCheckId",) . toJSON) _route53RecordSetHealthCheckId
         , fmap (("HostedZoneId",) . toJSON) _route53RecordSetHostedZoneId
         , fmap (("HostedZoneName",) . toJSON) _route53RecordSetHostedZoneName
-        , fmap (("MultiValueAnswer",) . toJSON . fmap Bool') _route53RecordSetMultiValueAnswer
+        , fmap (("MultiValueAnswer",) . toJSON) _route53RecordSetMultiValueAnswer
         , (Just . ("Name",) . toJSON) _route53RecordSetName
         , fmap (("Region",) . toJSON) _route53RecordSetRegion
         , fmap (("ResourceRecords",) . toJSON) _route53RecordSetResourceRecords
         , fmap (("SetIdentifier",) . toJSON) _route53RecordSetSetIdentifier
         , fmap (("TTL",) . toJSON) _route53RecordSetTTL
         , (Just . ("Type",) . toJSON) _route53RecordSetType
-        , fmap (("Weight",) . toJSON . fmap Integer') _route53RecordSetWeight
+        , fmap (("Weight",) . toJSON) _route53RecordSetWeight
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/SNSSubscription.hs
+++ b/library-gen/Stratosphere/Resources/SNSSubscription.hs
@@ -33,7 +33,7 @@ instance ToResourceProperties SNSSubscription where
         , fmap (("Endpoint",) . toJSON) _sNSSubscriptionEndpoint
         , fmap (("FilterPolicy",) . toJSON) _sNSSubscriptionFilterPolicy
         , (Just . ("Protocol",) . toJSON) _sNSSubscriptionProtocol
-        , fmap (("RawMessageDelivery",) . toJSON . fmap Bool') _sNSSubscriptionRawMessageDelivery
+        , fmap (("RawMessageDelivery",) . toJSON) _sNSSubscriptionRawMessageDelivery
         , fmap (("Region",) . toJSON) _sNSSubscriptionRegion
         , (Just . ("TopicArn",) . toJSON) _sNSSubscriptionTopicArn
         ]

--- a/library-gen/Stratosphere/Resources/SQSQueue.hs
+++ b/library-gen/Stratosphere/Resources/SQSQueue.hs
@@ -34,18 +34,18 @@ instance ToResourceProperties SQSQueue where
     { resourcePropertiesType = "AWS::SQS::Queue"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("ContentBasedDeduplication",) . toJSON . fmap Bool') _sQSQueueContentBasedDeduplication
-        , fmap (("DelaySeconds",) . toJSON . fmap Integer') _sQSQueueDelaySeconds
-        , fmap (("FifoQueue",) . toJSON . fmap Bool') _sQSQueueFifoQueue
-        , fmap (("KmsDataKeyReusePeriodSeconds",) . toJSON . fmap Integer') _sQSQueueKmsDataKeyReusePeriodSeconds
+        [ fmap (("ContentBasedDeduplication",) . toJSON) _sQSQueueContentBasedDeduplication
+        , fmap (("DelaySeconds",) . toJSON) _sQSQueueDelaySeconds
+        , fmap (("FifoQueue",) . toJSON) _sQSQueueFifoQueue
+        , fmap (("KmsDataKeyReusePeriodSeconds",) . toJSON) _sQSQueueKmsDataKeyReusePeriodSeconds
         , fmap (("KmsMasterKeyId",) . toJSON) _sQSQueueKmsMasterKeyId
-        , fmap (("MaximumMessageSize",) . toJSON . fmap Integer') _sQSQueueMaximumMessageSize
-        , fmap (("MessageRetentionPeriod",) . toJSON . fmap Integer') _sQSQueueMessageRetentionPeriod
+        , fmap (("MaximumMessageSize",) . toJSON) _sQSQueueMaximumMessageSize
+        , fmap (("MessageRetentionPeriod",) . toJSON) _sQSQueueMessageRetentionPeriod
         , fmap (("QueueName",) . toJSON) _sQSQueueQueueName
-        , fmap (("ReceiveMessageWaitTimeSeconds",) . toJSON . fmap Integer') _sQSQueueReceiveMessageWaitTimeSeconds
+        , fmap (("ReceiveMessageWaitTimeSeconds",) . toJSON) _sQSQueueReceiveMessageWaitTimeSeconds
         , fmap (("RedrivePolicy",) . toJSON) _sQSQueueRedrivePolicy
         , fmap (("Tags",) . toJSON) _sQSQueueTags
-        , fmap (("VisibilityTimeout",) . toJSON . fmap Integer') _sQSQueueVisibilityTimeout
+        , fmap (("VisibilityTimeout",) . toJSON) _sQSQueueVisibilityTimeout
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/SSMMaintenanceWindow.hs
+++ b/library-gen/Stratosphere/Resources/SSMMaintenanceWindow.hs
@@ -32,10 +32,10 @@ instance ToResourceProperties SSMMaintenanceWindow where
     { resourcePropertiesType = "AWS::SSM::MaintenanceWindow"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ (Just . ("AllowUnassociatedTargets",) . toJSON . fmap Bool') _sSMMaintenanceWindowAllowUnassociatedTargets
-        , (Just . ("Cutoff",) . toJSON . fmap Integer') _sSMMaintenanceWindowCutoff
+        [ (Just . ("AllowUnassociatedTargets",) . toJSON) _sSMMaintenanceWindowAllowUnassociatedTargets
+        , (Just . ("Cutoff",) . toJSON) _sSMMaintenanceWindowCutoff
         , fmap (("Description",) . toJSON) _sSMMaintenanceWindowDescription
-        , (Just . ("Duration",) . toJSON . fmap Integer') _sSMMaintenanceWindowDuration
+        , (Just . ("Duration",) . toJSON) _sSMMaintenanceWindowDuration
         , fmap (("EndDate",) . toJSON) _sSMMaintenanceWindowEndDate
         , (Just . ("Name",) . toJSON) _sSMMaintenanceWindowName
         , (Just . ("Schedule",) . toJSON) _sSMMaintenanceWindowSchedule

--- a/library-gen/Stratosphere/Resources/SSMMaintenanceWindowTask.hs
+++ b/library-gen/Stratosphere/Resources/SSMMaintenanceWindowTask.hs
@@ -42,7 +42,7 @@ instance ToResourceProperties SSMMaintenanceWindowTask where
         , (Just . ("MaxConcurrency",) . toJSON) _sSMMaintenanceWindowTaskMaxConcurrency
         , (Just . ("MaxErrors",) . toJSON) _sSMMaintenanceWindowTaskMaxErrors
         , fmap (("Name",) . toJSON) _sSMMaintenanceWindowTaskName
-        , (Just . ("Priority",) . toJSON . fmap Integer') _sSMMaintenanceWindowTaskPriority
+        , (Just . ("Priority",) . toJSON) _sSMMaintenanceWindowTaskPriority
         , (Just . ("ServiceRoleArn",) . toJSON) _sSMMaintenanceWindowTaskServiceRoleArn
         , (Just . ("Targets",) . toJSON) _sSMMaintenanceWindowTaskTargets
         , (Just . ("TaskArn",) . toJSON) _sSMMaintenanceWindowTaskTaskArn

--- a/library-gen/Stratosphere/Resources/SSMPatchBaseline.hs
+++ b/library-gen/Stratosphere/Resources/SSMPatchBaseline.hs
@@ -39,7 +39,7 @@ instance ToResourceProperties SSMPatchBaseline where
         [ fmap (("ApprovalRules",) . toJSON) _sSMPatchBaselineApprovalRules
         , fmap (("ApprovedPatches",) . toJSON) _sSMPatchBaselineApprovedPatches
         , fmap (("ApprovedPatchesComplianceLevel",) . toJSON) _sSMPatchBaselineApprovedPatchesComplianceLevel
-        , fmap (("ApprovedPatchesEnableNonSecurity",) . toJSON . fmap Bool') _sSMPatchBaselineApprovedPatchesEnableNonSecurity
+        , fmap (("ApprovedPatchesEnableNonSecurity",) . toJSON) _sSMPatchBaselineApprovedPatchesEnableNonSecurity
         , fmap (("Description",) . toJSON) _sSMPatchBaselineDescription
         , fmap (("GlobalFilters",) . toJSON) _sSMPatchBaselineGlobalFilters
         , (Just . ("Name",) . toJSON) _sSMPatchBaselineName

--- a/library-gen/Stratosphere/Resources/SageMakerNotebookInstance.hs
+++ b/library-gen/Stratosphere/Resources/SageMakerNotebookInstance.hs
@@ -41,7 +41,7 @@ instance ToResourceProperties SageMakerNotebookInstance where
         , fmap (("SecurityGroupIds",) . toJSON) _sageMakerNotebookInstanceSecurityGroupIds
         , fmap (("SubnetId",) . toJSON) _sageMakerNotebookInstanceSubnetId
         , fmap (("Tags",) . toJSON) _sageMakerNotebookInstanceTags
-        , fmap (("VolumeSizeInGB",) . toJSON . fmap Integer') _sageMakerNotebookInstanceVolumeSizeInGB
+        , fmap (("VolumeSizeInGB",) . toJSON) _sageMakerNotebookInstanceVolumeSizeInGB
         ]
     }
 

--- a/library-gen/Stratosphere/Resources/ServiceCatalogTagOption.hs
+++ b/library-gen/Stratosphere/Resources/ServiceCatalogTagOption.hs
@@ -25,7 +25,7 @@ instance ToResourceProperties ServiceCatalogTagOption where
     { resourcePropertiesType = "AWS::ServiceCatalog::TagOption"
     , resourcePropertiesProperties =
         hashMapFromList $ catMaybes
-        [ fmap (("Active",) . toJSON . fmap Bool') _serviceCatalogTagOptionActive
+        [ fmap (("Active",) . toJSON) _serviceCatalogTagOptionActive
         , (Just . ("Key",) . toJSON) _serviceCatalogTagOptionKey
         , (Just . ("Value",) . toJSON) _serviceCatalogTagOptionValue
         ]

--- a/library-gen/Stratosphere/Resources/WorkSpacesWorkspace.hs
+++ b/library-gen/Stratosphere/Resources/WorkSpacesWorkspace.hs
@@ -33,10 +33,10 @@ instance ToResourceProperties WorkSpacesWorkspace where
         hashMapFromList $ catMaybes
         [ (Just . ("BundleId",) . toJSON) _workSpacesWorkspaceBundleId
         , (Just . ("DirectoryId",) . toJSON) _workSpacesWorkspaceDirectoryId
-        , fmap (("RootVolumeEncryptionEnabled",) . toJSON . fmap Bool') _workSpacesWorkspaceRootVolumeEncryptionEnabled
+        , fmap (("RootVolumeEncryptionEnabled",) . toJSON) _workSpacesWorkspaceRootVolumeEncryptionEnabled
         , fmap (("Tags",) . toJSON) _workSpacesWorkspaceTags
         , (Just . ("UserName",) . toJSON) _workSpacesWorkspaceUserName
-        , fmap (("UserVolumeEncryptionEnabled",) . toJSON . fmap Bool') _workSpacesWorkspaceUserVolumeEncryptionEnabled
+        , fmap (("UserVolumeEncryptionEnabled",) . toJSON) _workSpacesWorkspaceUserVolumeEncryptionEnabled
         , fmap (("VolumeEncryptionKey",) . toJSON) _workSpacesWorkspaceVolumeEncryptionKey
         , fmap (("WorkspaceProperties",) . toJSON) _workSpacesWorkspaceWorkspaceProperties
         ]

--- a/library/Stratosphere/Parameters.hs
+++ b/library/Stratosphere/Parameters.hs
@@ -40,7 +40,7 @@ data Parameter =
     -- ^ A value of the appropriate type for the template to use if no value is
     -- specified when a stack is created. If you define constraints for the
     -- parameter, you must specify a value that adheres to those constraints.
-  , _parameterNoEcho :: Maybe Bool'
+  , _parameterNoEcho :: Maybe Bool
     -- ^ Whether to mask the parameter value whenever anyone makes a call that
     -- describes the stack. If you set the value to true, the parameter value
     -- is masked with asterisks (*****).
@@ -80,10 +80,10 @@ parameterToJSON Parameter {..} =
   , maybeField "NoEcho" _parameterNoEcho
   , maybeField "AllowedValues" _parameterAllowedValues
   , maybeField "AllowedPattern" _parameterAllowedPattern
-  , maybeField "MaxLength" (Integer' <$> _parameterMaxLength)
-  , maybeField "MinLength" (Integer' <$> _parameterMinLength)
-  , maybeField "MaxValue" (Integer' <$> _parameterMaxValue)
-  , maybeField "MinValue" (Integer' <$> _parameterMinValue)
+  , maybeField "MaxLength" _parameterMaxLength
+  , maybeField "MinLength" _parameterMinLength
+  , maybeField "MaxValue" _parameterMaxValue
+  , maybeField "MinValue" _parameterMinValue
   , maybeField "Description" _parameterDescription
   , maybeField "ConstraintDescription" _parameterConstraintDescription
   ]

--- a/library/Stratosphere/ResourceAttributes/AutoScalingReplacingUpdatePolicy.hs
+++ b/library/Stratosphere/ResourceAttributes/AutoScalingReplacingUpdatePolicy.hs
@@ -21,7 +21,7 @@ instance ToJSON AutoScalingReplacingUpdatePolicy where
   toJSON AutoScalingReplacingUpdatePolicy{..} =
     object $
     catMaybes
-    [ fmap (("WillReplace",) . toJSON . fmap Bool') _autoScalingReplacingUpdatePolicyWillReplace
+    [ fmap (("WillReplace",) . toJSON) _autoScalingReplacingUpdatePolicyWillReplace
     ]
 
 -- | Constructor for 'AutoScalingReplacingUpdatePolicy' containing required fields

--- a/library/Stratosphere/ResourceAttributes/AutoScalingRollingUpdatePolicy.hs
+++ b/library/Stratosphere/ResourceAttributes/AutoScalingRollingUpdatePolicy.hs
@@ -26,12 +26,12 @@ instance ToJSON AutoScalingRollingUpdatePolicy where
   toJSON AutoScalingRollingUpdatePolicy{..} =
     object $
     catMaybes
-    [ fmap (("MaxBatchSize",) . toJSON . fmap Integer') _autoScalingRollingUpdatePolicyMaxBatchSize
-    , fmap (("MinInstancesInService",) . toJSON . fmap Integer') _autoScalingRollingUpdatePolicyMinInstancesInService
-    , fmap (("MinSuccessfulInstancesPercent",) . toJSON . fmap Integer') _autoScalingRollingUpdatePolicyMinSuccessfulInstancesPercent
+    [ fmap (("MaxBatchSize",) . toJSON) _autoScalingRollingUpdatePolicyMaxBatchSize
+    , fmap (("MinInstancesInService",) . toJSON) _autoScalingRollingUpdatePolicyMinInstancesInService
+    , fmap (("MinSuccessfulInstancesPercent",) . toJSON) _autoScalingRollingUpdatePolicyMinSuccessfulInstancesPercent
     , fmap (("PauseTime",) . toJSON) _autoScalingRollingUpdatePolicyPauseTime
     , fmap (("SuspendProcesses",) . toJSON) _autoScalingRollingUpdatePolicySuspendProcesses
-    , fmap (("WaitOnResourceSignals",) . toJSON . fmap Bool') _autoScalingRollingUpdatePolicyWaitOnResourceSignals
+    , fmap (("WaitOnResourceSignals",) . toJSON) _autoScalingRollingUpdatePolicyWaitOnResourceSignals
     ]
 
 -- | Constructor for 'AutoScalingRollingUpdatePolicy' containing required fields as

--- a/library/Stratosphere/ResourceAttributes/AutoScalingScheduledActionPolicy.hs
+++ b/library/Stratosphere/ResourceAttributes/AutoScalingScheduledActionPolicy.hs
@@ -34,7 +34,7 @@ instance ToJSON AutoScalingScheduledActionPolicy where
   toJSON AutoScalingScheduledActionPolicy{..} =
     object $
     catMaybes
-    [ fmap (("IgnoreUnmodifiedGroupSizeProperties",) . toJSON . fmap Bool') _autoScalingScheduledActionPolicyIgnoreUnmodifiedGroupSizeProperties
+    [ fmap (("IgnoreUnmodifiedGroupSizeProperties",) . toJSON) _autoScalingScheduledActionPolicyIgnoreUnmodifiedGroupSizeProperties
     ]
 
 -- | Constructor for 'AutoScalingScheduledActionPolicy' containing required fields

--- a/library/Stratosphere/ResourceAttributes/ResourceSignal.hs
+++ b/library/Stratosphere/ResourceAttributes/ResourceSignal.hs
@@ -21,7 +21,7 @@ instance ToJSON ResourceSignal where
   toJSON ResourceSignal{..} =
     object $
     catMaybes
-    [ fmap (("Count",) . toJSON . fmap Integer') _resourceSignalCount
+    [ fmap (("Count",) . toJSON) _resourceSignalCount
     , fmap (("Timeout",) . toJSON) _resourceSignalTimeout
     ]
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stratosphere
-version: "0.33.1"
+version: "0.34.0"
 synopsis: EDSL for AWS CloudFormation
 description: EDSL for AWS CloudFormation
 category: AWS, Cloud


### PR DESCRIPTION
This is a fix for https://github.com/frontrowed/stratosphere/issues/86. Apparently we don't actually have to encode `Bool`, `Int`, and `Double` as strings in JSON. Like I mentioned in the issue, it is really important we test the hell out of this, because I bet things will break knowing AWS and CloudFormation :smile: 

This would be nice because then we wouldn't need a `Functor` instance for `Val a`, which would allow us to make `Val a` a GADT and type it properly.